### PR TITLE
🧹 Refactor: remove unused `json` import from `backend/api.py`

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime, timedelta
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -239,11 +238,10 @@ async def websocket_endpoint(websocket: WebSocket):
     try:
         while True:
             # Client sends filters over WS as JSON
-            data = await websocket.receive_text()
             try:
-                filters = json.loads(data)
+                filters = await websocket.receive_json()
                 await manager.update_filters(websocket, filters)
-            except json.JSONDecodeError:
+            except ValueError:
                 pass
     except WebSocketDisconnect:
         manager.disconnect(websocket)


### PR DESCRIPTION
🎯 **What:** The `json` import in `backend/api.py` was removed, as it was only used for manual JSON parsing in a WebSocket endpoint.
💡 **Why:** Refactoring to use FastAPI's native `websocket.receive_json()` improves maintainability by leveraging the framework's built-in abstractions and reduces unnecessary imports.
✅ **Verification:** Replaced `json.loads(await websocket.receive_text())` with `await websocket.receive_json()` and caught `ValueError` instead of `json.JSONDecodeError`. Ran `ruff check` (passed) and the full `pytest` test suite (passed).
✨ **Result:** Improved code cleanliness and slightly simpler websocket handler logic.

---
*PR created automatically by Jules for task [11939283622250669527](https://jules.google.com/task/11939283622250669527) started by @martinhoefling*