### PR TITLE
feat: tree view for Source/Target filters with real group names

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -172,11 +172,41 @@ async def get_filter_options():
     targets.sort(key=lambda x: x["address"])
     dpt_list = sorted(dpts.values(), key=lambda x: (x["main"], x.get("sub") or 0))
 
+    # Build group name maps from project topology
+    # ga_group_names: {"0": "Zentral", "0/1": "Wetter", ...}
+    # pa_line_names:  {"1": "Area 1", "1.0": "Line EG", ...}
+    ga_group_names: dict[str, str] = {}
+    pa_line_names: dict[str, str] = {}
+
+    if knx_daemon.global_knx_project:
+        def _collect_group_ranges(ranges: dict, depth: int = 0) -> None:
+            for key, data in ranges.items():
+                name = data.get("name", "")
+                if name:
+                    ga_group_names[str(key)] = name
+                nested = data.get("group_ranges", {})
+                if nested:
+                    _collect_group_ranges(nested, depth + 1)
+
+        _collect_group_ranges(knx_daemon.global_knx_project.get("group_ranges", {}))
+
+        for area_key, area_data in knx_daemon.global_knx_project.get("topology", {}).items():
+            area_name = area_data.get("name", "")
+            if area_name:
+                pa_line_names[str(area_key)] = area_name
+            for line_key, line_data in area_data.get("lines", {}).items():
+                line_name = line_data.get("name", "")
+                line_addr = f"{area_key}.{line_key}"
+                if line_name:
+                    pa_line_names[line_addr] = line_name
+
     return {
         "sources": sources,
         "targets": targets,
         "types": ["Write", "Read", "Response"],
         "dpts": dpt_list,
+        "ga_group_names": ga_group_names,
+        "pa_line_names": pa_line_names,
     }
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -198,6 +198,8 @@ function App() {
         targets: data.targets || [],
         types: data.types || ['Write', 'Read', 'Response'],
         dpts: data.dpts || [],
+        ga_group_names: data.ga_group_names || {},
+        pa_line_names: data.pa_line_names || {},
       }))
       .catch(() => {
         // Fallback: populate only the static types

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,7 +21,7 @@ import {
 
 declare const __APP_VERSION__: string;
 
-const EMPTY_FILTER_OPTIONS: FilterOptions = { sources: [], targets: [], types: [], dpts: [] };
+const EMPTY_FILTER_OPTIONS: FilterOptions = { sources: [], targets: [], types: [], dpts: [], ga_group_names: {}, pa_line_names: {} };
 
 const NavDropdown = ({ activeTab, isSettingsOpen, onChange }: { activeTab: string, isSettingsOpen: boolean, onChange: (id: string) => void }) => {
   const [isOpen, setIsOpen] = useState(false);

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_FILTERS
 } from '../types/filters';
 import { compareKnxAddress } from '../utils/knxAddress';
+import { KnxAddressTree } from './KnxAddressTree';
 
 // ─── FilterPanel component ────────────────────────────────────────────────────
 
@@ -338,16 +339,16 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         {/* Source */}
         {filteredSources.length > 0 && (
           <Section title="Source" defaultOpen>
-            {filteredSources.map(s => (
-              <OptionRow
-                key={s.address}
-                label={s.address!}
-                sublabel={s.name || undefined}
-                checked={activeFilters.sources.includes(s.address!)}
-                count={mode === 'live' ? (counts?.sources[s.address!] ?? 0) : undefined}
-                onToggle={() => update({ sources: toggle(activeFilters.sources, s.address!) })}
-              />
-            ))}
+            <KnxAddressTree
+              entries={filteredSources}
+              selected={activeFilters.sources}
+              groupNames={options.pa_line_names ?? {}}
+              separator="."
+              onToggle={addresses => update({ sources: addresses })}
+              counts={counts?.sources}
+              mode={mode}
+              searchQuery={q}
+            />
           </Section>
         )}
 
@@ -379,16 +380,16 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         {/* Target */}
         {filteredTargets.length > 0 && (
           <Section title="Target" defaultOpen>
-            {filteredTargets.map(s => (
-              <OptionRow
-                key={s.address}
-                label={s.address!}
-                sublabel={s.name || undefined}
-                checked={activeFilters.targets.includes(s.address!)}
-                count={mode === 'live' ? (counts?.targets[s.address!] ?? 0) : undefined}
-                onToggle={() => update({ targets: toggle(activeFilters.targets, s.address!) })}
-              />
-            ))}
+            <KnxAddressTree
+              entries={filteredTargets}
+              selected={activeFilters.targets}
+              groupNames={options.ga_group_names ?? {}}
+              separator="/"
+              onToggle={addresses => update({ targets: addresses })}
+              counts={counts?.targets}
+              mode={mode}
+              searchQuery={q}
+            />
           </Section>
         )}
 

--- a/frontend/src/components/KnxAddressTree.tsx
+++ b/frontend/src/components/KnxAddressTree.tsx
@@ -1,0 +1,266 @@
+import React, { useState, useMemo } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import type { FilterOption } from '../types/filters';
+
+interface KnxAddressTreeProps {
+  entries: FilterOption[];
+  selected: string[];
+  /** Group names keyed by address prefix (e.g. {"0": "Zentral", "0/1": "Wetter"} or {"1": "", "1.0": "EG"}) */
+  groupNames: Record<string, string>;
+  /** separator: '/' for GAs, '.' for PAs */
+  separator: '/' | '.';
+  onToggle: (addresses: string[]) => void;
+  counts?: Record<string, number>;
+  mode: 'live' | 'history';
+  searchQuery: string;
+}
+
+type CheckState = 'checked' | 'partial' | 'unchecked';
+
+function getCheckState(leafAddresses: string[], selected: string[]): CheckState {
+  const count = leafAddresses.filter(a => selected.includes(a)).length;
+  if (count === 0) return 'unchecked';
+  if (count === leafAddresses.length) return 'checked';
+  return 'partial';
+}
+
+interface TriCheckboxProps {
+  state: CheckState;
+  onClick: () => void;
+}
+
+const TriCheckbox: React.FC<TriCheckboxProps> = ({ state, onClick }) => (
+  <div
+    onClick={e => { e.stopPropagation(); onClick(); }}
+    style={{
+      width: 14, height: 14, flexShrink: 0, borderRadius: 3, cursor: 'pointer',
+      border: `1.5px solid ${state !== 'unchecked' ? 'var(--accent-primary)' : 'var(--border-color)'}`,
+      background: state === 'checked' ? 'var(--accent-primary)' : 'transparent',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      transition: 'all 0.15s',
+    }}
+  >
+    {state === 'checked' && (
+      <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+        <path d="M1.5 4L3.5 6L6.5 2" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    )}
+    {state === 'partial' && (
+      <div style={{ width: 6, height: 2, background: 'var(--accent-primary)', borderRadius: 1 }} />
+    )}
+  </div>
+);
+
+interface LeafRowProps {
+  address: string;
+  name: string;
+  checked: boolean;
+  count?: number;
+  mode: 'live' | 'history';
+  onToggle: () => void;
+}
+
+const LeafRow: React.FC<LeafRowProps> = ({ address, name, checked, count, mode, onToggle }) => (
+  <div
+    onClick={onToggle}
+    style={{
+      display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.3rem 0.25rem',
+      borderRadius: '5px', cursor: 'pointer', userSelect: 'none',
+      transition: 'background 0.15s',
+    }}
+    onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.04)')}
+    onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+  >
+    <TriCheckbox state={checked ? 'checked' : 'unchecked'} onClick={onToggle} />
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div title={address} style={{
+        fontSize: '0.8125rem', color: 'var(--text-main)', fontFamily: "'JetBrains Mono', monospace",
+        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }}>{address}</div>
+      {name && (
+        <div title={name} style={{
+          fontSize: '0.65rem', color: 'var(--text-dim)',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>{name}</div>
+      )}
+    </div>
+    {mode === 'live' && count !== undefined && (
+      <span style={{
+        fontSize: '0.65rem', fontWeight: 600, minWidth: '1.8rem', textAlign: 'center',
+        padding: '0.1rem 0.4rem', borderRadius: '999px',
+        background: count > 0 ? 'rgba(99,102,241,0.15)' : 'rgba(255,255,255,0.05)',
+        color: count > 0 ? 'var(--accent-primary)' : 'var(--text-dim)',
+        border: count > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border-color)',
+        flexShrink: 0,
+      }}>{count}</span>
+    )}
+  </div>
+);
+
+interface GroupNodeProps {
+  label: string;
+  sublabel?: string;
+  leafAddresses: string[];
+  selected: string[];
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  onToggleAll: () => void;
+}
+
+const GroupNode: React.FC<GroupNodeProps> = ({ label, sublabel, leafAddresses, selected, children, defaultOpen = true, onToggleAll }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  const state = getCheckState(leafAddresses, selected);
+
+  return (
+    <div>
+      <div
+        style={{
+          display: 'flex', alignItems: 'center', gap: '0.4rem',
+          padding: '0.3rem 0.25rem', borderRadius: '5px', cursor: 'pointer',
+          userSelect: 'none',
+        }}
+        onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.04)')}
+        onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+      >
+        <TriCheckbox state={state} onClick={onToggleAll} />
+        <div style={{ flex: 1, minWidth: 0 }} onClick={() => setOpen(o => !o)}>
+          <div title={label} style={{
+            fontSize: '0.8rem', fontWeight: 600, color: 'var(--text-main)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>{label}</div>
+          {sublabel && (
+            <div title={sublabel} style={{
+              fontSize: '0.65rem', color: 'var(--text-dim)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{sublabel}</div>
+          )}
+        </div>
+        <div onClick={() => setOpen(o => !o)} style={{ color: 'var(--text-dim)', flexShrink: 0, display: 'flex' }}>
+          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </div>
+      </div>
+      {open && <div style={{ paddingLeft: '1.25rem' }}>{children}</div>}
+    </div>
+  );
+};
+
+export const KnxAddressTree: React.FC<KnxAddressTreeProps> = ({
+  entries, selected, groupNames, separator, onToggle, counts, mode, searchQuery,
+}) => {
+  const q = searchQuery.toLowerCase();
+
+  // Build tree structure: level1 → level2 → leaves
+  const tree = useMemo(() => {
+    const map = new Map<string, Map<string, FilterOption[]>>();
+    for (const entry of entries) {
+      const parts = entry.address!.split(separator);
+      const l1 = parts[0];
+      const l2 = parts.length >= 2 ? `${parts[0]}${separator}${parts[1]}` : l1;
+      if (!map.has(l1)) map.set(l1, new Map());
+      const l1map = map.get(l1)!;
+      if (!l1map.has(l2)) l1map.set(l2, []);
+      l1map.get(l2)!.push(entry);
+    }
+    return map;
+  }, [entries, separator]);
+
+  // Filter entries by search query
+  const matchesSearch = (entry: FilterOption) =>
+    !q || entry.address!.toLowerCase().includes(q) || (entry.name ?? '').toLowerCase().includes(q);
+
+  return (
+    <div>
+      {[...tree.entries()].map(([l1Key, l2map]) => {
+        const allL1Leaves = [...l2map.values()].flat().map(e => e.address!);
+        const visibleL2 = [...l2map.entries()].filter(([, leaves]) =>
+          leaves.some(matchesSearch)
+        );
+        if (visibleL2.length === 0) return null;
+
+        const l1Name = groupNames[l1Key] || '';
+        const l1Label = l1Name ? `${l1Key} — ${l1Name}` : l1Key;
+
+        // If all leaves are in a single l2 group with the same key as l1 (2-part address), skip l1 level
+        const singleGroup = l2map.size === 1 && [...l2map.keys()][0] === l1Key;
+
+        if (singleGroup) {
+          // Only 1 level deep — render leaves directly under a single group node
+          const leaves = [...l2map.values()][0].filter(matchesSearch);
+          return (
+            <GroupNode
+              key={l1Key}
+              label={l1Label}
+              leafAddresses={allL1Leaves}
+              selected={selected}
+              onToggleAll={() => {
+                const state = getCheckState(allL1Leaves, selected);
+                if (state === 'checked') {
+                  onToggle(selected.filter(a => !allL1Leaves.includes(a)));
+                } else {
+                  onToggle([...new Set([...selected, ...allL1Leaves])]);
+                }
+              }}
+            >
+              {leaves.map(e => (
+                <LeafRow key={e.address} address={e.address!} name={e.name ?? ''} checked={selected.includes(e.address!)}
+                  count={counts?.[e.address!]} mode={mode}
+                  onToggle={() => onToggle(selected.includes(e.address!) ? selected.filter(a => a !== e.address) : [...selected, e.address!])}
+                />
+              ))}
+            </GroupNode>
+          );
+        }
+
+        return (
+          <GroupNode
+            key={l1Key}
+            label={l1Label}
+            leafAddresses={allL1Leaves}
+            selected={selected}
+            onToggleAll={() => {
+              const state = getCheckState(allL1Leaves, selected);
+              if (state === 'checked') {
+                onToggle(selected.filter(a => !allL1Leaves.includes(a)));
+              } else {
+                onToggle([...new Set([...selected, ...allL1Leaves])]);
+              }
+            }}
+          >
+            {visibleL2.map(([l2Key, leaves]) => {
+              const visibleLeaves = leaves.filter(matchesSearch);
+              if (visibleLeaves.length === 0) return null;
+              const l2Leaves = leaves.map(e => e.address!);
+              const l2Name = groupNames[l2Key] || '';
+              const l2Label = l2Name ? `${l2Key} — ${l2Name}` : l2Key;
+
+              return (
+                <GroupNode
+                  key={l2Key}
+                  label={l2Label}
+                  leafAddresses={l2Leaves}
+                  selected={selected}
+                  defaultOpen={false}
+                  onToggleAll={() => {
+                    const state = getCheckState(l2Leaves, selected);
+                    if (state === 'checked') {
+                      onToggle(selected.filter(a => !l2Leaves.includes(a)));
+                    } else {
+                      onToggle([...new Set([...selected, ...l2Leaves])]);
+                    }
+                  }}
+                >
+                  {visibleLeaves.map(e => (
+                    <LeafRow key={e.address} address={e.address!} name={e.name ?? ''} checked={selected.includes(e.address!)}
+                      count={counts?.[e.address!]} mode={mode}
+                      onToggle={() => onToggle(selected.includes(e.address!) ? selected.filter(a => a !== e.address) : [...selected, e.address!])}
+                    />
+                  ))}
+                </GroupNode>
+              );
+            })}
+          </GroupNode>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -15,6 +15,10 @@ export interface FilterOptions {
   targets: FilterOption[];
   types: string[];
   dpts: FilterOption[];
+  /** GA group names keyed by address prefix: {"0": "Zentral", "0/1": "Wetter"} */
+  ga_group_names: Record<string, string>;
+  /** PA area/line names keyed by address prefix: {"1": "Area 1", "1.0": "Line EG"} */
+  pa_line_names: Record<string, string>;
 }
 
 export interface ActiveFilters {


### PR DESCRIPTION
Closes #60

## Changes

### Backend
`/api/filter-options` now includes two new fields:
- `ga_group_names`: `{"0": "Zentral", "0/1": "Wetter", ...}` — parsed from the ETS project's `group_ranges` section
- `pa_line_names`: `{"1": "Area 1", "1.0": "Line EG", ...}` — parsed from the project's `topology` section

### Frontend — new `KnxAddressTree` component
- 3-level collapsible tree for both Source (PAs) and Target (GAs)
- **Tri-state checkboxes** on group nodes: checked (all children selected), partial (some), unchecked (none)
- Clicking a group checkbox toggles all its children at once
- Group labels show the real ETS name: e.g. `0/1 — Wetter`, `1.0 — Line EG`
- Search filters branches in-place — non-matching nodes collapse automatically
- Individual leaf rows retain the count bubble (live mode) and tooltips for truncated text
- Level 2 nodes default to collapsed; level 1 nodes default to open

## Structure
- GAs: `main / middle / sub` (e.g. `0 / 0/1 / 0/1/10`)
- PAs: `area / area.line / area.line.device` (e.g. `1 / 1.0 / 1.0.10`)
- 2-part addresses (no sub-level) render as a flat list under a single group node

🤖 Generated with [Claude Code](https://claude.com/claude-code)