### PR TITLE
fix: cap active filters height so filter selection stays visible (#87)

### DIFF
--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -184,7 +184,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
 
   return (
     <div style={{
-      height: '100%', overflowY: 'auto', display: 'flex', flexDirection: 'column',
+      height: '100%', overflow: 'hidden', display: 'flex', flexDirection: 'column',
       borderRight: '1px solid var(--border-color)',
     }}>
       {/* Header */}
@@ -228,7 +228,9 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           padding: '0.5rem 0.75rem',
           borderBottom: '1px solid var(--border-color)',
           background: 'rgba(255,255,255,0.02)',
-          flexShrink: 0
+          flexShrink: 0,
+          overflowY: 'auto',
+          maxHeight: '40%',
         }}>
           <div style={{ fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.4rem', paddingLeft: '0.25rem' }}>Active Filters</div>
           {activeFilters.sources.map(s => {


### PR DESCRIPTION
## Summary

Fixes #87.

When a large number of filters are active, the active-filters section grew without bound, pushing the filter-selection list (sources/targets/types/DPTs) completely out of view.

- Changed the root panel container from `overflowY: auto` to `overflow: hidden` so flex sizing is respected
- Capped the active-filters section at `maxHeight: 40%` with `overflowY: auto` — it scrolls internally when tall, while the selection list below always remains visible

## Test plan

- [ ] Add many filters at once (e.g. click a full main group to add many sources/targets)
- [ ] Verify the active filters section scrolls internally and the filter selection list remains visible below it
- [ ] Verify the panel still works normally with zero or few active filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)