### PR TITLE
feat: use more screen width — wider filter pane and tooltips

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -677,7 +677,7 @@ function App() {
 
               {/* Filter panel (slide-in) */}
               <div style={{
-                width: isFilterOpen ? '260px' : '0px',
+                width: isFilterOpen ? 'clamp(260px, 18vw, 340px)' : '0px',
                 overflow: 'hidden',
                 transition: 'width 0.25s cubic-bezier(0.4,0,0.2,1)',
                 flexShrink: 0,
@@ -685,7 +685,7 @@ function App() {
                 display: 'flex',
                 flexDirection: 'column'
               }}>
-                <div style={{ width: 260, flex: 1, overflow: 'hidden' }}>
+                <div style={{ width: 'clamp(260px, 18vw, 340px)', flex: 1, overflow: 'hidden' }}>
                   <FilterPanel
                     options={filterOptions}
                     activeFilters={activeFilters}

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -90,15 +90,19 @@ export const OptionRow: React.FC<OptionRowProps> = ({ label, sublabel, checked, 
 
       {/* Label */}
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{
-          fontSize: '0.8125rem', color: 'var(--text-main)', fontFamily: "'JetBrains Mono', monospace",
-          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-        }}>{label}</div>
-        {sublabel && (
-          <div style={{
-            fontSize: '0.65rem', color: 'var(--text-dim)',
+        <div
+          title={label}
+          style={{
+            fontSize: '0.8125rem', color: 'var(--text-main)', fontFamily: "'JetBrains Mono', monospace",
             overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-          }}>{sublabel}</div>
+          }}>{label}</div>
+        {sublabel && (
+          <div
+            title={sublabel}
+            style={{
+              fontSize: '0.65rem', color: 'var(--text-dim)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{sublabel}</div>
         )}
       </div>
 

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -249,12 +249,12 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
       <div style={{ flex: 1, overflow: 'hidden', display: 'flex' }}>
         {/* Filter panel (slide-in) */}
         <div style={{
-          width: isFilterOpen ? '240px' : '0px',
+          width: isFilterOpen ? 'clamp(260px, 18vw, 340px)' : '0px',
           overflow: 'hidden',
           transition: 'width 0.25s cubic-bezier(0.4,0,0.2,1)',
           flexShrink: 0,
         }}>
-          <div style={{ width: 240, height: '100%' }}>
+          <div style={{ width: 'clamp(260px, 18vw, 340px)', height: '100%' }}>
             <FilterPanel
               options={filterOptions}
               activeFilters={activeFilters}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -95,8 +95,9 @@ code, pre {
 
 /* Layout Utilities */
 .container {
-  max-width: 1400px;
-  margin: 0 auto;
+  /* No max-width — the app fills the full viewport width.
+     The filter pane scales via clamp() and the table takes the remaining space. */
+  width: 100%;
   padding: 2rem;
 }
 


### PR DESCRIPTION
Closes #61

## Changes

- **Filter pane width**: changed from hardcoded `260px` / `240px` to `clamp(260px, 18vw, 340px)` — stays compact on small screens, grows proportionally on wide ones up to 340px. Applied to both the live monitor and history search views.
- **App container**: removed the `max-width: 1400px` cap so the table fills the full remaining viewport width on large displays.
- **Tooltips**: added `title` attributes to the label and sublabel elements in `OptionRow` so hovering over a truncated PA/GA name shows the full text in a native browser tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)