### PR TITLE
🧪 Add test for get_simplified_type

### DIFF
--- a/backend/tests/test_parsers.py
+++ b/backend/tests/test_parsers.py
@@ -1,10 +1,18 @@
 from parsers import (
     convert_value_for_db,
     format_dpt_name,
+    get_simplified_type,
     parse_telegram_dpt,
     parse_telegram_payload,
 )
 
+
+def test_get_simplified_type():
+    assert get_simplified_type("GroupValueWrite") == "Write"
+    assert get_simplified_type("GroupValueRead") == "Read"
+    assert get_simplified_type("GroupValueResponse") == "Response"
+    assert get_simplified_type("UnknownType") == "UnknownType"
+    assert get_simplified_type("") == ""
 
 def test_convert_value_for_db_basic_types():
     assert convert_value_for_db(22.5) == 22.5


### PR DESCRIPTION
🎯 **What:** Added a unit test for the `get_simplified_type` function in `backend/parsers.py` which was missing test coverage.
📊 **Coverage:** Covered happy paths (mapping "GroupValueWrite" to "Write", "GroupValueRead" to "Read", "GroupValueResponse" to "Response"), as well as fallback scenarios (mapping "UnknownType" to "UnknownType" and empty string to empty string).
✨ **Result:** Improved test coverage in `test_parsers.py` ensuring the type simplification logic works correctly.

---
*PR created automatically by Jules for task [10051996214355595144](https://jules.google.com/task/10051996214355595144) started by @martinhoefling*