### PR TITLE
fix: string values from history no longer show raw JSON formatting

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -3,11 +3,11 @@ import subprocess
 from datetime import datetime
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from knx_telegram_store import TelegramQuery
 from xknx.telegram.address import IndividualAddress
 
 import knx_daemon  # import global config
 from database import store
-from knx_telegram_store import TelegramQuery
 from parsers import (
     format_dpt_name,
     format_value_nicely,
@@ -63,11 +63,14 @@ def _build_telegram_response(telegrams: list) -> list:
         r["dpt_name"] = d_name
         r["unit"] = unit
 
-        r["value_formatted"] = format_value_nicely(
-            r.get("value_numeric") if r.get("value_numeric") is not None else r.get("value_json"),
-            r.get("dpt_main"),
-            r.get("dpt_sub"),
-        )
+        display_value = r.get("value_numeric")
+        if display_value is None:
+            vj = r.get("value_json")
+            # Unwrap legacy {"value": x} storage format
+            if isinstance(vj, dict) and list(vj.keys()) == ["value"]:
+                vj = vj["value"]
+            display_value = vj
+        r["value_formatted"] = format_value_nicely(display_value, r.get("dpt_main"), r.get("dpt_sub"))
 
         r["raw_hex"] = f"0x{r['raw_data']}" if r.get("raw_data") and len(r["raw_data"]) > 1 else r.get("raw_data")
 

--- a/backend/parsers.py
+++ b/backend/parsers.py
@@ -120,7 +120,7 @@ def parse_telegram_payload(telegram, xknx=None):
         elif isinstance(val, bool):
             value_numeric = 1.0 if val else 0.0
         else:
-            value_json = {"value": val}
+            value_json = val
 
     # 3. Use raw string if decoding failed but payload exists
     if value_numeric is None and value_json is None and payload_val is not None:
@@ -130,9 +130,9 @@ def parse_telegram_payload(telegram, xknx=None):
         elif isinstance(v, bool):
             value_numeric = 1.0 if v else 0.0
         elif isinstance(v, tuple | list):
-            value_json = {"value": list(v)}
+            value_json = list(v)
         else:
-            value_json = {"value": str(v)}
+            value_json = str(v)
 
     raw_hex = raw_data.hex() if raw_data else None
     if raw_hex and len(raw_hex) > 1:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -2,9 +2,9 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
 
 import knx_daemon
-from knx_telegram_store import StoredTelegram, TelegramQueryResult
 from main import app
 
 client = TestClient(app)
@@ -106,6 +106,63 @@ def test_get_telegrams(mock_query):
     assert len(data["telegrams"]) == 1
     assert data["telegrams"][0]["source_address"] == "1.1.1"
     assert data["telegrams"][0]["raw_data"] == "01"
+
+
+@patch("database.store.query", new_callable=AsyncMock)
+def test_get_telegrams_string_value_formatted(mock_query):
+    """Strings stored as plain payload (new format) should display without JSON wrapping."""
+    mock_query.return_value = TelegramQueryResult(
+        telegrams=[
+            StoredTelegram(
+                timestamp=datetime(2023, 1, 1),
+                source="1.1.1",
+                destination="1/2/3",
+                telegramtype="GroupValueWrite",
+                direction="Incoming",
+                dpt_main=16,
+                dpt_sub=1,
+                payload="hello world",
+                value=None,
+                raw_data=None,
+            )
+        ],
+        total_count=1,
+        limit_reached=False,
+    )
+
+    response = client.get("/api/telegrams?limit=10")
+    assert response.status_code == 200
+    t = response.json()["telegrams"][0]
+    assert t["value_formatted"] == "hello world"
+
+
+@patch("database.store.query", new_callable=AsyncMock)
+def test_get_telegrams_legacy_wrapped_string_unwrapped(mock_query):
+    """Strings stored in legacy {'value': x} format should be unwrapped for display."""
+    mock_query.return_value = TelegramQueryResult(
+        telegrams=[
+            StoredTelegram(
+                timestamp=datetime(2023, 1, 1),
+                source="1.1.1",
+                destination="1/2/3",
+                telegramtype="GroupValueWrite",
+                direction="Incoming",
+                dpt_main=16,
+                dpt_sub=1,
+                payload={"value": "hello world"},
+                value=None,
+                raw_data=None,
+            )
+        ],
+        total_count=1,
+        limit_reached=False,
+    )
+
+    response = client.get("/api/telegrams?limit=10")
+    assert response.status_code == 200
+    t = response.json()["telegrams"][0]
+    assert t["value_formatted"] == "hello world"
+    assert t["value_formatted"] != "{'value': 'hello world'}"
 
 
 def test_get_filter_options_invalid_device_address():

--- a/backend/tests/test_parsers.py
+++ b/backend/tests/test_parsers.py
@@ -150,9 +150,9 @@ def test_parse_telegram_payload_with_dpt_array():
         parse_telegram_payload(MockTelegram())
     )
 
-    # 0xfc = 252
+    # 0xfc = 252 — stored as plain list, not wrapped
     assert raw_data == b"\xfc"
-    assert value_json == {"value": [252]}
+    assert value_json == [252]
     assert value_numeric is None
     assert dpt_main is None
 
@@ -181,6 +181,80 @@ def test_parse_telegram_payload_with_dpt_binary():
     assert value_numeric == 1.0
     assert value_json is None
     assert dpt_main is None
+
+
+def test_parse_telegram_payload_string_value_not_wrapped():
+    """String values decoded from DPT should be stored directly, not wrapped in {"value": ...}."""
+
+    class MockTranscoder:
+        dpt_main_number = 16
+        dpt_sub_number = 1
+        value_type = "string"
+        __name__ = "DPTString"
+
+    class MockDecoded:
+        transcoder = MockTranscoder()
+        value = "hello world"
+
+    class MockPayload:
+        value = None
+
+    class MockTelegram:
+        payload = MockPayload()
+        decoded_data = MockDecoded()
+        destination_address = "1/1/1"
+
+    value_numeric, value_json, raw_data, dpt_str, dpt_main, dpt_sub, unit, value_formatted, raw_hex = (
+        parse_telegram_payload(MockTelegram())
+    )
+
+    assert value_numeric is None
+    assert value_json == "hello world"
+    assert value_formatted == "hello world"
+
+
+def test_parse_telegram_payload_fallback_string_not_wrapped():
+    """Fallback string extraction (no decoded_data) should also store directly."""
+
+    class MockInnerPayload:
+        value = "raw string"
+
+    class MockPayload:
+        value = MockInnerPayload()
+
+    class MockTelegram:
+        payload = MockPayload()
+        decoded_data = None
+        destination_address = "1/1/2"
+
+    value_numeric, value_json, raw_data, dpt_str, dpt_main, dpt_sub, unit, value_formatted, raw_hex = (
+        parse_telegram_payload(MockTelegram())
+    )
+
+    assert value_numeric is None
+    assert value_json == "raw string"
+
+
+def test_parse_telegram_payload_fallback_list_not_wrapped():
+    """Fallback list values should be stored as plain list, not wrapped."""
+
+    class MockDPTArray:
+        value = (0x01, 0x02)
+
+    class MockPayload:
+        value = MockDPTArray()
+
+    class MockTelegram:
+        payload = MockPayload()
+        decoded_data = None
+        destination_address = "1/1/3"
+
+    value_numeric, value_json, raw_data, dpt_str, dpt_main, dpt_sub, unit, value_formatted, raw_hex = (
+        parse_telegram_payload(MockTelegram())
+    )
+
+    assert value_json == [1, 2]
+    assert value_numeric is None
 
 
 def test_format_dpt_name():


### PR DESCRIPTION
Closes #66

## Root cause

Two separate issues combined to cause the bug:

1. **`parsers.py`** — non-numeric decoded values (strings, booleans, lists) were wrapped in `{"value": x}` before being stored as `payload`. This was the legacy format.
2. **`api.py`** — `_build_telegram_response` computed `value_formatted` by passing the raw `payload` dict into `format_value_nicely`, which hit the `str()` fallback and produced `"{'value': 'hello world'}"`.

Live telegrams were unaffected because `value_formatted` is computed directly from the decoded value at receive time, not from the stored payload.

## Fix

- **`parsers.py`**: Store non-numeric values directly (e.g. `"hello world"` instead of `{"value": "hello world"}`) — fixes new rows going forward.
- **`api.py`**: Unwrap legacy `{"value": x}` payloads at read time in `_build_telegram_response` — fixes existing rows in the DB without requiring a migration.

## Tests

- `test_parse_telegram_payload_string_value_not_wrapped` — string from decoded DPT stored directly
- `test_parse_telegram_payload_fallback_string_not_wrapped` — fallback path also unwrapped
- `test_parse_telegram_payload_fallback_list_not_wrapped` — list fallback also unwrapped
- `test_get_telegrams_string_value_formatted` — new format displays correctly via API
- `test_get_telegrams_legacy_wrapped_string_unwrapped` — legacy `{"value": x}` rows unwrapped at read time

🤖 Generated with [Claude Code](https://claude.com/claude-code)