### PR TITLE
feat: stepped/linear chart toggle with persistence

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -8,6 +8,7 @@ interface MixedChartProps {
   bucket: ChartBucket;
   minTime: number | null;
   maxTime: number | null;
+  stepped: boolean;
 }
 
 // Generate simple distinct colors for series
@@ -24,7 +25,7 @@ const COLORS = [
 // Ensure we have a shared sync cursor across all charts
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const MixedChart: React.FC<MixedChartProps> = ({ bucket }) => {
+export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
 
@@ -105,7 +106,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket }) => {
         stroke: COLORS[idx % COLORS.length],
         width: 2,
         spanGaps: true, // Interpolate gaps so lines don't break on missing data
-        paths: isBinary ? uPlot.paths.stepped?.({ align: 1 }) : undefined,
+        paths: (isBinary || stepped) ? uPlot.paths.stepped?.({ align: 1 }) : undefined,
         fill: isBinary ? COLORS[idx % COLORS.length] + '33' : undefined,
         points: { show: false }, // Hide explicit dots for performance/cleanliness
         value: (_u: uPlot, v: number | null) => {

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -1,10 +1,11 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import type { Telegram } from '../hooks/useWebSocket';
 import { VisualizerSidebar } from './VisualizerSidebar';
 import { useChartData } from '../hooks/useChartData';
 import { MixedChart } from './MixedChart';
 import { TimelineChart } from './TimelineChart';
 import { Download } from 'lucide-react';
+import { getCookie, setCookie } from '../utils/cookies';
 
 interface VisualizerProps {
   telegrams: Telegram[];
@@ -17,6 +18,15 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
 
   const chartWrapperRef = useRef<HTMLDivElement>(null);
   const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets);
+  const [stepped, setStepped] = useState(() => getCookie('chartStepped') !== 'false');
+
+  const toggleStepped = () => {
+    setStepped(s => {
+      const next = !s;
+      setCookie('chartStepped', String(next));
+      return next;
+    });
+  };
 
   const exportPng = () => {
     // A quick hack: uPlot naturally renders to canvas
@@ -51,14 +61,29 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
             </div>
 
             {buckets.length > 0 && (
-              <button
-                className="icon-button"
-                onClick={exportPng}
-                title="Print / PDF Export"
-                style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.4rem 0.85rem', border: '1px solid var(--border-color)', borderRadius: '7px', fontSize: '0.8125rem' }}
-              >
-                <Download size={16} /> Export
-              </button>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                <button
+                  onClick={toggleStepped}
+                  title={stepped ? 'Switch to linear interpolation' : 'Switch to stepped (hold-last-value)'}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '0.5rem',
+                    padding: '0.4rem 0.85rem', border: '1px solid var(--border-color)',
+                    borderRadius: '7px', fontSize: '0.8125rem', cursor: 'pointer',
+                    background: stepped ? 'rgba(99,102,241,0.15)' : 'transparent',
+                    color: stepped ? 'var(--accent-primary)' : 'var(--text-dim)',
+                  }}
+                >
+                  {stepped ? 'Stepped' : 'Linear'}
+                </button>
+                <button
+                  className="icon-button"
+                  onClick={exportPng}
+                  title="Print / PDF Export"
+                  style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.4rem 0.85rem', border: '1px solid var(--border-color)', borderRadius: '7px', fontSize: '0.8125rem' }}
+                >
+                  <Download size={16} /> Export
+                </button>
+              </div>
             )}
           </div>
 
@@ -67,7 +92,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
               b.isBinary ? (
                 <TimelineChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} />
               ) : (
-                <MixedChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} />
+                <MixedChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} stepped={stepped} />
               )
             ))}
 


### PR DESCRIPTION
Closes #64

## Change

Adds a **Stepped / Linear** toggle button to the visualizer toolbar. When stepped (the default), numeric charts hold the last reported value until a new telegram arrives — which is how KNX devices actually behave. Linear interpolation is still available for cases where it makes more sense.

- Defaults to **stepped** (more accurate for KNX)
- Preference persisted in a cookie (`chartStepped`) so it survives page reloads
- Toggle applies to all numeric (`MixedChart`) charts simultaneously
- Binary/timeline charts are unaffected — they were already stepped

🤖 Generated with [Claude Code](https://claude.com/claude-code)