### PR TITLE
feat: show filtered and total buffered telegram counts separately

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -452,7 +452,11 @@ function App() {
                     Rate: <span onClick={() => setRateMode(m => m === 's' ? 'm' : m === 'm' ? 'h' : 's')} style={{ color: 'var(--accent-primary)', fontWeight: 600, cursor: 'pointer' }}>{busRate.toFixed(1)}/{rateMode}</span>
                   </span>
                   <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-dim)' }}>
-                    Buffer: <span style={{ color: 'var(--text-main)', fontWeight: 500 }}>{filteredLiveTelegrams.length}</span>
+                    Buffer: <span style={{ color: 'var(--text-main)', fontWeight: 500 }}>
+                      {activeFilterCount
+                        ? <>{filteredLiveTelegrams.length}<span style={{ color: 'var(--text-dim)', fontWeight: 400 }}> / {liveTelegrams.length}</span></>
+                        : liveTelegrams.length}
+                    </span>
                   </span>
                   {isPaused && (
                     <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: '#fbbf24' }}>


### PR DESCRIPTION
Closes #67

## Change

When filters are active, the Buffer display in the status bar now shows `<filtered> / <total>` — e.g. `42 / 1500` — making it clear how many telegrams are buffered in total versus how many match the current filter.

When no filters are active it shows only the total count, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)