### PR TITLE
feat: improve history search UX — persist time range, filter loaded data

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { KeysUploadWizard } from './components/KeysUploadWizard';
 import {
   DEFAULT_FILTERS,
   hasActiveFilters,
+  matchesTelegram,
   type ActiveFilters,
   type FilterOptions,
   type FilterCounts,
@@ -361,23 +362,9 @@ function App() {
       f.dpts.length === 0;
 
     // Step 1: mark each row as matching / not-matching
-    const matches = sortedLiveTelegrams.map(t => {
-      if (noFilter) return true;
-      const srcMatch = f.sources.includes(t.source_address);
-      const tgtMatch = f.targets.includes(t.target_address);
-      const srcOk = f.sources.length === 0 || srcMatch;
-      const tgtOk = f.targets.length === 0 || tgtMatch;
-      const typeOk = f.types.length === 0 || f.types.includes(t.simplified_type ?? '');
-      const dptOk = f.dpts.length === 0 || (t.dpt_main != null && f.dpts.includes(t.dpt_main));
-
-      // When both sides are active, sourceTargetRelation controls AND vs OR.
-      // When only one side is active the relation is irrelevant — standard pass-through.
-      const srcTgtOk = f.sources.length > 0 && f.targets.length > 0
-        ? (f.sourceTargetRelation === 'OR' ? (srcMatch || tgtMatch) : (srcOk && tgtOk))
-        : (srcOk && tgtOk);
-
-      return srcTgtOk && typeOk && dptOk;
-    });
+    const matches = sortedLiveTelegrams.map(t =>
+      noFilter ? true : matchesTelegram(t, f)
+    );
 
     const hasDelta = f.deltaBeforeMs > 0 || f.deltaAfterMs > 0;
 

--- a/frontend/src/components/HistoryLoader.tsx
+++ b/frontend/src/components/HistoryLoader.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { X, Clock, Database, AlertCircle, CheckCircle2, Calendar, Search } from 'lucide-react';
 import type { Telegram } from '../hooks/useWebSocket';
 import type { ActiveFilters } from '../types/filters';
+import type { LoaderTimeRange } from './HistorySearch';
 import { apiUrl } from '../utils/basePath';
 
 interface Metadata {
@@ -17,6 +18,9 @@ interface HistoryLoaderProps {
   mode?: 'monitor' | 'search';
   /** Active filter state — appended as query params for backend-side filtering (History Search) */
   filters?: ActiveFilters;
+  /** Persisted time range values — retained across open/close cycles */
+  timeRange?: LoaderTimeRange;
+  onTimeRangeChange?: (r: LoaderTimeRange) => void;
 }
 
 type Unit = 'seconds' | 'minutes' | 'hours' | 'days';
@@ -42,19 +46,24 @@ function applyFilterParams(url: string, filters?: ActiveFilters): string {
   return url + (url.includes('?') ? '&' : '?') + params.join('&');
 }
 
-export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, limit, mode = 'search', filters }) => {
+export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, limit, mode = 'search', filters, timeRange, onTimeRangeChange }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<'idle' | 'loading' | 'success'>('idle');
   const [resultMeta, setResultMeta] = useState<Metadata | null>(null);
 
-  // Custom relative
-  const [relValue, setRelValue] = useState<number>(1);
-  const [relUnit, setRelUnit] = useState<Unit>('hours');
+  // Custom relative — initialised from persisted timeRange if provided
+  const [relValue, setRelValue] = useState<number>(timeRange?.relValue ?? 1);
+  const [relUnit, setRelUnit] = useState<Unit>(timeRange?.relUnit ?? 'hours');
 
   // Custom absolute (history search only)
-  const [startTime, setStartTime] = useState('');
-  const [endTime, setEndTime] = useState('');
+  const [startTime, setStartTime] = useState(timeRange?.startTime ?? '');
+  const [endTime, setEndTime] = useState(timeRange?.endTime ?? '');
+
+  // Persist state changes back to parent whenever values change
+  const persistTimeRange = (patch: Partial<LoaderTimeRange>) => {
+    onTimeRangeChange?.({ relValue, relUnit, startTime, endTime, ...patch });
+  };
 
   const doFetch = useCallback(async (baseUrl: string) => {
     setIsLoading(true);
@@ -201,13 +210,13 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
             type="number"
             min={1}
             value={relValue}
-            onChange={e => setRelValue(Number(e.target.value))}
+            onChange={e => { const v = Number(e.target.value); setRelValue(v); persistTimeRange({ relValue: v }); }}
             className="glass-input"
             style={{ width: '90px', flexShrink: 0 }}
           />
           <select
             value={relUnit}
-            onChange={e => setRelUnit(e.target.value as Unit)}
+            onChange={e => { const v = e.target.value as Unit; setRelUnit(v); persistTimeRange({ relUnit: v }); }}
             className="glass-input"
             style={{ flex: 1 }}
           >
@@ -237,11 +246,11 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.75rem' }}>
               <div>
                 <label style={{ display: 'block', fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.35rem' }}>From</label>
-                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={startTime} onChange={e => setStartTime(e.target.value)} />
+                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={startTime} onChange={e => { setStartTime(e.target.value); persistTimeRange({ startTime: e.target.value }); }} />
               </div>
               <div>
                 <label style={{ display: 'block', fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.35rem' }}>To</label>
-                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={endTime} onChange={e => setEndTime(e.target.value)} />
+                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={endTime} onChange={e => { setEndTime(e.target.value); persistTimeRange({ endTime: e.target.value }); }} />
               </div>
             </div>
             <button

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -1,15 +1,23 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef } from 'react';
 import { TelegramTable, type SortConfig, type SortKey } from './TelegramTable';
 import type { Telegram } from '../hooks/useWebSocket';
-import { History, Download, AlertTriangle, Trash2, SlidersHorizontal, LineChart } from 'lucide-react';
+import { History, Download, AlertTriangle, Trash2, SlidersHorizontal, LineChart, RefreshCw } from 'lucide-react';
 import { HistoryLoader } from './HistoryLoader';
 import { Visualizer } from './Visualizer';
 import { FilterPanel } from './FilterPanel';
 import {
   hasActiveFilters,
+  matchesTelegram,
   type ActiveFilters,
   type FilterOptions,
 } from '../types/filters';
+
+export type LoaderTimeRange = {
+  relValue: number;
+  relUnit: 'seconds' | 'minutes' | 'hours' | 'days';
+  startTime: string;
+  endTime: string;
+};
 
 interface HistorySearchProps {
   visibleColumns: { [key: string]: boolean };
@@ -32,7 +40,14 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   const [sortConfig, setSortConfig] = useState<SortConfig>({ key: 'timestamp', direction: 'desc' });
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isVisualizerOpen, setIsVisualizerOpen] = useState(false);
-  // activeFilters and onFiltersChange come from App.tsx (shared with live view)
+
+  // Persisted time range — survives HistoryLoader open/close cycles
+  const [timeRange, setTimeRange] = useState<LoaderTimeRange>({
+    relValue: 1, relUnit: 'hours', startTime: '', endTime: '',
+  });
+
+  // Snapshot of filters at the time of the last load — used to detect stale results
+  const filtersAtLoadRef = useRef<ActiveFilters | null>(null);
 
   const handleSort = (key: SortKey) => {
     setSortConfig(prev => ({
@@ -99,7 +114,34 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
       return next.length > loadLimit ? next.slice(0, loadLimit) : next;
     });
     setMetadata(meta || null);
+    // Snapshot the filters at load time so we can detect when they diverge
+    filtersAtLoadRef.current = activeFilters;
   };
+
+  // In-memory filter pass — mirrors live view filtering so changing filters
+  // immediately applies to already-loaded data without a re-fetch.
+  const filteredSortedTelegrams = useMemo(() => {
+    if (!hasActiveFilters(activeFilters)) return sortedTelegrams;
+    return sortedTelegrams.filter(t => matchesTelegram(t, activeFilters));
+  }, [sortedTelegrams, activeFilters]);
+
+  // True when current filters are less restrictive than what was used to fetch,
+  // meaning some telegrams may be missing from the loaded set.
+  const filtersLessRestrictive = useMemo(() => {
+    const atLoad = filtersAtLoadRef.current;
+    if (!atLoad || telegrams.length === 0) return false;
+    // A category became less restrictive if it had selections at load time
+    // but now has fewer (or none) — data for the removed entries was never fetched.
+    const wasFiltered = (arr: (string | number)[]) => arr.length > 0;
+    const nowHasFewer = (now: (string | number)[], then: (string | number)[]) =>
+      then.some(v => !now.includes(v as never));
+    return (
+      (wasFiltered(atLoad.sources) && nowHasFewer(activeFilters.sources, atLoad.sources)) ||
+      (wasFiltered(atLoad.targets) && nowHasFewer(activeFilters.targets, atLoad.targets)) ||
+      (wasFiltered(atLoad.types)   && nowHasFewer(activeFilters.types,   atLoad.types))   ||
+      (wasFiltered(atLoad.dpts)    && nowHasFewer(activeFilters.dpts,    atLoad.dpts as number[]))
+    );
+  }, [activeFilters, telegrams.length]);
 
   const activeFilterCount = hasActiveFilters(activeFilters)
     ? activeFilters.sources.length + activeFilters.targets.length + activeFilters.types.length + activeFilters.dpts.length
@@ -118,7 +160,19 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
               fontSize: '0.75rem', color: 'var(--text-dim)', background: 'rgba(255,255,255,0.05)',
               padding: '0.2rem 0.6rem', borderRadius: '999px', border: '1px solid var(--border-color)',
             }}>
-              {telegrams.length.toLocaleString()} telegrams
+              {hasActiveFilters(activeFilters)
+                ? <>{filteredSortedTelegrams.length.toLocaleString()}<span style={{ color: 'var(--text-dim)', fontWeight: 400 }}> / {telegrams.length.toLocaleString()}</span></>
+                : telegrams.length.toLocaleString()
+              } telegrams
+            </span>
+          )}
+          {filtersLessRestrictive && (
+            <span
+              style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', fontSize: '0.75rem', color: '#fbbf24', cursor: 'pointer' }}
+              onClick={() => setIsLoaderOpen(true)}
+              title="Filters were broadened after the last load — some matching telegrams may not be in the loaded set. Click to reload."
+            >
+              <RefreshCw size={13} /> Reload for full results
             </span>
           )}
           {metadata?.limit_reached && (
@@ -245,7 +299,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
             </div>
           ) : (
             <TelegramTable
-              telegrams={sortedTelegrams}
+              telegrams={filteredSortedTelegrams}
               visibleColumns={visibleColumns}
               sortConfig={sortConfig}
               onSort={handleSort}
@@ -263,6 +317,8 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
           onLoad={handleLoad}
           limit={loadLimit}
           filters={activeFilters}
+          timeRange={timeRange}
+          onTimeRangeChange={setTimeRange}
         />
       )}
     </div>

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef } from 'react';
+import React, { useState, useMemo } from 'react';
 import { TelegramTable, type SortConfig, type SortKey } from './TelegramTable';
 import type { Telegram } from '../hooks/useWebSocket';
 import { History, Download, AlertTriangle, Trash2, SlidersHorizontal, LineChart, RefreshCw } from 'lucide-react';
@@ -47,7 +47,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   });
 
   // Snapshot of filters at the time of the last load — used to detect stale results
-  const filtersAtLoadRef = useRef<ActiveFilters | null>(null);
+  const [filtersAtLoad, setFiltersAtLoad] = useState<ActiveFilters | null>(null);
 
   const handleSort = (key: SortKey) => {
     setSortConfig(prev => ({
@@ -115,7 +115,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     });
     setMetadata(meta || null);
     // Snapshot the filters at load time so we can detect when they diverge
-    filtersAtLoadRef.current = activeFilters;
+    setFiltersAtLoad(activeFilters);
   };
 
   // In-memory filter pass — mirrors live view filtering so changing filters
@@ -128,7 +128,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   // True when current filters are less restrictive than what was used to fetch,
   // meaning some telegrams may be missing from the loaded set.
   const filtersLessRestrictive = useMemo(() => {
-    const atLoad = filtersAtLoadRef.current;
+    const atLoad = filtersAtLoad;
     if (!atLoad || telegrams.length === 0) return false;
     // A category became less restrictive if it had selections at load time
     // but now has fewer (or none) — data for the removed entries was never fetched.
@@ -141,7 +141,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
       (wasFiltered(atLoad.types)   && nowHasFewer(activeFilters.types,   atLoad.types))   ||
       (wasFiltered(atLoad.dpts)    && nowHasFewer(activeFilters.dpts,    atLoad.dpts as number[]))
     );
-  }, [activeFilters, telegrams.length]);
+  }, [activeFilters, filtersAtLoad, telegrams.length]);
 
   const activeFilterCount = hasActiveFilters(activeFilters)
     ? activeFilters.sources.length + activeFilters.targets.length + activeFilters.types.length + activeFilters.dpts.length

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -54,6 +54,33 @@ export const DEFAULT_FILTERS: ActiveFilters = {
   sourceTargetRelation: 'AND',
 };
 
+/** Minimal telegram shape needed for in-memory filtering. */
+export interface FilterableTelegram {
+  source_address: string;
+  target_address: string;
+  simplified_type?: string | null;
+  dpt_main?: number | null;
+}
+
+/**
+ * Returns true if the telegram passes the active filters.
+ * Used for both live in-memory filtering and history client-side filtering.
+ */
+export function matchesTelegram(t: FilterableTelegram, f: ActiveFilters): boolean {
+  const srcMatch = f.sources.includes(t.source_address);
+  const tgtMatch = f.targets.includes(t.target_address);
+  const srcOk = f.sources.length === 0 || srcMatch;
+  const tgtOk = f.targets.length === 0 || tgtMatch;
+  const typeOk = f.types.length === 0 || f.types.includes(t.simplified_type ?? '');
+  const dptOk = f.dpts.length === 0 || (t.dpt_main != null && f.dpts.includes(t.dpt_main));
+
+  const srcTgtOk = f.sources.length > 0 && f.targets.length > 0
+    ? (f.sourceTargetRelation === 'OR' ? (srcMatch || tgtMatch) : (srcOk && tgtOk))
+    : (srcOk && tgtOk);
+
+  return srcTgtOk && typeOk && dptOk;
+}
+
 export function hasActiveFilters(f: ActiveFilters): boolean {
   return (
     f.sources.length > 0 ||


### PR DESCRIPTION
Closes #68

## Changes

### 1. Persist last time range
`HistoryLoader` state was reset every time the modal was closed. The time range values (`relValue`, `relUnit`, `startTime`, `endTime`) are now lifted to `HistorySearch` and passed back as props, so reopening the loader restores the last-used values.

### 2. In-memory filtering on loaded data
Changing filters now instantly filters the already-loaded telegram list without requiring a re-fetch. The toolbar shows filtered/total (e.g. `42 / 1500 telegrams`) when filters are active, mirroring the live view behaviour.

A shared `matchesTelegram()` utility extracted to `filters.ts` is used by both live and history filtering to avoid logic duplication.

### 3. Stale-filters warning
When a filter category is **broadened** after a load (e.g. a source filter that was selected at load time is removed), a **"Reload for full results"** notice appears in the toolbar. The loaded data never contained those telegrams, so the user may be missing results. Clicking the notice opens the loader.

Tightening filters (making them more restrictive) doesn't show the warning — that just hides rows that are already loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)