### PR TITLE
feat: add light/dark/system theme support

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useWebSocket, type Telegram } from './hooks/useWebSocket';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
-import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, ChevronDown, AlertTriangle } from 'lucide-react';
+import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, ChevronDown, AlertTriangle, Sun, Moon, Monitor } from 'lucide-react';
 import { getCookie, setCookie } from './utils/cookies';
+import { useTheme } from './hooks/useTheme';
 import { apiUrl, wsUrl } from './utils/basePath';
 import { HistoryLoader } from './components/HistoryLoader';
 import { HistorySearch } from './components/HistorySearch';
@@ -56,7 +57,7 @@ const NavDropdown = ({ activeTab, isSettingsOpen, onChange }: { activeTab: strin
           display: 'flex', alignItems: 'center', gap: '0.75rem',
           fontSize: '0.95rem', fontWeight: 600, padding: '0.5rem 1rem',
           borderRadius: '8px', border: '1px solid var(--border-color)',
-          background: isOpen ? 'rgba(255,255,255,0.1)' : 'rgba(255,255,255,0.05)',
+          background: isOpen ? 'var(--bg-hover)' : 'var(--bg-tag)',
           color: 'var(--text-main)', cursor: 'pointer', outline: 'none',
           minWidth: '220px', justifyContent: 'space-between',
           transition: 'all 0.2s ease'
@@ -113,6 +114,7 @@ const NavDropdown = ({ activeTab, isSettingsOpen, onChange }: { activeTab: strin
 };
 
 function App() {
+  const [theme, setTheme] = useTheme();
   const [activeTab, setActiveTab] = useState<'live' | 'history'>('live');
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(true);
@@ -446,7 +448,7 @@ function App() {
             {activeTab === 'live' && !isSettingsOpen && (
               <>
                 {/* Embedded Stats */}
-                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginRight: '1rem', background: 'rgba(255,255,255,0.03)', padding: '0.4rem 0.85rem', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginRight: '1rem', background: 'var(--bg-subtle)', padding: '0.4rem 0.85rem', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
                   <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-dim)' }}>
                     Rate: <span onClick={() => setRateMode(m => m === 's' ? 'm' : m === 'm' ? 'h' : 's')} style={{ color: 'var(--accent-primary)', fontWeight: 600, cursor: 'pointer' }}>{busRate.toFixed(1)}/{rateMode}</span>
                   </span>
@@ -524,12 +526,44 @@ function App() {
             <div className="glass-card" style={{ padding: '1.5rem', maxWidth: 600, margin: '0 auto' }}>
                <h2 style={{ marginBottom: '1.5rem', fontSize: '1.1rem' }}>Application Settings</h2>
 
+              <h3 style={{ fontSize: '0.75rem', color: 'var(--text-dim)', textTransform: 'uppercase', marginBottom: '0.75rem', letterSpacing: '0.05em' }}>
+                Appearance
+              </h3>
+              <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '2rem' }}>
+                {([
+                  { id: 'system', label: 'System', Icon: Monitor },
+                  { id: 'light',  label: 'Light',  Icon: Sun },
+                  { id: 'dark',   label: 'Dark',   Icon: Moon },
+                ] as const).map(({ id, label, Icon }) => (
+                  <button
+                    key={id}
+                    onClick={() => setTheme(id)}
+                    style={{
+                      flex: 1,
+                      display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.4rem',
+                      padding: '0.5rem',
+                      borderRadius: 6,
+                      border: `1px solid ${theme === id ? 'var(--accent-primary)' : 'var(--border-color)'}`,
+                      background: theme === id ? 'rgba(99,102,241,0.15)' : 'var(--bg-subtle)',
+                      color: theme === id ? 'var(--accent-primary)' : 'var(--text-dim)',
+                      cursor: 'pointer',
+                      fontSize: '0.8rem',
+                      fontWeight: theme === id ? 600 : 400,
+                      transition: 'all 0.15s',
+                    }}
+                  >
+                    <Icon size={14} />
+                    {label}
+                  </button>
+                ))}
+              </div>
+
                <h3 style={{ fontSize: '0.75rem', color: 'var(--text-dim)', textTransform: 'uppercase', marginBottom: '0.75rem', letterSpacing: '0.05em' }}>
                 Table Columns
               </h3>
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', marginBottom: '2rem' }}>
                 {Object.keys(visibleColumns).map(col => (
-                  <button key={col} className="setting-item" onClick={() => toggleColumn(col)} style={{ padding: '0.5rem', background: 'rgba(255,255,255,0.02)', borderRadius: 6 }}>
+                  <button key={col} className="setting-item" onClick={() => toggleColumn(col)} style={{ padding: '0.5rem', background: 'var(--bg-subtle)', borderRadius: 6 }}>
                     <div className={`checkbox ${visibleColumns[col] ? 'checked' : ''}`} style={{ width: 14, height: 14, border: '1px solid var(--border-color)', borderRadius: 3, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                       {visibleColumns[col] && <div style={{ width: 8, height: 8, background: 'white', borderRadius: 2 }} />}
                     </div>
@@ -609,7 +643,7 @@ function App() {
                       value != null && (
                         <div key={key} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                           <span style={{ color: 'var(--text-dim)' }}>{key.replace(/_/g, ' ')}:</span>
-                          <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'rgba(255,255,255,0.05)', padding: '0.15rem 0.4rem', borderRadius: 4, fontSize: '0.75rem' }}>
+                          <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'var(--bg-tag)', padding: '0.15rem 0.4rem', borderRadius: 4, fontSize: '0.75rem' }}>
                             {String(value)}
                           </span>
                         </div>
@@ -617,7 +651,7 @@ function App() {
                     ))}
 
                     {/* Files */}
-                    <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid rgba(255,255,255,0.05)' }}>
+                    <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--border-subtle)' }}>
                       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                         <span style={{ color: 'var(--text-dim)' }}>Project file:</span>
                         <span style={{ color: serverConfig.files?.project_loaded ? 'var(--success)' : 'var(--text-dim)', fontSize: '0.75rem' }}>
@@ -634,12 +668,12 @@ function App() {
 
                     {/* Security */}
                     {Object.entries(serverConfig.security || {}).some(([, v]) => v != null) && (
-                      <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid rgba(255,255,255,0.05)' }}>
+                      <div style={{ marginTop: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid var(--border-subtle)' }}>
                         {Object.entries(serverConfig.security || {}).map(([key, value]) => (
                           value != null && (
                             <div key={key} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '0.25rem' }}>
                               <span style={{ color: 'var(--text-dim)' }}>{key.replace(/_/g, ' ')}:</span>
-                              <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'rgba(255,255,255,0.05)', padding: '0.15rem 0.4rem', borderRadius: 4, fontSize: '0.75rem' }}>
+                              <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'var(--bg-tag)', padding: '0.15rem 0.4rem', borderRadius: 4, fontSize: '0.75rem' }}>
                                 {String(value)}
                               </span>
                             </div>
@@ -659,13 +693,13 @@ function App() {
                 </h3>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.85rem' }}>
                   <span style={{ color: 'var(--text-dim)' }}>Frontend Version:</span>
-                  <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'rgba(255,255,255,0.05)', padding: '0.2rem 0.4rem', borderRadius: 4 }}>
+                  <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'var(--bg-tag)', padding: '0.2rem 0.4rem', borderRadius: 4 }}>
                     {typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'unknown'}
                   </span>
                 </div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: '0.85rem' }}>
                   <span style={{ color: 'var(--text-dim)' }}>Backend Version:</span>
-                  <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'rgba(255,255,255,0.05)', padding: '0.2rem 0.4rem', borderRadius: 4 }}>
+                  <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'var(--bg-tag)', padding: '0.2rem 0.4rem', borderRadius: 4 }}>
                     {backendVersion}
                   </span>
                 </div>
@@ -775,7 +809,7 @@ function App() {
 
       <style>{`
         .nav-item { display: flex; align-items: center; gap: 0.75rem; padding: 0.75rem 1rem; border-radius: 8px; border: none; background: transparent; color: var(--text-dim); cursor: pointer; font-weight: 500; transition: all 0.2s ease; width: 100%; text-align: left; }
-        .nav-item:hover { background: rgba(255,255,255,0.05); color: var(--text-main); }
+        .nav-item:hover { background: var(--bg-hover); color: var(--text-main); }
         .nav-item.active { background: rgba(99,102,241,0.1); color: var(--accent-primary); }
         .icon-button { background: transparent; border: none; cursor: pointer; color: var(--text-dim); transition: all 0.2s; }
         .icon-button:hover { color: var(--text-main); transform: scale(1.1); }
@@ -786,7 +820,7 @@ function App() {
         .highlight { color: var(--text-dim); }
         .highlight-target { color: var(--accent-primary); font-weight: 500; }
         .subtitle-name { font-size: 0.7rem; color: var(--text-dim); margin-top: 0.15rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        .raw-badge { background: rgba(255,255,255,0.05); padding: 0.15rem 0.4rem; border-radius: 3px; font-family: 'JetBrains Mono', monospace; font-size: 0.65rem; color: var(--text-dim); display: inline-block; border: 1px solid rgba(255,255,255,0.05); }
+        .raw-badge { background: var(--bg-tag); padding: 0.15rem 0.4rem; border-radius: 3px; font-family: 'JetBrains Mono', monospace; font-size: 0.65rem; color: var(--text-dim); display: inline-block; border: 1px solid var(--border-subtle); }
       `}</style>
     </div>
   );

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -62,7 +62,7 @@ export const OptionRow: React.FC<OptionRowProps> = ({ label, sublabel, checked, 
     borderRadius: '6px', transition: 'background 0.15s',
     paddingRight: '0.25rem'
   }}
-    onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.04)')}
+    onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
     onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
   >
     <label
@@ -112,7 +112,7 @@ export const OptionRow: React.FC<OptionRowProps> = ({ label, sublabel, checked, 
         <span style={{
           fontSize: '0.65rem', fontWeight: 600, minWidth: '1.8rem', textAlign: 'center',
           padding: '0.1rem 0.4rem', borderRadius: '999px',
-          background: count > 0 ? 'rgba(99,102,241,0.15)' : 'rgba(255,255,255,0.05)',
+          background: count > 0 ? 'rgba(99,102,241,0.15)' : 'var(--bg-tag)',
           color: count > 0 ? 'var(--accent-primary)' : 'var(--text-dim)',
           border: count > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border-color)',
         }}>
@@ -227,7 +227,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         <div style={{
           padding: '0.5rem 0.75rem',
           borderBottom: '1px solid var(--border-color)',
-          background: 'rgba(255,255,255,0.02)',
+          background: 'var(--bg-subtle)',
           flexShrink: 0,
           overflowY: 'auto',
           maxHeight: '40%',
@@ -308,7 +308,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
       <div style={{ padding: '0.75rem', borderBottom: '1px solid var(--border-color)', flexShrink: 0 }}>
         <div style={{
           display: 'flex', alignItems: 'center', gap: '0.5rem',
-          background: 'rgba(255,255,255,0.05)', border: '1px solid var(--border-color)',
+          background: 'var(--bg-tag)', border: '1px solid var(--border-color)',
           borderRadius: '7px', padding: '0.45rem 0.65rem',
           transition: 'border-color 0.2s',
         }}>
@@ -445,7 +445,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
                 placeholder="0 = off"
                 onChange={e => update({ deltaBeforeMs: Math.max(0, Number(e.target.value)) })}
                 style={{
-                  flex: 1, background: 'rgba(255,255,255,0.05)', border: '1px solid var(--border-color)',
+                  flex: 1, background: 'var(--bg-tag)', border: '1px solid var(--border-color)',
                   borderRadius: '6px', padding: '0.45rem 0.6rem', color: 'var(--text-main)',
                   fontSize: '0.8125rem', fontFamily: 'inherit', outline: 'none',
                 }}
@@ -465,7 +465,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
                 placeholder="0 = off"
                 onChange={e => update({ deltaAfterMs: Math.max(0, Number(e.target.value)) })}
                 style={{
-                  flex: 1, background: 'rgba(255,255,255,0.05)', border: '1px solid var(--border-color)',
+                  flex: 1, background: 'var(--bg-tag)', border: '1px solid var(--border-color)',
                   borderRadius: '6px', padding: '0.45rem 0.6rem', color: 'var(--text-main)',
                   fontSize: '0.8125rem', fontFamily: 'inherit', outline: 'none',
                 }}

--- a/frontend/src/components/HistoryLoader.tsx
+++ b/frontend/src/components/HistoryLoader.tsx
@@ -182,13 +182,13 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
               <span key={t} style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'rgba(251,191,36,0.1)', color: '#fbbf24', border: '1px solid rgba(251,191,36,0.3)' }}>{t}</span>
             ))}
             {filters.dpts.map(d => (
-              <span key={d} style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'rgba(255,255,255,0.05)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>DPT {d}</span>
+              <span key={d} style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'var(--bg-tag)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>DPT {d}</span>
             ))}
             {filters.deltaBeforeMs > 0 && (
-              <span style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'rgba(255,255,255,0.05)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>−{filters.deltaBeforeMs}ms before</span>
+              <span style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'var(--bg-tag)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>−{filters.deltaBeforeMs}ms before</span>
             )}
             {filters.deltaAfterMs > 0 && (
-              <span style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'rgba(255,255,255,0.05)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>+{filters.deltaAfterMs}ms after</span>
+              <span style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'var(--bg-tag)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>+{filters.deltaAfterMs}ms after</span>
             )}
           </div>
         )}
@@ -298,10 +298,10 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
         .modal-overlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.45); backdrop-filter: blur(6px); display: flex; align-items: center; justify-content: center; z-index: 1000; animation: fade-in 0.15s ease-out; }
         .modal-content { width: 480px; max-height: 90vh; overflow-y: auto; padding: 2rem; border-radius: 14px; animation: scale-in 0.2s cubic-bezier(0.16,1,0.3,1); }
         .section-label { display: flex; align-items: center; gap: 0.4rem; font-size: 0.65rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 0.65rem; }
-        .quick-load-btn { display: flex; align-items: center; justify-content: center; padding: 0.65rem 0.5rem; background: rgba(255,255,255,0.03); border: 1px solid var(--border-color); border-radius: 8px; color: var(--text-main); font-size: 0.8125rem; cursor: pointer; transition: all 0.2s; }
+        .quick-load-btn { display: flex; align-items: center; justify-content: center; padding: 0.65rem 0.5rem; background: var(--bg-subtle); border: 1px solid var(--border-color); border-radius: 8px; color: var(--text-main); font-size: 0.8125rem; cursor: pointer; transition: all 0.2s; }
         .quick-load-btn:hover:not(:disabled) { background: rgba(99,102,241,0.1); border-color: var(--accent-primary); color: var(--accent-primary); }
         .quick-load-btn:disabled { opacity: 0.5; cursor: not-allowed; }
-        .glass-input { background: rgba(255,255,255,0.05); border: 1px solid var(--border-color); border-radius: 8px; padding: 0.65rem 0.75rem; color: var(--text-main); font-family: inherit; font-size: 0.8125rem; outline: none; transition: border-color 0.2s; box-sizing: border-box; }
+        .glass-input { background: var(--bg-tag); border: 1px solid var(--border-color); border-radius: 8px; padding: 0.65rem 0.75rem; color: var(--text-main); font-family: inherit; font-size: 0.8125rem; outline: none; transition: border-color 0.2s; box-sizing: border-box; }
         .glass-input:focus { border-color: var(--accent-primary); }
         .glass-input::-webkit-calendar-picker-indicator { filter: invert(0.8); cursor: pointer; }
         .search-submit-btn { display: flex; align-items: center; justify-content: center; gap: 0.6rem; padding: 0.8rem; background: rgba(99,102,241,0.12); border: 1px solid var(--accent-primary); border-radius: 8px; color: var(--accent-primary); font-weight: 600; font-size: 0.875rem; cursor: pointer; transition: all 0.2s; }

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -157,7 +157,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
           {telegrams.length > 0 && (
             <span style={{
-              fontSize: '0.75rem', color: 'var(--text-dim)', background: 'rgba(255,255,255,0.05)',
+              fontSize: '0.75rem', color: 'var(--text-dim)', background: 'var(--bg-tag)',
               padding: '0.2rem 0.6rem', borderRadius: '999px', border: '1px solid var(--border-color)',
             }}>
               {hasActiveFilters(activeFilters)

--- a/frontend/src/components/KnxAddressTree.tsx
+++ b/frontend/src/components/KnxAddressTree.tsx
@@ -68,7 +68,7 @@ const LeafRow: React.FC<LeafRowProps> = ({ address, name, checked, count, mode, 
       borderRadius: '5px', cursor: 'pointer', userSelect: 'none',
       transition: 'background 0.15s',
     }}
-    onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.04)')}
+    onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
     onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
   >
     <TriCheckbox state={checked ? 'checked' : 'unchecked'} onClick={onToggle} />
@@ -88,7 +88,7 @@ const LeafRow: React.FC<LeafRowProps> = ({ address, name, checked, count, mode, 
       <span style={{
         fontSize: '0.65rem', fontWeight: 600, minWidth: '1.8rem', textAlign: 'center',
         padding: '0.1rem 0.4rem', borderRadius: '999px',
-        background: count > 0 ? 'rgba(99,102,241,0.15)' : 'rgba(255,255,255,0.05)',
+        background: count > 0 ? 'rgba(99,102,241,0.15)' : 'var(--bg-tag)',
         color: count > 0 ? 'var(--accent-primary)' : 'var(--text-dim)',
         border: count > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border-color)',
         flexShrink: 0,
@@ -119,7 +119,7 @@ const GroupNode: React.FC<GroupNodeProps> = ({ label, sublabel, leafAddresses, s
           padding: '0.3rem 0.25rem', borderRadius: '5px', cursor: 'pointer',
           userSelect: 'none',
         }}
-        onMouseEnter={e => (e.currentTarget.style.background = 'rgba(255,255,255,0.04)')}
+        onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
         onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
       >
         <TriCheckbox state={state} onClick={onToggleAll} />

--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useLayoutEffect, useState } from 'react';
+import React, { useRef, useLayoutEffect, useState, useMemo } from 'react';
 import UplotReact from 'uplot-react';
 import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';
 import type { ChartBucket } from '../hooks/useChartData';
+import { useThemeTick } from '../hooks/useTheme';
 
 interface MixedChartProps {
   bucket: ChartBucket;
@@ -28,6 +29,7 @@ const syncCursor = uPlot.sync('knx-time-axis');
 export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
+  const themeTick = useThemeTick();
 
   // Resize observer to keep chart fluid
   useLayoutEffect(() => {
@@ -48,78 +50,76 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
     ...series.map(s => s.data)
   ];
 
-  // Configure Y-Axis scale limits based on smart defaults
-  let scaleConfig: uPlot.Scale = {
-    // scale auto
-  };
+  const options: uPlot.Options = useMemo(() => {
+    const style = getComputedStyle(document.documentElement);
+    const gridStroke = style.getPropertyValue('--border-subtle').trim();
+    const axisStroke = style.getPropertyValue('--text-dim').trim();
 
-  if (!isBinary && (unit === '%' || unit === 'Hz' || unit === 'W')) {
-    // Smart Y bounds: these should typically floor at 0
-    scaleConfig = {
-      auto: true,
-      range: (_u, _min, max) => {
-        const hardMin = 0;
-        return [hardMin, max > hardMin ? max * 1.1 : 100];
-      }
-    };
-  } else if (isBinary) {
-    // For boolean square wave, lock to slightly outside 0-1
-    scaleConfig = {
-      auto: false,
-      range: [-0.1, 1.1]
-    };
-  }
-
-  const options: uPlot.Options = {
-    width,
-    height: isBinary ? Math.max(150, series.length * 50) : 300,
-    cursor: { sync: { key: syncCursor.key } },
-    scales: {
-      x: { time: true },
-      // Shared Y scale for this unit bucket
-      y: scaleConfig
-    },
-    axes: [
-      {
-        space: 50,
-        grid: { stroke: 'rgba(255,255,255,0.05)', width: 1 },
-        stroke: '#94a3b8',
-        values: (_u, splits) => splits.map(v =>
-          new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
-        )
-      },
-      {
-        space: 30,
-        grid: { stroke: 'rgba(255,255,255,0.05)', width: 1 },
-        stroke: '#94a3b8',
-        values: isBinary
-          ? (_u, splits) => splits.map(v => v === 1 ? 'ON' : v === 0 ? 'OFF' : '')
-          : undefined
-      }
-    ],
-    series: [
-      {
-        value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
-      },
-      ...series.map((s, idx) => ({
-        label: s.name,
-        stroke: COLORS[idx % COLORS.length],
-        width: 2,
-        spanGaps: true, // Interpolate gaps so lines don't break on missing data
-        paths: (isBinary || stepped) ? uPlot.paths.stepped?.({ align: 1 }) : undefined,
-        fill: isBinary ? COLORS[idx % COLORS.length] + '33' : undefined,
-        points: { show: false }, // Hide explicit dots for performance/cleanliness
-        value: (_u: uPlot, v: number | null) => {
-          if (v === null) return '-';
-          if (isBinary) return v === 1 ? 'On' : 'Off';
-          return v + ' ' + unit;
+    // Configure Y-Axis scale limits based on smart defaults
+    let scaleConfig: uPlot.Scale = {};
+    if (!isBinary && (unit === '%' || unit === 'Hz' || unit === 'W')) {
+      scaleConfig = {
+        auto: true,
+        range: (_u, _min, max) => {
+          const hardMin = 0;
+          return [hardMin, max > hardMin ? max * 1.1 : 100];
         }
-      }))
-    ]
-  };
+      };
+    } else if (isBinary) {
+      scaleConfig = { auto: false, range: [-0.1, 1.1] };
+    }
+
+    return {
+      width,
+      height: isBinary ? Math.max(150, series.length * 50) : 300,
+      cursor: { sync: { key: syncCursor.key } },
+      scales: {
+        x: { time: true },
+        y: scaleConfig
+      },
+      axes: [
+        {
+          space: 50,
+          grid: { stroke: gridStroke, width: 1 },
+          stroke: axisStroke,
+          values: (_u, splits) => splits.map(v =>
+            new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
+          )
+        },
+        {
+          space: 30,
+          grid: { stroke: gridStroke, width: 1 },
+          stroke: axisStroke,
+          values: isBinary
+            ? (_u, splits) => splits.map(v => v === 1 ? 'ON' : v === 0 ? 'OFF' : '')
+            : undefined
+        }
+      ],
+      series: [
+        {
+          value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+        },
+        ...series.map((s, idx) => ({
+          label: s.name,
+          stroke: COLORS[idx % COLORS.length],
+          width: 2,
+          spanGaps: true,
+          paths: (isBinary || stepped) ? uPlot.paths.stepped?.({ align: 1 }) : undefined,
+          fill: isBinary ? COLORS[idx % COLORS.length] + '33' : undefined,
+          points: { show: false },
+          value: (_u: uPlot, v: number | null) => {
+            if (v === null) return '-';
+            if (isBinary) return v === 1 ? 'On' : 'Off';
+            return v + ' ' + unit;
+          }
+        }))
+      ]
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width, bucket, stepped, themeTick]);
 
   return (
-    <div style={{ marginBottom: '2rem', background: 'rgba(0,0,0,0.2)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
+    <div style={{ marginBottom: '2rem', background: 'var(--bg-inset)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
       <h4 style={{ margin: '0 0 1rem', fontSize: '0.9rem', color: 'var(--text-main)' }}>
         {isBinary ? 'Binary States (Ein/Aus)' : `Metrics (${unit})`}
       </h4>

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -38,6 +38,14 @@ const getDPTColor = (dpt_main: number | null) => {
   return 'var(--dpt-unknown, #6b7280)';
 };
 
+const getDPTLabel = (dpt_main: number | null) => {
+  if (dpt_main === 1) return 'DPT 1.x – Binary / Switch';
+  if (dpt_main === 5) return 'DPT 5.x – 8-bit unsigned';
+  if (dpt_main === 9) return 'DPT 9.x – 2-byte float';
+  if (dpt_main != null) return `DPT ${dpt_main}.x`;
+  return 'Unknown DPT';
+};
+
 export const TelegramTable: React.FC<TelegramTableProps> = ({
   telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize
 }) => {
@@ -232,7 +240,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                       </button>
                     </div>
                     {visibleColumns.sourceName && (
-                      <div className="subtitle-name" style={{ fontSize: '0.7rem', color: 'var(--text-dim)', marginTop: '0.15rem', maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <div className="subtitle-name" title={t.source_name || undefined} style={{ fontSize: '0.7rem', color: 'var(--text-dim)', marginTop: '0.15rem', maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {t.source_name || '-'}
                       </div>
                     )}
@@ -254,7 +262,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                       </button>
                     </div>
                     {visibleColumns.targetName && (
-                      <div className="subtitle-name" style={{ fontSize: '0.7rem', color: 'var(--text-main)', fontWeight: 500, marginTop: '0.15rem', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <div className="subtitle-name" title={t.target_name || undefined} style={{ fontSize: '0.7rem', color: 'var(--text-main)', fontWeight: 500, marginTop: '0.15rem', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {t.target_name || '-'}
                       </div>
                     )}
@@ -285,8 +293,8 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                     <div style={{ padding: cellPadding, minWidth: 0, overflow: 'hidden' }} className="filterable-cell">
                       {t.dpt_name && t.dpt_main != null ? (
                         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', minWidth: 0 }}>
-                          <div style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: getDPTColor(t.dpt_main), flexShrink: 0 }} />
-                          <span style={{ fontSize: '0.75rem', color: 'var(--text-dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{t.dpt_name}</span>
+                          <div title={getDPTLabel(t.dpt_main)} style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: getDPTColor(t.dpt_main), flexShrink: 0 }} />
+                          <span title={t.dpt_name ?? undefined} style={{ fontSize: '0.75rem', color: 'var(--text-dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{t.dpt_name}</span>
                           <button
                             className={`quick-filter-btn ${activeFilters.dpts.includes(t.dpt_main) ? 'active' : ''}`}
                             onClick={(e) => { e.stopPropagation(); if (t.dpt_main != null) onQuickFilter('dpts', t.dpt_main); }}

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -206,7 +206,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                     gridTemplateColumns: gridTemplate,
                     borderBottom: '1px solid var(--border-color)',
                     fontSize: '0.8125rem',
-                    background: virtualRow.index % 2 === 0 ? 'rgba(255,255,255,0.01)' : 'transparent',
+                    background: virtualRow.index % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
                     alignItems: 'start',
                     minHeight: '60px' // Ensure a minimum touch/visual target
                   }}
@@ -325,7 +325,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                       </button>
                     </div>
                     {visibleColumns.data && t.raw_hex && (
-                      <div className="raw-badge" style={{ marginTop: '0.4rem', background: 'rgba(255,255,255,0.05)', padding: '0.1rem 0.3rem', borderRadius: '3px', fontSize: '0.65rem', color: 'var(--text-dim)', display: 'inline-block', fontFamily: 'var(--font-mono)' }}>
+                      <div className="raw-badge" style={{ marginTop: '0.4rem', background: 'var(--bg-tag)', padding: '0.1rem 0.3rem', borderRadius: '3px', fontSize: '0.65rem', color: 'var(--text-dim)', display: 'inline-block', fontFamily: 'var(--font-mono)' }}>
                         {t.raw_hex}
                       </div>
                     )}

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useLayoutEffect, useState } from 'react';
+import React, { useRef, useLayoutEffect, useState, useMemo } from 'react';
 import UplotReact from 'uplot-react';
 import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';
 import type { ChartBucket } from '../hooks/useChartData';
+import { useThemeTick } from '../hooks/useTheme';
 
 interface TimelineChartProps {
   bucket: ChartBucket;
@@ -15,6 +16,7 @@ const syncCursor = uPlot.sync('knx-time-axis');
 export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
+  const themeTick = useThemeTick();
 
   useLayoutEffect(() => {
     if (!containerRef.current) return;
@@ -33,18 +35,21 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
 
   const rowHeight = 40;
   const rowGap = 4;
-  const chartHeight = series.length * (rowHeight + rowGap) + 60; // Extra for axis
+  const chartHeight = series.length * (rowHeight + rowGap) + 60;
 
-  // Custom plugin to draw the timeline blocks
-  const timelinePlugin = () => {
-    return {
+  const options: uPlot.Options = useMemo(() => {
+    const style = getComputedStyle(document.documentElement);
+    const gridStroke = style.getPropertyValue('--border-subtle').trim();
+    const axisStroke = style.getPropertyValue('--text-dim').trim();
+    const accentPrimary = style.getPropertyValue('--accent-primary').trim();
+
+    const timelinePlugin = () => ({
       hooks: {
         draw: [(u: uPlot) => {
           const { ctx } = u;
           const { left, top, width, height } = u.bbox;
 
           ctx.save();
-          // Clip to chart area for the colored blocks
           ctx.beginPath();
           ctx.rect(left, top, width, height);
           ctx.clip();
@@ -58,7 +63,6 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
               if (val === null) continue;
 
               const xStart = u.valToPos(timestamps[i] / 1000, 'x', true);
-              // Find end of this segment (next data point or end of chart)
               let xEnd;
               if (i < timestamps.length - 1) {
                 xEnd = u.valToPos(timestamps[i + 1] / 1000, 'x', true);
@@ -69,10 +73,9 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
               if (xEnd <= xStart) continue;
 
               const isOn = val === 1;
-              ctx.fillStyle = isOn ? '#22c55e' : '#ef4444'; // Green / Red
+              ctx.fillStyle = isOn ? '#22c55e' : '#ef4444';
               ctx.fillRect(xStart, yTop, xEnd - xStart, rowHeight);
 
-              // Draw Label if wide enough
               if (xEnd - xStart > 40) {
                 ctx.fillStyle = 'white';
                 ctx.font = 'bold 11px sans-serif';
@@ -85,10 +88,9 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
 
           ctx.restore();
 
-          // Draw series names on the right (unclipped)
           series.forEach((s, sIdx) => {
             const yTop = top + sIdx * (rowHeight + rowGap) + rowGap;
-            ctx.fillStyle = '#6366f1';
+            ctx.fillStyle = accentPrimary;
             ctx.font = '600 12px sans-serif';
             ctx.textAlign = 'left';
             ctx.textBaseline = 'middle';
@@ -96,49 +98,50 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
           });
         }]
       }
-    };
-  };
+    });
 
-  const options: uPlot.Options = {
-    width, // Use full width
-    height: chartHeight,
-    padding: [0, 180, 0, 0], // Leave 180px on the right for labels
-    cursor: { sync: { key: syncCursor.key } },
-    plugins: [timelinePlugin()],
-    scales: {
-      x: { time: true },
-      y: { auto: false, range: [0, 1] }
-    },
-    axes: [
-      {
-        space: 50,
-        stroke: '#94a3b8',
-        grid: { stroke: 'rgba(255,255,255,0.05)' },
-        values: (_u, splits) => splits.map(v =>
-          new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
-        )
+    return {
+      width,
+      height: chartHeight,
+      padding: [0, 180, 0, 0],
+      cursor: { sync: { key: syncCursor.key } },
+      plugins: [timelinePlugin()],
+      scales: {
+        x: { time: true },
+        y: { auto: false, range: [0, 1] }
       },
-      {
-        show: true,
-        stroke: '#94a3b8',
-        grid: { stroke: 'rgba(255,255,255,0.05)' },
-        size: 1, // Minimal size just to show the line
-        values: () => [] // No labels needed since they are on the right
-      }
-    ],
-    series: [
-      {
-        value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
-      },
-      ...series.map((s) => ({
-        label: s.name,
-        show: false, // Don't draw actual lines
-      }))
-    ]
-  };
+      axes: [
+        {
+          space: 50,
+          stroke: axisStroke,
+          grid: { stroke: gridStroke },
+          values: (_u, splits) => splits.map(v =>
+            new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
+          )
+        },
+        {
+          show: true,
+          stroke: axisStroke,
+          grid: { stroke: gridStroke },
+          size: 1,
+          values: () => []
+        }
+      ],
+      series: [
+        {
+          value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+        },
+        ...series.map((s) => ({
+          label: s.name,
+          show: false,
+        }))
+      ]
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [width, bucket, themeTick]);
 
   return (
-    <div style={{ marginBottom: '2rem', background: 'rgba(0,0,0,0.2)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)', overflow: 'visible' }}>
+    <div style={{ marginBottom: '2rem', background: 'var(--bg-inset)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)', overflow: 'visible' }}>
       <h4 style={{ margin: '0 0 1rem', fontSize: '0.9rem', color: 'var(--text-main)' }}>
         Binary States Timeline
       </h4>

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -49,7 +49,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
         />
 
         {/* Chart Area */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'rgba(255,255,255,0.02)' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: 'var(--bg-subtle)' }}>
           <div style={{ padding: '1rem 1.5rem', display: 'flex', alignItems: 'center', justifyContent: 'space-between', borderBottom: '1px solid var(--border-color)' }}>
             <div>
               <h3 style={{ fontSize: '1rem', margin: 0 }}>Visualization</h3>

--- a/frontend/src/components/VisualizerSidebar.tsx
+++ b/frontend/src/components/VisualizerSidebar.tsx
@@ -53,7 +53,7 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({ telegrams,
   };
 
   return (
-    <div style={{ width: 260, borderRight: '1px solid var(--border-color)', display: 'flex', flexDirection: 'column', background: 'rgba(0,0,0,0.1)' }}>
+    <div style={{ width: 260, borderRight: '1px solid var(--border-color)', display: 'flex', flexDirection: 'column', background: 'var(--bg-inset)' }}>
       <div style={{ padding: '0.75rem 1rem', borderBottom: '1px solid var(--border-color)', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
         <span style={{ fontWeight: 600, fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <LineChart size={16} style={{ color: 'var(--accent-primary)' }} /> Targets
@@ -66,7 +66,7 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({ telegrams,
       <div style={{ padding: '0.75rem', borderBottom: '1px solid var(--border-color)', flexShrink: 0 }}>
         <div style={{
           display: 'flex', alignItems: 'center', gap: '0.5rem',
-          background: 'rgba(255,255,255,0.05)', border: '1px solid var(--border-color)',
+          background: 'var(--bg-tag)', border: '1px solid var(--border-color)',
           borderRadius: '7px', padding: '0.45rem 0.65rem'
         }}>
           <Search size={13} style={{ color: 'var(--text-dim)', flexShrink: 0 }} />

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,53 @@
+import { useEffect, useLayoutEffect, useState } from 'react';
+import { getCookie, setCookie } from '../utils/cookies';
+
+export type Theme = 'system' | 'dark' | 'light';
+
+const VALID_THEMES: Theme[] = ['system', 'dark', 'light'];
+
+function applyTheme(theme: Theme) {
+  if (theme === 'system') {
+    document.documentElement.removeAttribute('data-theme');
+  } else {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+}
+
+export function useTheme(): [Theme, (t: Theme) => void] {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const saved = getCookie('theme') as Theme | null;
+    return saved && VALID_THEMES.includes(saved) ? saved : 'system';
+  });
+
+  useLayoutEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = (t: Theme) => {
+    setThemeState(t);
+    setCookie('theme', t);
+  };
+
+  return [theme, setTheme];
+}
+
+/**
+ * Returns an incrementing counter that bumps whenever the active theme changes
+ * (either via explicit data-theme attribute or via prefers-color-scheme media query).
+ * Use as a useMemo dependency in chart components that have JS-side color values.
+ */
+export function useThemeTick(): number {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const bump = () => setTick(t => t + 1);
+    const observer = new MutationObserver(bump);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    const mq = window.matchMedia('(prefers-color-scheme: light)');
+    mq.addEventListener('change', bump);
+    return () => {
+      observer.disconnect();
+      mq.removeEventListener('change', bump);
+    };
+  }, []);
+  return tick;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,17 +1,28 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
+  /* === Dark theme defaults === */
   --bg-dark: #0a0a0c;
   --bg-panel: rgba(22, 22, 26, 0.7);
   --bg-card: rgba(30, 30, 35, 0.4);
+  --bg-subtle: rgba(255, 255, 255, 0.025);
+  --bg-tag: rgba(255, 255, 255, 0.05);
+  --bg-hover: rgba(255, 255, 255, 0.08);
+  --bg-inset: rgba(0, 0, 0, 0.2);
   --accent-primary: #6366f1;
   --accent-secondary: #a855f7;
   --text-main: #f8fafc;
   --text-dim: #94a3b8;
   --border-color: rgba(255, 255, 255, 0.1);
+  --border-subtle: rgba(255, 255, 255, 0.05);
+  --border-hover: rgba(255, 255, 255, 0.2);
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --glass-blur: blur(12px);
+  --scrollbar-thumb: rgba(255, 255, 255, 0.1);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.2);
+  --gradient-1: rgba(99, 102, 241, 0.15);
+  --gradient-2: rgba(168, 85, 247, 0.1);
   --error: #ef4444;
   --success: #22c55e;
   --warning: #f59e0b;
@@ -22,6 +33,74 @@
   --dpt-5: #a855f7;  /* Scaling/Percent */
   --dpt-9: #22c55e;  /* Temperature/Floats */
   --dpt-unknown: #64748b;
+}
+
+/* === System preference: light === */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    --bg-dark: #f0f2fa;
+    --bg-panel: rgba(255, 255, 255, 0.8);
+    --bg-card: rgba(240, 242, 250, 0.7);
+    --bg-subtle: rgba(0, 0, 0, 0.025);
+    --bg-tag: rgba(0, 0, 0, 0.06);
+    --bg-hover: rgba(0, 0, 0, 0.07);
+    --bg-inset: rgba(0, 0, 0, 0.04);
+    --accent-primary: #4f46e5;
+    --accent-secondary: #9333ea;
+    --text-main: #0f172a;
+    --text-dim: #64748b;
+    --border-color: rgba(0, 0, 0, 0.1);
+    --border-subtle: rgba(0, 0, 0, 0.07);
+    --border-hover: rgba(0, 0, 0, 0.2);
+    --scrollbar-thumb: rgba(0, 0, 0, 0.15);
+    --scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
+    --gradient-1: rgba(99, 102, 241, 0.07);
+    --gradient-2: rgba(168, 85, 247, 0.05);
+  }
+}
+
+/* === Explicit dark override === */
+[data-theme="dark"] {
+  --bg-dark: #0a0a0c;
+  --bg-panel: rgba(22, 22, 26, 0.7);
+  --bg-card: rgba(30, 30, 35, 0.4);
+  --bg-subtle: rgba(255, 255, 255, 0.025);
+  --bg-tag: rgba(255, 255, 255, 0.05);
+  --bg-hover: rgba(255, 255, 255, 0.08);
+  --bg-inset: rgba(0, 0, 0, 0.2);
+  --accent-primary: #6366f1;
+  --accent-secondary: #a855f7;
+  --text-main: #f8fafc;
+  --text-dim: #94a3b8;
+  --border-color: rgba(255, 255, 255, 0.1);
+  --border-subtle: rgba(255, 255, 255, 0.05);
+  --border-hover: rgba(255, 255, 255, 0.2);
+  --scrollbar-thumb: rgba(255, 255, 255, 0.1);
+  --scrollbar-thumb-hover: rgba(255, 255, 255, 0.2);
+  --gradient-1: rgba(99, 102, 241, 0.15);
+  --gradient-2: rgba(168, 85, 247, 0.1);
+}
+
+/* === Explicit light override === */
+[data-theme="light"] {
+  --bg-dark: #f0f2fa;
+  --bg-panel: rgba(255, 255, 255, 0.8);
+  --bg-card: rgba(240, 242, 250, 0.7);
+  --bg-subtle: rgba(0, 0, 0, 0.025);
+  --bg-tag: rgba(0, 0, 0, 0.06);
+  --bg-hover: rgba(0, 0, 0, 0.07);
+  --bg-inset: rgba(0, 0, 0, 0.04);
+  --accent-primary: #4f46e5;
+  --accent-secondary: #9333ea;
+  --text-main: #0f172a;
+  --text-dim: #64748b;
+  --border-color: rgba(0, 0, 0, 0.1);
+  --border-subtle: rgba(0, 0, 0, 0.07);
+  --border-hover: rgba(0, 0, 0, 0.2);
+  --scrollbar-thumb: rgba(0, 0, 0, 0.15);
+  --scrollbar-thumb-hover: rgba(0, 0, 0, 0.25);
+  --gradient-1: rgba(99, 102, 241, 0.07);
+  --gradient-2: rgba(168, 85, 247, 0.05);
 }
 
 * {
@@ -35,8 +114,8 @@ body {
   background-color: var(--bg-dark);
   color: var(--text-main);
   background-image:
-    radial-gradient(at 0% 0%, rgba(99, 102, 241, 0.15) 0px, transparent 50%),
-    radial-gradient(at 100% 100%, rgba(168, 85, 247, 0.1) 0px, transparent 50%);
+    radial-gradient(at 0% 0%, var(--gradient-1) 0px, transparent 50%),
+    radial-gradient(at 100% 100%, var(--gradient-2) 0px, transparent 50%);
   min-height: 100vh;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
@@ -65,7 +144,7 @@ code, pre {
 }
 
 .glass-card:hover {
-  border-color: rgba(255, 255, 255, 0.2);
+  border-color: var(--border-hover);
   transform: translateY(-2px);
 }
 
@@ -107,7 +186,7 @@ code, pre {
   overflow: hidden;
 }
 
-/* Custom uPlot styles for dark mode transparency */
+/* Custom uPlot styles */
 .uplot {
   background: transparent !important;
   border-radius: 8px;
@@ -132,10 +211,10 @@ code, pre {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--scrollbar-thumb);
   border-radius: 10px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--scrollbar-thumb-hover);
 }


### PR DESCRIPTION
## Summary

- Adds a **System / Light / Dark** theme selector in the Settings panel, persisted in a cookie
- **System** mode follows `prefers-color-scheme` (OS preference); **Light** and **Dark** override it via a `data-theme` attribute on `<html>`
- No flash on load — `useLayoutEffect` applies the theme before first paint
- Charts (MixedChart, TimelineChart) re-read axis/grid colors from `getComputedStyle` on theme switch via a `useThemeTick` hook, so they update without a page reload

## Changes

- **`hooks/useTheme.ts`** (new) — `useTheme()` hook for state + persistence; `useThemeTick()` hook for chart invalidation on theme or media-query change
- **`index.css`** — full light-mode variable set added; new semantic vars (`--bg-subtle`, `--bg-tag`, `--bg-hover`, `--bg-inset`, `--border-subtle`, `--border-hover`, scrollbar/gradient vars) replace hardcoded `rgba` values throughout
- **All components** — `rgba(255,255,255,*)` inline styles replaced with the new semantic CSS vars so they adapt automatically

Closes #100

## Test plan

- [ ] Open Settings → Appearance section shows System / Light / Dark buttons
- [ ] Switching to Light applies light theme immediately across all views
- [ ] Switching to Dark applies dark theme immediately
- [ ] Switching to System follows OS preference (test by changing OS theme)
- [ ] Theme persists across page reload
- [ ] Charts (Visualizer) update axis/grid colors on theme switch
- [ ] No visible flash on initial page load in any theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)