### PR TITLE
fix: prevent >4-digit year in datetime-local inputs (#88)

### DIFF
--- a/frontend/src/components/HistoryLoader.tsx
+++ b/frontend/src/components/HistoryLoader.tsx
@@ -65,6 +65,13 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
     onTimeRangeChange?.({ relValue, relUnit, startTime, endTime, ...patch });
   };
 
+  // Some browsers allow typing more than 4 digits into the year segment of a
+  // datetime-local input. Clamp to 4 digits to prevent e.g. "202600-01-01T00:00".
+  const clampYear = (value: string) => {
+    const match = value.match(/^(\d{5,})(-.+)$/);
+    return match ? match[1].slice(0, 4) + match[2] : value;
+  };
+
   const doFetch = useCallback(async (baseUrl: string) => {
     setIsLoading(true);
     setError(null);
@@ -246,11 +253,11 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.75rem' }}>
               <div>
                 <label style={{ display: 'block', fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.35rem' }}>From</label>
-                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={startTime} onChange={e => { setStartTime(e.target.value); persistTimeRange({ startTime: e.target.value }); }} />
+                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={startTime} onChange={e => { const v = clampYear(e.target.value); setStartTime(v); persistTimeRange({ startTime: v }); }} />
               </div>
               <div>
                 <label style={{ display: 'block', fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.35rem' }}>To</label>
-                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={endTime} onChange={e => { setEndTime(e.target.value); persistTimeRange({ endTime: e.target.value }); }} />
+                <input type="datetime-local" className="glass-input" style={{ width: '100%' }} value={endTime} onChange={e => { const v = clampYear(e.target.value); setEndTime(v); persistTimeRange({ endTime: v }); }} />
               </div>
             </div>
             <button


### PR DESCRIPTION
## Summary

Fixes #88.

Some browsers allow typing extra digits into the year segment of a `datetime-local` input, producing malformed values like `202600-01-01T00:00` that then fail to parse as query parameters.

Added a `clampYear` helper that strips excess leading digits from the year part on every `onChange` event, keeping the value well-formed before it reaches state or the backend.

## Test plan

- [ ] Open Load History dialog
- [ ] Click into the year segment of the From or To date input and type more than 4 digits
- [ ] Verify the year is clamped to 4 digits and does not allow `202600`-style values
- [ ] Verify normal date entry (2-digit day → 2-digit month → 4-digit year) still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)