### PR TITLE
fix: sort PA/GA filter entries numerically

### DIFF
--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -6,6 +6,7 @@ import {
   type FilterCounts,
   DEFAULT_FILTERS
 } from '../types/filters';
+import { compareKnxAddress } from '../utils/knxAddress';
 
 // ─── FilterPanel component ────────────────────────────────────────────────────
 
@@ -145,14 +146,16 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   const q = search.toLowerCase();
 
   const filteredSources = useMemo(() =>
-    options.sources.filter(s =>
-      !q || s.address?.toLowerCase().includes(q) || s.name?.toLowerCase().includes(q)
-    ), [options.sources, q]);
+    options.sources
+      .filter(s => !q || s.address?.toLowerCase().includes(q) || s.name?.toLowerCase().includes(q))
+      .sort((a, b) => compareKnxAddress(a.address ?? '', b.address ?? '')),
+    [options.sources, q]);
 
   const filteredTargets = useMemo(() =>
-    options.targets.filter(s =>
-      !q || s.address?.toLowerCase().includes(q) || s.name?.toLowerCase().includes(q)
-    ), [options.targets, q]);
+    options.targets
+      .filter(s => !q || s.address?.toLowerCase().includes(q) || s.name?.toLowerCase().includes(q))
+      .sort((a, b) => compareKnxAddress(a.address ?? '', b.address ?? '')),
+    [options.targets, q]);
 
   const filteredTypes = useMemo(() =>
     options.types.filter(t => !q || t.toLowerCase().includes(q)), [options.types, q]);

--- a/frontend/src/utils/knxAddress.test.ts
+++ b/frontend/src/utils/knxAddress.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { compareKnxAddress } from './knxAddress';
+
+describe('compareKnxAddress', () => {
+  it('sorts PAs numerically not lexicographically', () => {
+    const addrs = ['1.0.10', '1.0.2', '1.0.1', '1.0.100', '1.0.11'];
+    const sorted = [...addrs].sort(compareKnxAddress);
+    expect(sorted).toEqual(['1.0.1', '1.0.2', '1.0.10', '1.0.11', '1.0.100']);
+  });
+
+  it('sorts 3-part GAs numerically', () => {
+    const addrs = ['1/2/10', '1/2/2', '1/2/1', '1/10/1', '1/2/11'];
+    const sorted = [...addrs].sort(compareKnxAddress);
+    expect(sorted).toEqual(['1/2/1', '1/2/2', '1/2/10', '1/2/11', '1/10/1']);
+  });
+
+  it('sorts 2-part GAs numerically', () => {
+    const addrs = ['0/10', '0/2', '0/1', '1/1', '0/11'];
+    const sorted = [...addrs].sort(compareKnxAddress);
+    expect(sorted).toEqual(['0/1', '0/2', '0/10', '0/11', '1/1']);
+  });
+
+  it('handles mixed 2-part and 3-part GAs', () => {
+    const addrs = ['1/2/3', '1/2', '1/1/255', '1/1'];
+    const sorted = [...addrs].sort(compareKnxAddress);
+    expect(sorted).toEqual(['1/1', '1/1/255', '1/2', '1/2/3']);
+  });
+
+  it('considers leading segments first', () => {
+    const addrs = ['2/1/1', '1/2/1', '1/1/2'];
+    const sorted = [...addrs].sort(compareKnxAddress);
+    expect(sorted).toEqual(['1/1/2', '1/2/1', '2/1/1']);
+  });
+
+  it('returns 0 for equal addresses', () => {
+    expect(compareKnxAddress('1/2/3', '1/2/3')).toBe(0);
+    expect(compareKnxAddress('1.1.1', '1.1.1')).toBe(0);
+  });
+});

--- a/frontend/src/utils/knxAddress.ts
+++ b/frontend/src/utils/knxAddress.ts
@@ -1,0 +1,15 @@
+/**
+ * Numerically compares two KNX addresses of the same type.
+ * Handles dot-separated PAs (e.g. 1.1.10) and slash-separated GAs
+ * with 2 or 3 parts (e.g. 0/1 or 1/2/10).
+ */
+export function compareKnxAddress(a: string, b: string): number {
+  const sep = a.includes('/') ? '/' : '.';
+  const aParts = a.split(sep).map(Number);
+  const bParts = b.split(sep).map(Number);
+  for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}


### PR DESCRIPTION
Closes #59

## Problem

PA and GA filter entries were sorted as strings, so `1.0.10` appeared before `1.0.2`, and `1/2/10` before `1/2/2`.

## Fix

Added `compareKnxAddress` utility in `src/utils/knxAddress.ts` that splits on `.` or `/` and compares each segment numerically. Applied to `filteredSources` and `filteredTargets` in `FilterPanel` — sorting now happens in the frontend on the already-filtered list, independent of whatever order the backend sends.

Handles all address formats:
- 3-part PAs: `1.1.10`
- 3-part GAs: `1/2/10`  
- 2-part GAs: `0/1`
- Mixed 2/3-part GA lists

## Tests

6 new unit tests in `knxAddress.test.ts` covering all formats and edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)