### PR TITLE
chore: fix import order in knx_daemon.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist-ssr/
 *.local
 
 # Python
+.python-version
 __pycache__/
 *.py[cod]
 *$py.class

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -4,13 +4,13 @@ import os
 from datetime import UTC, datetime
 from typing import Any
 
+from knx_telegram_store import StoredTelegram
 from xknx import XKNX
 from xknx.io import ConnectionConfig, ConnectionType, SecureConfig
 from xknx.telegram import Telegram as XknxTelegram
 from xknx.telegram.address import IndividualAddress
 
 from database import store
-from knx_telegram_store import StoredTelegram
 from parsers import format_dpt_name, get_simplified_type, parse_telegram_payload
 from ws_manager import manager
 


### PR DESCRIPTION
## Summary

- Moves `knx_telegram_store` import into the third-party block so it sorts alphabetically alongside the other third-party imports, consistent with ruff/isort ordering.

No logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)