### PR TITLE
fix: allow project upload without password and improve error display

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -273,7 +273,7 @@ async def get_project_status():
 @router.post("/api/project/upload")
 async def upload_project(
     file: UploadFile = File(...),
-    password: str = Form(...)
+    password: str = Form("")
 ):
     """Uploads a KNX project file and password, saving them to the default volume"""
     env_proj = os.getenv("KNX_PROJECT_PATH")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -357,3 +357,27 @@ def test_upload_project_failure(monkeypatch, tmp_path):
     response = client.post("/api/project/upload", data={"password": "bad"}, files={"file": ("test.knxproj", b"dummy")})
     assert response.status_code == 400
     assert "Incorrect password" in response.json()["detail"]
+def test_upload_project_empty_password(monkeypatch, tmp_path):
+    monkeypatch.delenv("KNX_PROJECT_PATH", raising=False)
+    monkeypatch.delenv("KNX_PASSWORD", raising=False)
+    
+    import os
+    original_makedirs = os.makedirs
+    def mock_makedirs(name, exist_ok=False):
+        if name == "/project":
+            return
+        original_makedirs(name, exist_ok=exist_ok)
+    monkeypatch.setattr(os, "makedirs", mock_makedirs)
+    
+    from unittest.mock import mock_open
+    m = mock_open()
+    monkeypatch.setattr("builtins.open", m)
+    
+    async def mock_load():
+        return True
+    monkeypatch.setattr(knx_daemon, "_load_project_data", mock_load)
+    
+    # Test with empty password
+    response = client.post("/api/project/upload", data={"password": ""}, files={"file": ("test.knxproj", b"dummy")})
+    assert response.status_code == 200
+    m.assert_any_call(os.path.join("/project", "knx_project_password"), "w", encoding="utf-8")

--- a/frontend/src/components/KeysUploadWizard.tsx
+++ b/frontend/src/components/KeysUploadWizard.tsx
@@ -40,7 +40,24 @@ export function KeysUploadWizard({ onSuccess, onClose }: KeysUploadWizardProps) 
       const data = await response.json();
       
       if (!response.ok) {
-        throw new Error(data.detail || 'Upload failed');
+        // Handle FastAPI validation errors which return 'detail' as an array
+        interface ValidationErrorDetail {
+          msg: string;
+          loc: (string | number)[];
+          type: string;
+          input?: unknown;
+        }
+        let errorMsg = 'Upload failed';
+        if (data.detail) {
+          if (typeof data.detail === 'string') {
+            errorMsg = data.detail;
+          } else if (Array.isArray(data.detail)) {
+            errorMsg = (data.detail as ValidationErrorDetail[]).map((d) => d.msg || JSON.stringify(d)).join(', ');
+          } else {
+            errorMsg = JSON.stringify(data.detail);
+          }
+        }
+        throw new Error(errorMsg);
       }
       
       onSuccess();

--- a/frontend/src/components/ProjectUploadWizard.tsx
+++ b/frontend/src/components/ProjectUploadWizard.tsx
@@ -42,12 +42,18 @@ export function ProjectUploadWizard({ onSuccess, isClosable = false, onClose }: 
       
       if (!response.ok) {
         // Handle FastAPI validation errors which return 'detail' as an array
+        interface ValidationErrorDetail {
+          msg: string;
+          loc: (string | number)[];
+          type: string;
+          input?: unknown;
+        }
         let errorMsg = 'Upload failed';
         if (data.detail) {
           if (typeof data.detail === 'string') {
             errorMsg = data.detail;
           } else if (Array.isArray(data.detail)) {
-            errorMsg = data.detail.map((d: any) => d.msg || JSON.stringify(d)).join(', ');
+            errorMsg = (data.detail as ValidationErrorDetail[]).map((d) => d.msg || JSON.stringify(d)).join(', ');
           } else {
             errorMsg = JSON.stringify(data.detail);
           }

--- a/frontend/src/components/ProjectUploadWizard.tsx
+++ b/frontend/src/components/ProjectUploadWizard.tsx
@@ -41,7 +41,18 @@ export function ProjectUploadWizard({ onSuccess, isClosable = false, onClose }: 
       const data = await response.json();
       
       if (!response.ok) {
-        throw new Error(data.detail || 'Upload failed');
+        // Handle FastAPI validation errors which return 'detail' as an array
+        let errorMsg = 'Upload failed';
+        if (data.detail) {
+          if (typeof data.detail === 'string') {
+            errorMsg = data.detail;
+          } else if (Array.isArray(data.detail)) {
+            errorMsg = data.detail.map((d: any) => d.msg || JSON.stringify(d)).join(', ');
+          } else {
+            errorMsg = JSON.stringify(data.detail);
+          }
+        }
+        throw new Error(errorMsg);
       }
       
       onSuccess();

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.0.4"
+version: "1.0.5"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
- Backend: Change 'password' field to optional in /api/project/upload endpoint.
- Frontend: Update ProjectUploadWizard to correctly parse and display complex FastAPI validation error objects.
- Tests: Add regression test for uploading a project with an empty password.

Fixes #41