### PR TITLE
feat: allow project file upload regardless of env var configuration

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -193,18 +193,45 @@ async def get_project():
     }
 
 
-@router.get("/api/project/status")
-async def get_project_status():
-    """Returns the status of the project upload feature"""
+def _project_upload_path() -> tuple[str, str | None]:
+    """Returns (project_file_path, password_file_path_or_None) for uploads.
+
+    When KNX_PROJECT_PATH is set we write directly to that path and store the
+    password next to it. Otherwise we fall back to the default /project volume.
+    The password file is None when KNX_PASSWORD is set via env (caller should
+    not overwrite it).
+    """
     env_proj = os.getenv("KNX_PROJECT_PATH")
     env_pwd = os.getenv("KNX_PASSWORD")
 
-    upload_feature_active = not env_proj and not env_pwd
+    if env_proj:
+        proj_file = env_proj
+        # Only write a password sidecar when no env password is configured
+        pwd_file = os.path.splitext(env_proj)[0] + "_password" if not env_pwd else None
+    else:
+        proj_file = os.path.join("/project", "knx_project.knxproj")
+        pwd_file = os.path.join("/project", "knx_project_password")
+
+    return proj_file, pwd_file
+
+
+def _project_upload_writable() -> bool:
+    """Returns True if the upload destination is writable."""
+    proj_file, _ = _project_upload_path()
+    target = proj_file if os.path.exists(proj_file) else os.path.dirname(proj_file)
+    return os.access(target, os.W_OK)
+
+
+@router.get("/api/project/status")
+async def get_project_status():
+    """Returns the status of the project upload feature"""
     project_loaded = knx_daemon.global_knx_project is not None
-    upload_required = upload_feature_active and not project_loaded
+    upload_writable = _project_upload_writable()
+    upload_required = not project_loaded
 
     return {
-        "upload_feature_active": upload_feature_active,
+        "upload_feature_active": True,
+        "upload_writable": upload_writable,
         "project_loaded": project_loaded,
         "upload_required": upload_required,
     }
@@ -212,38 +239,33 @@ async def get_project_status():
 
 @router.post("/api/project/upload")
 async def upload_project(file: UploadFile = File(...), password: str = Form("")):
-    """Uploads a KNX project file and password, saving them to the default volume"""
-    env_proj = os.getenv("KNX_PROJECT_PATH")
-    env_pwd = os.getenv("KNX_PASSWORD")
-
-    if env_proj or env_pwd:
-        raise HTTPException(status_code=400, detail="Upload feature is disabled because environment variables are set.")
-
+    """Uploads a KNX project file and password, saving them to the configured path"""
     if not file.filename or not file.filename.endswith(".knxproj"):
         raise HTTPException(status_code=400, detail="File must be a .knxproj file")
 
-    default_dir = "/project"
-    default_file = os.path.join(default_dir, "knx_project.knxproj")
-    default_pwd = os.path.join(default_dir, "knx_project_password")
+    proj_file, pwd_file = _project_upload_path()
 
-    os.makedirs(default_dir, exist_ok=True)
+    os.makedirs(os.path.dirname(proj_file), exist_ok=True)
 
     content = await file.read()
 
-    with open(default_file, "wb") as f:
-        f.write(content)
-
-    with open(default_pwd, "w", encoding="utf-8") as f:
-        f.write(password)
+    try:
+        with open(proj_file, "wb") as f:
+            f.write(content)
+        if pwd_file:
+            with open(pwd_file, "w", encoding="utf-8") as f:
+                f.write(password)
+    except PermissionError as e:
+        raise HTTPException(status_code=403, detail=f"Cannot write project file: {e}") from e
 
     # Trigger reload
     success = await knx_daemon._load_project_data()
 
     if not success:
-        if os.path.exists(default_file):
-            os.remove(default_file)
-        if os.path.exists(default_pwd):
-            os.remove(default_pwd)
+        if os.path.exists(proj_file) and not os.getenv("KNX_PROJECT_PATH"):
+            os.remove(proj_file)
+        if pwd_file and os.path.exists(pwd_file):
+            os.remove(pwd_file)
         raise HTTPException(status_code=400, detail="Failed to load project. Incorrect password or invalid file.")
 
     return {"status": "ok", "message": "Project loaded successfully"}

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -290,36 +290,77 @@ def test_get_telegrams_delta_with_matches(mock_query):
     assert "1.1.2" in sources
 
 
-def test_get_project_status_active(monkeypatch):
+def test_get_project_status_no_project(monkeypatch):
     monkeypatch.delenv("KNX_PROJECT_PATH", raising=False)
     monkeypatch.delenv("KNX_PASSWORD", raising=False)
     knx_daemon.global_knx_project = None
 
-    response = client.get("/api/project/status")
+    with patch("api._project_upload_writable", return_value=True):
+        response = client.get("/api/project/status")
     assert response.status_code == 200
     data = response.json()
     assert data["upload_feature_active"] is True
+    assert data["upload_writable"] is True
     assert data["project_loaded"] is False
     assert data["upload_required"] is True
 
 
-def test_get_project_status_inactive(monkeypatch):
+def test_get_project_status_with_env_vars(monkeypatch):
     monkeypatch.setenv("KNX_PROJECT_PATH", "/some/path")
     monkeypatch.setenv("KNX_PASSWORD", "secret")
     knx_daemon.global_knx_project = None
 
-    response = client.get("/api/project/status")
+    with patch("api._project_upload_writable", return_value=True):
+        response = client.get("/api/project/status")
     assert response.status_code == 200
     data = response.json()
-    assert data["upload_feature_active"] is False
-    assert data["upload_required"] is False
+    # Upload is always active now
+    assert data["upload_feature_active"] is True
+    assert data["upload_required"] is True
 
 
-def test_upload_project_disabled(monkeypatch):
-    monkeypatch.setenv("KNX_PROJECT_PATH", "/some/path")
+def test_get_project_status_not_writable(monkeypatch):
+    monkeypatch.delenv("KNX_PROJECT_PATH", raising=False)
+    knx_daemon.global_knx_project = None
+
+    with patch("api._project_upload_writable", return_value=False):
+        response = client.get("/api/project/status")
+    assert response.status_code == 200
+    assert response.json()["upload_writable"] is False
+
+
+def test_upload_project_permission_error(monkeypatch, tmp_path):
+    proj_file = tmp_path / "readonly.knxproj"
+    proj_file.write_bytes(b"existing")
+    proj_file.chmod(0o444)
+    monkeypatch.setenv("KNX_PROJECT_PATH", str(proj_file))
+    monkeypatch.delenv("KNX_PASSWORD", raising=False)
+
     response = client.post("/api/project/upload", data={"password": "test"}, files={"file": ("test.knxproj", b"dummy")})
-    assert response.status_code == 400
-    assert "disabled" in response.json()["detail"]
+    assert response.status_code == 403
+    assert "Cannot write project file" in response.json()["detail"]
+
+
+def test_upload_project_with_env_path(monkeypatch, tmp_path):
+    """When KNX_PROJECT_PATH is set, upload writes to that path."""
+    proj_file = tmp_path / "my.knxproj"
+    monkeypatch.setenv("KNX_PROJECT_PATH", str(proj_file))
+    monkeypatch.delenv("KNX_PASSWORD", raising=False)
+
+    async def mock_load():
+        knx_daemon.global_knx_project = {"fake": "project"}
+        return True
+
+    monkeypatch.setattr(knx_daemon, "_load_project_data", mock_load)
+
+    response = client.post(
+        "/api/project/upload", data={"password": "test_pass"}, files={"file": ("test.knxproj", b"dummy_content")}
+    )
+    assert response.status_code == 200
+    assert proj_file.read_bytes() == b"dummy_content"
+    # Password sidecar written next to the project file
+    pwd_file = tmp_path / "my_password"
+    assert pwd_file.read_text() == "test_pass"
 
 
 def test_upload_project_invalid_file(monkeypatch):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -452,7 +452,11 @@ function App() {
                     Rate: <span onClick={() => setRateMode(m => m === 's' ? 'm' : m === 'm' ? 'h' : 's')} style={{ color: 'var(--accent-primary)', fontWeight: 600, cursor: 'pointer' }}>{busRate.toFixed(1)}/{rateMode}</span>
                   </span>
                   <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-dim)' }}>
-                    Buffer: <span style={{ color: 'var(--text-main)', fontWeight: 500 }}>{filteredLiveTelegrams.length}</span>
+                    Buffer: <span style={{ color: 'var(--text-main)', fontWeight: 500 }}>
+                      {activeFilterCount
+                        ? <>{filteredLiveTelegrams.length}<span style={{ color: 'var(--text-dim)', fontWeight: 400 }}> / {liveTelegrams.length}</span></>
+                        : liveTelegrams.length}
+                    </span>
                   </span>
                   {isPaused && (
                     <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: '#fbbf24' }}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -119,6 +119,7 @@ function App() {
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
   const [projectStatus, setProjectStatus] = useState<{
     upload_feature_active: boolean;
+    upload_writable: boolean;
     project_loaded: boolean;
     upload_required: boolean;
   } | null>(null);
@@ -553,11 +554,15 @@ function App() {
                 />
               </div>
 
-              {projectStatus?.upload_feature_active && (
-                <>
-                  <h3 style={{ fontSize: '0.75rem', color: 'var(--text-dim)', textTransform: 'uppercase', marginBottom: '0.75rem', letterSpacing: '0.05em', marginTop: '1.5rem' }}>
-                    Project File
-                  </h3>
+              <>
+                <h3 style={{ fontSize: '0.75rem', color: 'var(--text-dim)', textTransform: 'uppercase', marginBottom: '0.75rem', letterSpacing: '0.05em', marginTop: '1.5rem' }}>
+                  Project File
+                </h3>
+                {projectStatus?.upload_writable === false ? (
+                  <div style={{ fontSize: '0.8rem', color: 'var(--text-dim)', padding: '0.75rem', border: '1px solid var(--border-color)', borderRadius: '6px' }}>
+                    Project file is not writable. Mount the project directory as a writable volume to enable browser upload.
+                  </div>
+                ) : (
                   <button
                     className="glass-input"
                     onClick={() => setIsUploadWizardOpen(true)}
@@ -565,8 +570,8 @@ function App() {
                   >
                     Upload / Replace ETS Project File
                   </button>
-                </>
-              )}
+                )}
+              </>
 
               {knxkeysStatus?.upload_feature_active && (
                 <>


### PR DESCRIPTION
Closes #62

## Problem

The project file upload was gated behind `KNX_PROJECT_PATH` / `KNX_PASSWORD` not being set. Users who configured these env vars (typical production setups) couldn't update their `.knxproj` via the browser — they had to copy the file manually to the host.

## Changes

**Backend**
- `/api/project/upload` no longer rejects requests when env vars are set. When `KNX_PROJECT_PATH` is configured it writes directly to that path; otherwise falls back to `/project/knx_project.knxproj`
- `/api/project/status` always returns `upload_feature_active: true` and adds `upload_writable: bool` — checked via `os.access()` on the target path
- `PermissionError` during write returns HTTP 403 with a clear message

**Frontend**
- Settings panel always shows the **Project File** section
- When `upload_writable` is `false`, the upload button is replaced with an explanatory message: *"Project file is not writable. Mount the project directory as a writable volume to enable browser upload."*

## Tests

- `test_get_project_status_with_env_vars` — upload always active even when env vars set
- `test_get_project_status_not_writable` — `upload_writable: false` surfaced correctly
- `test_upload_project_permission_error` — 403 on read-only file
- `test_upload_project_with_env_path` — writes to `KNX_PROJECT_PATH` when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)