### PR TITLE
chore: group pydantic and pydantic_core in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,18 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      pydantic:
+        patterns:
+          - "pydantic"
+          - "pydantic_core"
+          - "pydantic-core"
       dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "pydantic"
+          - "pydantic_core"
+          - "pydantic-core"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
## Problem

Dependabot PR #72 bumped `pydantic_core` to `2.47.0` while keeping `pydantic` at `2.13.4`, which hard-pins `pydantic-core==2.46.4`. This caused an unresolvable dependency conflict in CI.

## Fix

Split `pydantic` + `pydantic_core` into their own dependabot group, excluded from the catch-all group. Dependabot will now raise a single PR for both packages together — and since there's no `pydantic` release yet that requires `pydantic_core 2.47.0`, it won't raise any PR until both are ready.

## Follow-up

Close dependabot PR #72 after merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)