### PR TITLE
feat: add traffic statistics view

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -3,12 +3,12 @@ import subprocess
 from datetime import datetime
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
-from knx_telegram_store import TelegramQuery
 from sqlalchemy import text
 from xknx.telegram.address import IndividualAddress
 
 import knx_daemon  # import global config
 from database import engine, store
+from knx_telegram_store import TelegramQuery
 from parsers import (
     format_dpt_name,
     format_value_nicely,

--- a/backend/api.py
+++ b/backend/api.py
@@ -4,10 +4,11 @@ from datetime import datetime
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
 from knx_telegram_store import TelegramQuery
+from sqlalchemy import text
 from xknx.telegram.address import IndividualAddress
 
 import knx_daemon  # import global config
-from database import store
+from database import engine, store
 from parsers import (
     format_dpt_name,
     format_value_nicely,
@@ -208,6 +209,51 @@ async def get_filter_options():
         "ga_group_names": ga_group_names,
         "pa_line_names": pa_line_names,
     }
+
+
+@router.get("/api/statistics")
+async def get_statistics():
+    """Returns telegram counts grouped by group address and physical address."""
+    sql = text("""
+        SELECT s_lk.value AS source_address, d_lk.value AS destination, COUNT(*) AS cnt
+        FROM telegrams t
+        JOIN string_lookup s_lk ON t.source_id = s_lk.id
+        JOIN string_lookup d_lk ON t.destination_id = d_lk.id
+        GROUP BY s_lk.value, d_lk.value
+    """)
+
+    async with engine.connect() as conn:
+        result = await conn.execute(sql)
+        rows = result.fetchall()
+
+    ga_counts: dict[str, int] = {}
+    pa_counts: dict[str, int] = {}
+    for source, destination, cnt in rows:
+        ga_counts[destination] = ga_counts.get(destination, 0) + cnt
+        pa_counts[source] = pa_counts.get(source, 0) + cnt
+
+    ga_name_map: dict[str, str] = {}
+    pa_name_map: dict[str, str] = {}
+    if knx_daemon.global_knx_project:
+        for addr, data in knx_daemon.global_knx_project.get("group_addresses", {}).items():
+            ga_name_map[addr] = data.get("name", "")
+        for addr, data in knx_daemon.global_knx_project.get("devices", {}).items():
+            try:
+                ia_str = str(IndividualAddress(addr))
+            except Exception:
+                ia_str = str(addr)
+            pa_name_map[ia_str] = data.get("name", "")
+
+    by_ga = sorted(
+        [{"address": addr, "name": ga_name_map.get(addr, ""), "count": cnt} for addr, cnt in ga_counts.items()],
+        key=lambda x: x["count"], reverse=True,
+    )
+    by_pa = sorted(
+        [{"address": addr, "name": pa_name_map.get(addr, ""), "count": cnt} for addr, cnt in pa_counts.items()],
+        key=lambda x: x["count"], reverse=True,
+    )
+
+    return {"total": sum(ga_counts.values()), "by_ga": by_ga, "by_pa": by_pa}
 
 
 @router.get("/api/project")

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -4,13 +4,13 @@ import os
 from datetime import UTC, datetime
 from typing import Any
 
-from knx_telegram_store import StoredTelegram
 from xknx import XKNX
 from xknx.io import ConnectionConfig, ConnectionType, SecureConfig
 from xknx.telegram import Telegram as XknxTelegram
 from xknx.telegram.address import IndividualAddress
 
 from database import store
+from knx_telegram_store import StoredTelegram
 from parsers import format_dpt_name, get_simplified_type, parse_telegram_payload
 from ws_manager import manager
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -2,9 +2,9 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
-from knx_telegram_store import StoredTelegram, TelegramQueryResult
 
 import knx_daemon
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
 from main import app
 
 client = TestClient(app)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useWebSocket, type Telegram } from './hooks/useWebSocket';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
-import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, ChevronDown, AlertTriangle, Sun, Moon, Monitor } from 'lucide-react';
+import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, ChevronDown, AlertTriangle, Sun, Moon, Monitor } from 'lucide-react';
 import { getCookie, setCookie } from './utils/cookies';
 import { useTheme } from './hooks/useTheme';
 import { apiUrl, wsUrl } from './utils/basePath';
@@ -12,6 +12,7 @@ import { FilterPanel } from './components/FilterPanel';
 import { ProjectUploadWizard } from './components/ProjectUploadWizard';
 import { KeysUploadWizard } from './components/KeysUploadWizard';
 import { LastSeenOverlay } from './components/LastSeenOverlay';
+import { StatisticsOverlay } from './components/StatisticsOverlay';
 import {
   DEFAULT_FILTERS,
   hasActiveFilters,
@@ -123,6 +124,7 @@ function App() {
   const [isLastSeenOpen, setIsLastSeenOpen] = useState(false);
   const [lastSeenAddress, setLastSeenAddress] = useState('');
   const [lastSeenMode, setLastSeenMode] = useState<'ga' | 'pa'>('ga');
+  const [isStatisticsOpen, setIsStatisticsOpen] = useState(false);
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
   const [projectStatus, setProjectStatus] = useState<{
     upload_feature_active: boolean;
@@ -339,6 +341,7 @@ function App() {
     );
     setIsVisualizerOpen(true);
     setIsLastSeenOpen(false);
+    setIsStatisticsOpen(false);
   };
 
   const handleQuickLastSeen = useCallback((address: string, mode: 'ga' | 'pa') => {
@@ -346,6 +349,7 @@ function App() {
     setLastSeenMode(mode);
     setIsLastSeenOpen(true);
     setIsVisualizerOpen(false);
+    setIsStatisticsOpen(false);
   }, []);
 
   const sortedLiveTelegrams = useMemo(() => {
@@ -514,6 +518,14 @@ function App() {
                   style={{ color: isVisualizerOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
                 >
                   <LineChart size={18} />
+                </button>
+                <button
+                  className="icon-button"
+                  onClick={() => { setIsStatisticsOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); }}
+                  title="Traffic statistics"
+                  style={{ color: isStatisticsOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
+                >
+                  <BarChart2 size={18} />
                 </button>
                 <div style={{ width: 1, height: 18, background: 'var(--border-color)' }} />
 
@@ -760,6 +772,11 @@ function App() {
                     initialAddress={lastSeenAddress}
                     initialMode={lastSeenMode}
                     onClose={() => setIsLastSeenOpen(false)}
+                  />
+                ) : isStatisticsOpen ? (
+                  <StatisticsOverlay
+                    filterOptions={filterOptions}
+                    onClose={() => setIsStatisticsOpen(false)}
                   />
                 ) : (
                   <TelegramTable

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { Visualizer } from './components/Visualizer';
 import { FilterPanel } from './components/FilterPanel';
 import { ProjectUploadWizard } from './components/ProjectUploadWizard';
 import { KeysUploadWizard } from './components/KeysUploadWizard';
+import { LastSeenOverlay } from './components/LastSeenOverlay';
 import {
   DEFAULT_FILTERS,
   hasActiveFilters,
@@ -119,6 +120,9 @@ function App() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(true);
   const [isVisualizerOpen, setIsVisualizerOpen] = useState(false);
+  const [isLastSeenOpen, setIsLastSeenOpen] = useState(false);
+  const [lastSeenAddress, setLastSeenAddress] = useState('');
+  const [lastSeenMode, setLastSeenMode] = useState<'ga' | 'pa'>('ga');
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
   const [projectStatus, setProjectStatus] = useState<{
     upload_feature_active: boolean;
@@ -334,7 +338,15 @@ function App() {
       prev.includes(targetAddress) ? prev : [...prev, targetAddress]
     );
     setIsVisualizerOpen(true);
+    setIsLastSeenOpen(false);
   };
+
+  const handleQuickLastSeen = useCallback((address: string, mode: 'ga' | 'pa') => {
+    setLastSeenAddress(address);
+    setLastSeenMode(mode);
+    setIsLastSeenOpen(true);
+    setIsVisualizerOpen(false);
+  }, []);
 
   const sortedLiveTelegrams = useMemo(() => {
     const items = [...liveTelegrams];
@@ -727,6 +739,7 @@ function App() {
                     activeFilters={activeFilters}
                     onFiltersChange={handleFiltersChange}
                     counts={filterCounts}
+                    onQuickLastSeen={handleQuickLastSeen}
                     mode="live"
                   />
                 </div>
@@ -741,6 +754,13 @@ function App() {
                     onTargetsChange={setSelectedVisualizationTargets}
                     onClose={() => setIsVisualizerOpen(false)}
                   />
+                ) : isLastSeenOpen ? (
+                  <LastSeenOverlay
+                    filterOptions={filterOptions}
+                    initialAddress={lastSeenAddress}
+                    initialMode={lastSeenMode}
+                    onClose={() => setIsLastSeenOpen(false)}
+                  />
                 ) : (
                   <TelegramTable
                     telegrams={filteredLiveTelegrams}
@@ -750,6 +770,7 @@ function App() {
                     activeFilters={activeFilters}
                     onQuickFilter={handleQuickFilter}
                     onQuickVisualize={handleQuickVisualize}
+                    onQuickLastSeen={handleQuickLastSeen}
                   />
                 )}
               </div>

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -18,6 +18,7 @@ interface FilterPanelProps {
   /** Live-only: count of telegrams that would match each option in isolation */
   counts?: FilterCounts;
   mode: 'live' | 'history';
+  onQuickLastSeen?: (address: string, mode: 'ga' | 'pa') => void;
 }
 
 interface SectionProps {
@@ -145,6 +146,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   onFiltersChange,
   counts,
   mode,
+  onQuickLastSeen,
 }) => {
   const [search, setSearch] = useState('');
 
@@ -350,6 +352,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               counts={counts?.sources}
               mode={mode}
               searchQuery={q}
+              onLastSeen={onQuickLastSeen ? addr => onQuickLastSeen(addr, 'pa') : undefined}
             />
           </Section>
         )}
@@ -391,6 +394,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               counts={counts?.targets}
               mode={mode}
               searchQuery={q}
+              onLastSeen={onQuickLastSeen ? addr => onQuickLastSeen(addr, 'ga') : undefined}
             />
           </Section>
         )}

--- a/frontend/src/components/HistoryLoader.tsx
+++ b/frontend/src/components/HistoryLoader.tsx
@@ -151,7 +151,7 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
     } finally {
       setIsLoading(false);
     }
-  }, [limit, filters, onLoad, onClose]);
+  }, [filters, onLoad, onClose]);
 
   const handleLoadRelative = useCallback((seconds: number) => {
     const start = new Date(Date.now() - seconds * 1000).toISOString();
@@ -170,7 +170,7 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
     if (startTime) url += `&start_time=${encodeURIComponent(startTime + ':00Z')}`;
     if (endTime) url += `&end_time=${encodeURIComponent(endTime + ':00Z')}`;
     doFetch(url);
-  }, [limit, startTime, endTime, filters, doFetch]);
+  }, [limit, startTime, endTime, doFetch]);
 
   return (
     <div className="modal-overlay">

--- a/frontend/src/components/KnxAddressTree.tsx
+++ b/frontend/src/components/KnxAddressTree.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { ChevronDown, ChevronRight, Clock } from 'lucide-react';
 import type { FilterOption } from '../types/filters';
 
 interface KnxAddressTreeProps {
@@ -13,6 +13,7 @@ interface KnxAddressTreeProps {
   counts?: Record<string, number>;
   mode: 'live' | 'history';
   searchQuery: string;
+  onLastSeen?: (address: string) => void;
 }
 
 type CheckState = 'checked' | 'partial' | 'unchecked';
@@ -58,44 +59,66 @@ interface LeafRowProps {
   count?: number;
   mode: 'live' | 'history';
   onToggle: () => void;
+  onLastSeen?: () => void;
 }
 
-const LeafRow: React.FC<LeafRowProps> = ({ address, name, checked, count, mode, onToggle }) => (
-  <div
-    onClick={onToggle}
-    style={{
-      display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.3rem 0.25rem',
-      borderRadius: '5px', cursor: 'pointer', userSelect: 'none',
-      transition: 'background 0.15s',
-    }}
-    onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
-    onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-  >
-    <TriCheckbox state={checked ? 'checked' : 'unchecked'} onClick={onToggle} />
-    <div style={{ flex: 1, minWidth: 0 }}>
-      <div title={address} style={{
-        fontSize: '0.8125rem', color: 'var(--text-main)', fontFamily: "'JetBrains Mono', monospace",
-        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-      }}>{address}</div>
-      {name && (
-        <div title={name} style={{
-          fontSize: '0.65rem', color: 'var(--text-dim)',
+const LeafRow: React.FC<LeafRowProps> = ({ address, name, checked, count, mode, onToggle, onLastSeen }) => {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      onClick={onToggle}
+      style={{
+        display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.3rem 0.25rem',
+        borderRadius: '5px', cursor: 'pointer', userSelect: 'none',
+        transition: 'background 0.15s',
+      }}
+      onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'var(--bg-hover)'; setHovered(true); }}
+      onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; setHovered(false); }}
+    >
+      <TriCheckbox state={checked ? 'checked' : 'unchecked'} onClick={onToggle} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div title={address} style={{
+          fontSize: '0.8125rem', color: 'var(--text-main)', fontFamily: "'JetBrains Mono', monospace",
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-        }}>{name}</div>
+        }}>{address}</div>
+        {name && (
+          <div title={name} style={{
+            fontSize: '0.65rem', color: 'var(--text-dim)',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          }}>{name}</div>
+        )}
+      </div>
+      {onLastSeen && (
+        <button
+          onClick={e => { e.stopPropagation(); onLastSeen(); }}
+          title="Show last seen values"
+          style={{
+            background: 'transparent', border: 'none', cursor: 'pointer',
+            color: 'var(--text-dim)', padding: '0.15rem', borderRadius: '3px',
+            display: 'flex', alignItems: 'center',
+            opacity: hovered ? 0.8 : 0,
+            transition: 'opacity 0.15s',
+            flexShrink: 0,
+          }}
+          onMouseEnter={e => { e.stopPropagation(); (e.currentTarget as HTMLElement).style.opacity = '1'; (e.currentTarget as HTMLElement).style.color = 'var(--accent-primary)'; }}
+          onMouseLeave={e => { (e.currentTarget as HTMLElement).style.opacity = hovered ? '0.8' : '0'; (e.currentTarget as HTMLElement).style.color = 'var(--text-dim)'; }}
+        >
+          <Clock size={12} />
+        </button>
+      )}
+      {mode === 'live' && count !== undefined && (
+        <span style={{
+          fontSize: '0.65rem', fontWeight: 600, minWidth: '1.8rem', textAlign: 'center',
+          padding: '0.1rem 0.4rem', borderRadius: '999px',
+          background: count > 0 ? 'rgba(99,102,241,0.15)' : 'var(--bg-tag)',
+          color: count > 0 ? 'var(--accent-primary)' : 'var(--text-dim)',
+          border: count > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border-color)',
+          flexShrink: 0,
+        }}>{count}</span>
       )}
     </div>
-    {mode === 'live' && count !== undefined && (
-      <span style={{
-        fontSize: '0.65rem', fontWeight: 600, minWidth: '1.8rem', textAlign: 'center',
-        padding: '0.1rem 0.4rem', borderRadius: '999px',
-        background: count > 0 ? 'rgba(99,102,241,0.15)' : 'var(--bg-tag)',
-        color: count > 0 ? 'var(--accent-primary)' : 'var(--text-dim)',
-        border: count > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border-color)',
-        flexShrink: 0,
-      }}>{count}</span>
-    )}
-  </div>
-);
+  );
+};
 
 interface GroupNodeProps {
   label: string;
@@ -145,7 +168,7 @@ const GroupNode: React.FC<GroupNodeProps> = ({ label, sublabel, leafAddresses, s
 };
 
 export const KnxAddressTree: React.FC<KnxAddressTreeProps> = ({
-  entries, selected, groupNames, separator, onToggle, counts, mode, searchQuery,
+  entries, selected, groupNames, separator, onToggle, counts, mode, searchQuery, onLastSeen,
 }) => {
   const q = searchQuery.toLowerCase();
 
@@ -205,6 +228,7 @@ export const KnxAddressTree: React.FC<KnxAddressTreeProps> = ({
                 <LeafRow key={e.address} address={e.address!} name={e.name ?? ''} checked={selected.includes(e.address!)}
                   count={counts?.[e.address!]} mode={mode}
                   onToggle={() => onToggle(selected.includes(e.address!) ? selected.filter(a => a !== e.address) : [...selected, e.address!])}
+                  onLastSeen={onLastSeen ? () => onLastSeen(e.address!) : undefined}
                 />
               ))}
             </GroupNode>

--- a/frontend/src/components/LastSeenOverlay.tsx
+++ b/frontend/src/components/LastSeenOverlay.tsx
@@ -1,0 +1,359 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { X, Clock, RefreshCw, Search, ToggleLeft, ToggleRight } from 'lucide-react';
+import { format, formatDistanceToNowStrict } from 'date-fns';
+import type { Telegram } from '../hooks/useWebSocket';
+import type { FilterOptions } from '../types/filters';
+import { apiUrl } from '../utils/basePath';
+
+const LIMITS = [10, 20, 50, 100] as const;
+
+interface LastSeenOverlayProps {
+  filterOptions: FilterOptions;
+  initialAddress: string;
+  initialMode: 'ga' | 'pa';
+  onClose: () => void;
+}
+
+const getTypeColor = (type?: string | null) => {
+  switch (type) {
+    case 'Write': return 'var(--accent-primary)';
+    case 'Read': return '#fbbf24';
+    case 'Response': return '#10b981';
+    default: return 'var(--text-dim)';
+  }
+};
+
+const thStyle: React.CSSProperties = {
+  padding: '0.5rem 0.75rem',
+  textAlign: 'left',
+  fontWeight: 600,
+  fontSize: '0.7rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: 'var(--text-dim)',
+  whiteSpace: 'nowrap',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '0.45rem 0.75rem',
+  verticalAlign: 'middle',
+};
+
+export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
+  filterOptions,
+  initialAddress,
+  initialMode,
+  onClose,
+}) => {
+  const [mode, setMode] = useState<'ga' | 'pa'>(initialMode);
+  const [selectedAddress, setSelectedAddress] = useState(initialAddress);
+  const [limit, setLimit] = useState<number>(20);
+  const [search, setSearch] = useState('');
+  const [telegrams, setTelegrams] = useState<Telegram[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const addressList = mode === 'ga' ? filterOptions.targets : filterOptions.sources;
+
+  const fetchData = useCallback(async () => {
+    if (!selectedAddress) return;
+    setIsLoading(true);
+    try {
+      const param = mode === 'ga' ? 'target_address' : 'source_address';
+      const res = await fetch(
+        apiUrl(`/api/telegrams?${param}=${encodeURIComponent(selectedAddress)}&limit=${limit}`)
+      );
+      const json = await res.json();
+      setTelegrams(json.telegrams ?? []);
+      setLastFetchedAt(new Date());
+    } catch {
+      // network errors are non-fatal
+    } finally {
+      setIsLoading(false);
+    }
+  }, [selectedAddress, mode, limit]);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  useEffect(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    if (autoRefresh) {
+      intervalRef.current = setInterval(fetchData, 10_000);
+    }
+    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+  }, [autoRefresh, fetchData]);
+
+  const handleModeChange = (newMode: 'ga' | 'pa') => {
+    setMode(newMode);
+    const list = newMode === 'ga' ? filterOptions.targets : filterOptions.sources;
+    if (list.length > 0 && !list.find(a => a.address === selectedAddress)) {
+      setSelectedAddress(list[0].address ?? '');
+    }
+    setSearch('');
+  };
+
+  const filteredAddresses = addressList.filter(a => {
+    const q = search.toLowerCase();
+    return (a.address ?? '').toLowerCase().includes(q) || (a.name ?? '').toLowerCase().includes(q);
+  });
+
+  const selectedInfo = addressList.find(a => a.address === selectedAddress);
+
+  const getDelta = (idx: number): string | null => {
+    if (idx >= telegrams.length - 1) return null;
+    const diffMs =
+      new Date(telegrams[idx].timestamp).getTime() -
+      new Date(telegrams[idx + 1].timestamp).getTime();
+    if (diffMs < 60_000) return `+${(diffMs / 1000).toFixed(1)}s`;
+    if (diffMs < 3_600_000) return `+${(diffMs / 60_000).toFixed(1)}m`;
+    return `+${(diffMs / 3_600_000).toFixed(1)}h`;
+  };
+
+  return (
+    <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+
+      {/* ── Sidebar ─────────────────────────────────────────────────── */}
+      <div style={{
+        width: 250, flexShrink: 0,
+        borderRight: '1px solid var(--border-color)',
+        display: 'flex', flexDirection: 'column',
+        background: 'var(--bg-inset)',
+      }}>
+        {/* Mode tabs */}
+        <div style={{ display: 'flex', borderBottom: '1px solid var(--border-color)', flexShrink: 0 }}>
+          {(['ga', 'pa'] as const).map(m => (
+            <button key={m} onClick={() => handleModeChange(m)} style={{
+              flex: 1, padding: '0.55rem 0.25rem', border: 'none', cursor: 'pointer',
+              fontSize: '0.73rem', fontWeight: mode === m ? 600 : 400,
+              background: mode === m ? 'rgba(99,102,241,0.12)' : 'transparent',
+              color: mode === m ? 'var(--accent-primary)' : 'var(--text-dim)',
+              borderBottom: `2px solid ${mode === m ? 'var(--accent-primary)' : 'transparent'}`,
+              transition: 'all 0.15s',
+            }}>
+              {m === 'ga' ? 'Group Addresses' : 'Devices'}
+            </button>
+          ))}
+        </div>
+
+        {/* Search */}
+        <div style={{ padding: '0.55rem', borderBottom: '1px solid var(--border-color)', flexShrink: 0 }}>
+          <div style={{
+            display: 'flex', alignItems: 'center', gap: '0.4rem',
+            background: 'var(--bg-tag)', border: '1px solid var(--border-color)',
+            borderRadius: '6px', padding: '0.3rem 0.55rem',
+          }}>
+            <Search size={12} style={{ color: 'var(--text-dim)', flexShrink: 0 }} />
+            <input
+              type="text" placeholder="Filter…" value={search}
+              onChange={e => setSearch(e.target.value)}
+              style={{
+                flex: 1, background: 'transparent', border: 'none', outline: 'none',
+                fontSize: '0.8rem', color: 'var(--text-main)',
+              }}
+            />
+            {search && (
+              <button onClick={() => setSearch('')} style={{ background: 'transparent', border: 'none', cursor: 'pointer', padding: 0, color: 'var(--text-dim)' }}>
+                <X size={10} />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Address list */}
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {filteredAddresses.length === 0 ? (
+            <div style={{ padding: '1.5rem 1rem', fontSize: '0.8rem', color: 'var(--text-dim)', textAlign: 'center' }}>
+              {addressList.length === 0 ? 'No addresses seen yet.' : 'No matches.'}
+            </div>
+          ) : filteredAddresses.map(addr => {
+            const isSelected = addr.address === selectedAddress;
+            return (
+              <button
+                key={addr.address}
+                onClick={() => setSelectedAddress(addr.address ?? '')}
+                style={{
+                  width: '100%', textAlign: 'left', padding: '0.45rem 0.75rem',
+                  border: 'none', cursor: 'pointer',
+                  background: isSelected ? 'rgba(99,102,241,0.15)' : 'transparent',
+                  borderLeft: `2px solid ${isSelected ? 'var(--accent-primary)' : 'transparent'}`,
+                  transition: 'background 0.1s',
+                }}
+                onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'var(--bg-hover)'; }}
+                onMouseLeave={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+              >
+                <div style={{
+                  fontFamily: "'JetBrains Mono', monospace", fontSize: '0.75rem',
+                  color: isSelected ? 'var(--accent-primary)' : 'var(--text-main)',
+                }}>
+                  {addr.address}
+                </div>
+                {addr.name && (
+                  <div style={{
+                    fontSize: '0.65rem', color: 'var(--text-dim)', marginTop: '0.1rem',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  }}>
+                    {addr.name}
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* ── Main content ─────────────────────────────────────────────── */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+
+        {/* Header */}
+        <div style={{
+          padding: '0.65rem 1rem', borderBottom: '1px solid var(--border-color)',
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          flexShrink: 0, gap: '1rem',
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.65rem', minWidth: 0 }}>
+            <Clock size={15} style={{ color: 'var(--accent-primary)', flexShrink: 0 }} />
+            <div style={{ minWidth: 0 }}>
+              <div style={{ fontWeight: 600, fontSize: '0.875rem' }}>Last Seen Values</div>
+              {selectedInfo && (
+                <div style={{ fontSize: '0.73rem', color: 'var(--text-dim)', marginTop: '0.1rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  <span style={{ fontFamily: "'JetBrains Mono', monospace" }}>{selectedInfo.address}</span>
+                  {selectedInfo.name && <> — {selectedInfo.name}</>}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexShrink: 0 }}>
+            {/* Limit selector */}
+            <div style={{ display: 'flex', gap: '0.2rem' }}>
+              {LIMITS.map(l => (
+                <button key={l} onClick={() => setLimit(l)} style={{
+                  padding: '0.2rem 0.45rem', fontSize: '0.72rem', borderRadius: 4, cursor: 'pointer',
+                  border: `1px solid ${limit === l ? 'var(--accent-primary)' : 'var(--border-color)'}`,
+                  background: limit === l ? 'rgba(99,102,241,0.15)' : 'var(--bg-subtle)',
+                  color: limit === l ? 'var(--accent-primary)' : 'var(--text-dim)',
+                }}>
+                  {l}
+                </button>
+              ))}
+            </div>
+
+            {/* Auto-refresh toggle */}
+            <button
+              onClick={() => setAutoRefresh(r => !r)}
+              title={autoRefresh ? 'Disable auto-refresh (10s)' : 'Enable auto-refresh (10s)'}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '0.25rem',
+                padding: '0.2rem 0.45rem', borderRadius: 4, cursor: 'pointer', fontSize: '0.72rem',
+                border: `1px solid ${autoRefresh ? 'var(--accent-primary)' : 'var(--border-color)'}`,
+                background: autoRefresh ? 'rgba(99,102,241,0.15)' : 'var(--bg-subtle)',
+                color: autoRefresh ? 'var(--accent-primary)' : 'var(--text-dim)',
+              }}
+            >
+              {autoRefresh ? <ToggleRight size={13} /> : <ToggleLeft size={13} />}
+              Live
+            </button>
+
+            {/* Manual refresh */}
+            <button
+              onClick={fetchData} disabled={isLoading} title="Refresh now"
+              style={{ background: 'transparent', border: 'none', cursor: isLoading ? 'wait' : 'pointer', color: 'var(--text-dim)', padding: '0.2rem', display: 'flex' }}
+            >
+              <RefreshCw size={15} style={{ animation: isLoading ? 'spin 1s linear infinite' : 'none', color: isLoading ? 'var(--accent-primary)' : undefined }} />
+            </button>
+
+            {lastFetchedAt && (
+              <span style={{ fontSize: '0.7rem', color: 'var(--text-dim)' }}>
+                {format(lastFetchedAt, 'HH:mm:ss')}
+              </span>
+            )}
+
+            <button onClick={onClose} className="icon-button" title="Close" style={{ padding: '0.2rem' }}>
+              <X size={16} />
+            </button>
+          </div>
+        </div>
+
+        {/* Table */}
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          {!isLoading && telegrams.length === 0 ? (
+            <div style={{ padding: '4rem', textAlign: 'center', color: 'var(--text-dim)', fontSize: '0.875rem' }}>
+              No telegrams found for <span style={{ fontFamily: "'JetBrains Mono', monospace", color: 'var(--text-main)' }}>{selectedAddress}</span>.
+            </div>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8125rem' }}>
+              <thead>
+                <tr style={{
+                  borderBottom: '1px solid var(--border-color)',
+                  position: 'sticky', top: 0,
+                  background: 'var(--bg-panel)', zIndex: 1,
+                }}>
+                  <th style={thStyle}>Time</th>
+                  <th style={thStyle}>∆t</th>
+                  <th style={thStyle}>{mode === 'ga' ? 'Source' : 'Target'}</th>
+                  <th style={thStyle}>{mode === 'ga' ? 'Source Name' : 'Target Name'}</th>
+                  <th style={thStyle}>Type</th>
+                  <th style={thStyle}>Value</th>
+                  <th style={thStyle}>DPT</th>
+                </tr>
+              </thead>
+              <tbody>
+                {telegrams.map((t, idx) => (
+                  <tr
+                    key={`${t.timestamp}-${idx}`}
+                    style={{
+                      borderBottom: '1px solid var(--border-subtle)',
+                      background: idx % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
+                    }}
+                  >
+                    <td style={tdStyle}>
+                      <div style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.78rem', whiteSpace: 'nowrap' }}>
+                        {format(new Date(t.timestamp), 'HH:mm:ss.SSS')}
+                      </div>
+                      <div style={{ fontSize: '0.65rem', color: 'var(--text-dim)', marginTop: '0.1rem' }}>
+                        {formatDistanceToNowStrict(new Date(t.timestamp), { addSuffix: true })}
+                      </div>
+                    </td>
+                    <td style={{ ...tdStyle, fontFamily: "'JetBrains Mono', monospace", fontSize: '0.72rem', color: 'var(--text-dim)', whiteSpace: 'nowrap' }}>
+                      {getDelta(idx) ?? '—'}
+                    </td>
+                    <td style={tdStyle}>
+                      <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.78rem', color: 'var(--text-dim)' }}>
+                        {mode === 'ga' ? t.source_address : t.target_address}
+                      </span>
+                    </td>
+                    <td style={{ ...tdStyle, color: 'var(--text-dim)', fontSize: '0.78rem', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {(mode === 'ga' ? t.source_name : t.target_name) || '—'}
+                    </td>
+                    <td style={tdStyle}>
+                      <span style={{ color: getTypeColor(t.simplified_type), fontWeight: 600, fontSize: '0.72rem', textTransform: 'uppercase' }}>
+                        {t.simplified_type || t.telegram_type}
+                      </span>
+                    </td>
+                    <td style={tdStyle}>
+                      <span style={{ fontWeight: 700, color: 'var(--accent-primary)' }}>
+                        {t.value_formatted || (t.value_numeric !== null ? String(t.value_numeric) : '—')}
+                      </span>
+                      {t.unit && (
+                        <span style={{ marginLeft: '0.3rem', fontSize: '0.72rem', color: 'var(--text-dim)' }}>
+                          {t.unit}
+                        </span>
+                      )}
+                    </td>
+                    <td style={{ ...tdStyle, color: 'var(--text-dim)', fontSize: '0.75rem' }}>
+                      {t.dpt_name || (t.dpt_main != null ? `DPT ${t.dpt_main}` : '—')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};

--- a/frontend/src/components/LastSeenOverlay.tsx
+++ b/frontend/src/components/LastSeenOverlay.tsx
@@ -75,7 +75,10 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
     }
   }, [selectedAddress, mode, limit]);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchData();
+  }, [fetchData]);
 
   useEffect(() => {
     if (intervalRef.current) clearInterval(intervalRef.current);

--- a/frontend/src/components/StatisticsOverlay.tsx
+++ b/frontend/src/components/StatisticsOverlay.tsx
@@ -1,0 +1,378 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { X, RefreshCw, BarChart2, ChevronDown, ChevronRight } from 'lucide-react';
+import { apiUrl } from '../utils/basePath';
+import type { FilterOptions } from '../types/filters';
+
+interface StatEntry {
+  address: string;
+  name: string;
+  count: number;
+}
+
+interface StatisticsData {
+  total: number;
+  by_ga: StatEntry[];
+  by_pa: StatEntry[];
+}
+
+interface StatisticsOverlayProps {
+  filterOptions: FilterOptions;
+  onClose: () => void;
+}
+
+type TabId = 'ga' | 'pa' | 'hierarchy';
+type SortKey = 'address' | 'count';
+
+function formatCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+// ── Flat stat table ───────────────────────────────────────────────────────────
+
+interface StatTableProps {
+  entries: StatEntry[];
+  total: number;
+  sortKey: SortKey;
+  sortDir: 'asc' | 'desc';
+  onSort: (key: SortKey) => void;
+  searchQuery: string;
+}
+
+const StatTable: React.FC<StatTableProps> = ({ entries, total, sortKey, sortDir, onSort, searchQuery }) => {
+  const q = searchQuery.toLowerCase();
+  const visible = useMemo(
+    () => !q ? entries : entries.filter(e => e.address.toLowerCase().includes(q) || e.name.toLowerCase().includes(q)),
+    [entries, q],
+  );
+  const maxCount = entries[0]?.count ?? 1;
+
+  const SortArrow = ({ k }: { k: SortKey }) =>
+    sortKey === k ? <span style={{ color: 'var(--accent-primary)', marginLeft: 2 }}>{sortDir === 'desc' ? '↓' : '↑'}</span> : null;
+
+  return (
+    <div style={{ flex: 1, overflowY: 'auto' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8rem' }}>
+        <thead style={{ position: 'sticky', top: 0, background: 'var(--bg-dark)', zIndex: 1 }}>
+          <tr style={{ borderBottom: '1px solid var(--border-color)' }}>
+            <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', color: 'var(--text-dim)', fontWeight: 600, whiteSpace: 'nowrap', cursor: 'pointer', userSelect: 'none' }}
+              onClick={() => onSort('address')}>
+              Address <SortArrow k="address" />
+            </th>
+            <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', color: 'var(--text-dim)', fontWeight: 600 }}>
+              Name
+            </th>
+            <th style={{ padding: '0.5rem 0.75rem', textAlign: 'right', color: 'var(--text-dim)', fontWeight: 600, whiteSpace: 'nowrap', cursor: 'pointer', userSelect: 'none' }}
+              onClick={() => onSort('count')}>
+              Count <SortArrow k="count" />
+            </th>
+            <th style={{ padding: '0.5rem 0.75rem', color: 'var(--text-dim)', fontWeight: 600, width: '30%' }}>Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map(e => {
+            const pct = total > 0 ? (e.count / total) * 100 : 0;
+            const barPct = maxCount > 0 ? (e.count / maxCount) * 100 : 0;
+            return (
+              <tr key={e.address} style={{ borderBottom: '1px solid var(--border-subtle)' }}
+                onMouseEnter={ev => (ev.currentTarget.style.background = 'var(--bg-hover)')}
+                onMouseLeave={ev => (ev.currentTarget.style.background = 'transparent')}>
+                <td style={{ padding: '0.4rem 0.75rem', fontFamily: "'JetBrains Mono', monospace", color: 'var(--text-main)', whiteSpace: 'nowrap' }}>
+                  {e.address}
+                </td>
+                <td style={{ padding: '0.4rem 0.75rem', color: 'var(--text-dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', maxWidth: 200 }}>
+                  {e.name}
+                </td>
+                <td style={{ padding: '0.4rem 0.75rem', textAlign: 'right', fontFamily: "'JetBrains Mono', monospace", color: 'var(--text-main)', fontWeight: 600, whiteSpace: 'nowrap' }}>
+                  {formatCount(e.count)}
+                  <span style={{ color: 'var(--text-dim)', fontWeight: 400, fontSize: '0.7rem', marginLeft: '0.3rem' }}>
+                    {pct.toFixed(1)}%
+                  </span>
+                </td>
+                <td style={{ padding: '0.4rem 0.75rem' }}>
+                  <div style={{ height: 6, borderRadius: 3, background: 'var(--bg-tag)', overflow: 'hidden' }}>
+                    <div style={{ height: '100%', width: `${barPct}%`, borderRadius: 3, background: 'var(--accent-primary)', transition: 'width 0.3s' }} />
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {visible.length === 0 && (
+        <div style={{ textAlign: 'center', color: 'var(--text-dim)', padding: '3rem', fontSize: '0.85rem' }}>
+          No results
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ── GA Hierarchy tree ─────────────────────────────────────────────────────────
+
+interface HierarchyNode {
+  key: string;
+  label: string;
+  count: number;
+  children: HierarchyNode[];
+}
+
+function buildHierarchy(entries: StatEntry[], groupNames: Record<string, string>): HierarchyNode[] {
+  const l1Map = new Map<string, Map<string, StatEntry[]>>();
+  for (const e of entries) {
+    const parts = e.address.split('/');
+    const l1 = parts[0];
+    const l2 = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : l1;
+    if (!l1Map.has(l1)) l1Map.set(l1, new Map());
+    const inner = l1Map.get(l1)!;
+    if (!inner.has(l2)) inner.set(l2, []);
+    inner.get(l2)!.push(e);
+  }
+
+  const result: HierarchyNode[] = [];
+  for (const [l1Key, l2Map] of l1Map.entries()) {
+    const l1Name = groupNames[l1Key] || '';
+    const l1Label = l1Name ? `${l1Key} — ${l1Name}` : l1Key;
+    const l1Count = [...l2Map.values()].flat().reduce((s, e) => s + e.count, 0);
+
+    const children: HierarchyNode[] = [];
+    for (const [l2Key, leaves] of l2Map.entries()) {
+      const l2Name = groupNames[l2Key] || '';
+      const l2Label = l2Name ? `${l2Key} — ${l2Name}` : l2Key;
+      const l2Count = leaves.reduce((s, e) => s + e.count, 0);
+
+      const singleGroup = l2Map.size === 1 && l2Key === l1Key;
+      if (singleGroup) {
+        // Flat: leaves directly under l1
+        for (const leaf of leaves) {
+          children.push({ key: leaf.address, label: leaf.name ? `${leaf.address} — ${leaf.name}` : leaf.address, count: leaf.count, children: [] });
+        }
+      } else {
+        children.push({
+          key: l2Key,
+          label: l2Label,
+          count: l2Count,
+          children: leaves.map(leaf => ({
+            key: leaf.address,
+            label: leaf.name ? `${leaf.address} — ${leaf.name}` : leaf.address,
+            count: leaf.count,
+            children: [],
+          })),
+        });
+      }
+    }
+
+    result.push({ key: l1Key, label: l1Label, count: l1Count, children });
+  }
+
+  return result.sort((a, b) => b.count - a.count);
+}
+
+interface HierarchyRowProps {
+  node: HierarchyNode;
+  maxCount: number;
+  total: number;
+  depth: number;
+  searchQuery: string;
+}
+
+const HierarchyRow: React.FC<HierarchyRowProps> = ({ node, maxCount, total, depth, searchQuery }) => {
+  const [open, setOpen] = useState(depth < 1);
+  const hasChildren = node.children.length > 0;
+  const q = searchQuery.toLowerCase();
+  const matchesSelf = !q || node.key.toLowerCase().includes(q) || node.label.toLowerCase().includes(q);
+  const matchesAny = matchesSelf || node.children.some(c =>
+    c.key.toLowerCase().includes(q) || c.label.toLowerCase().includes(q)
+  );
+  if (!matchesAny) return null;
+
+  const pct = total > 0 ? (node.count / total) * 100 : 0;
+  const barPct = maxCount > 0 ? (node.count / maxCount) * 100 : 0;
+  const isLeaf = !hasChildren;
+
+  return (
+    <div>
+      <div
+        style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.3rem 0.75rem', paddingLeft: `${0.75 + depth * 1.25}rem`, cursor: hasChildren ? 'pointer' : 'default' }}
+        onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
+        onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+        onClick={() => hasChildren && setOpen(o => !o)}
+      >
+        <span style={{ width: 12, flexShrink: 0, color: 'var(--text-dim)' }}>
+          {hasChildren ? (open ? <ChevronDown size={12} /> : <ChevronRight size={12} />) : null}
+        </span>
+        <span style={{
+          flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          fontSize: isLeaf ? '0.8rem' : '0.825rem',
+          fontWeight: isLeaf ? 400 : 600,
+          color: isLeaf ? 'var(--text-dim)' : 'var(--text-main)',
+          fontFamily: "'JetBrains Mono', monospace",
+        }}>
+          {node.label}
+        </span>
+        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.75rem', color: 'var(--text-main)', fontWeight: 600, marginLeft: '0.5rem', flexShrink: 0 }}>
+          {formatCount(node.count)}
+        </span>
+        <span style={{ color: 'var(--text-dim)', fontSize: '0.7rem', width: '3rem', textAlign: 'right', flexShrink: 0 }}>
+          {pct.toFixed(1)}%
+        </span>
+        <div style={{ width: 60, height: 6, borderRadius: 3, background: 'var(--bg-tag)', overflow: 'hidden', flexShrink: 0, marginLeft: '0.5rem' }}>
+          <div style={{ height: '100%', width: `${barPct}%`, borderRadius: 3, background: 'var(--accent-primary)' }} />
+        </div>
+      </div>
+      {open && hasChildren && node.children.map(child => (
+        <HierarchyRow key={child.key} node={child} maxCount={maxCount} total={total} depth={depth + 1} searchQuery={searchQuery} />
+      ))}
+    </div>
+  );
+};
+
+// ── Main overlay ──────────────────────────────────────────────────────────────
+
+export const StatisticsOverlay: React.FC<StatisticsOverlayProps> = ({ filterOptions, onClose }) => {
+  const [tab, setTab] = useState<TabId>('ga');
+  const [data, setData] = useState<StatisticsData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('count');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const fetchStats = useCallback(() => {
+    setIsLoading(true);
+    fetch(apiUrl('/api/statistics'))
+      .then(r => r.json())
+      .then((d: StatisticsData) => {
+        setData(d);
+        setLastFetchedAt(new Date());
+      })
+      .catch(console.error)
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  useEffect(() => { fetchStats(); }, [fetchStats]);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) setSortDir(d => d === 'desc' ? 'asc' : 'desc');
+    else { setSortKey(key); setSortDir('desc'); }
+  };
+
+  const sortedGa = useMemo(() => {
+    if (!data) return [];
+    return [...data.by_ga].sort((a, b) => {
+      const v = sortKey === 'count' ? b.count - a.count : a.address.localeCompare(b.address);
+      return sortDir === 'desc' ? v : -v;
+    });
+  }, [data, sortKey, sortDir]);
+
+  const sortedPa = useMemo(() => {
+    if (!data) return [];
+    return [...data.by_pa].sort((a, b) => {
+      const v = sortKey === 'count' ? b.count - a.count : a.address.localeCompare(b.address);
+      return sortDir === 'desc' ? v : -v;
+    });
+  }, [data, sortKey, sortDir]);
+
+  const hierarchy = useMemo(() => {
+    if (!data) return [];
+    return buildHierarchy(data.by_ga, filterOptions.ga_group_names);
+  }, [data, filterOptions.ga_group_names]);
+
+  const hierarchyMaxCount = hierarchy[0]?.count ?? 1;
+
+  const tabs: { id: TabId; label: string }[] = [
+    { id: 'ga', label: 'Group Addresses' },
+    { id: 'pa', label: 'Physical Addresses' },
+    { id: 'hierarchy', label: 'GA Hierarchy' },
+  ];
+
+  const timeAgo = lastFetchedAt
+    ? `${Math.round((Date.now() - lastFetchedAt.getTime()) / 1000)}s ago`
+    : null;
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: '0.75rem',
+        padding: '0.75rem 1rem', borderBottom: '1px solid var(--border-color)',
+        flexShrink: 0, background: 'var(--bg-subtle)',
+      }}>
+        <BarChart2 size={16} style={{ color: 'var(--accent-primary)', flexShrink: 0 }} />
+        <span style={{ fontWeight: 700, fontSize: '0.9rem', color: 'var(--text-main)' }}>Traffic Statistics</span>
+        {data && (
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-dim)', background: 'var(--bg-tag)', padding: '0.15rem 0.5rem', borderRadius: '999px', border: '1px solid var(--border-color)' }}>
+            {formatCount(data.total)} total
+          </span>
+        )}
+        {timeAgo && (
+          <span style={{ fontSize: '0.7rem', color: 'var(--text-dim)', marginLeft: 'auto' }}>
+            Updated {timeAgo}
+          </span>
+        )}
+        <button
+          onClick={fetchStats}
+          disabled={isLoading}
+          title="Refresh"
+          style={{ background: 'transparent', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--text-dim)', padding: '0.2rem', display: 'flex', marginLeft: timeAgo ? undefined : 'auto' }}
+        >
+          <RefreshCw size={14} style={isLoading ? { animation: 'spin 1s linear infinite' } : undefined} />
+        </button>
+        <button onClick={onClose} style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--text-dim)', padding: '0.2rem', display: 'flex' }}>
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* Tab bar + search */}
+      <div style={{ display: 'flex', alignItems: 'center', borderBottom: '1px solid var(--border-color)', flexShrink: 0, gap: '0.25rem', padding: '0 0.5rem' }}>
+        {tabs.map(t => (
+          <button key={t.id} onClick={() => setTab(t.id)} style={{
+            background: 'transparent', border: 'none', cursor: 'pointer',
+            padding: '0.5rem 0.75rem',
+            fontSize: '0.8rem', fontWeight: tab === t.id ? 600 : 400,
+            color: tab === t.id ? 'var(--accent-primary)' : 'var(--text-dim)',
+            borderBottom: tab === t.id ? '2px solid var(--accent-primary)' : '2px solid transparent',
+            transition: 'all 0.15s', whiteSpace: 'nowrap',
+          }}>
+            {t.label}
+          </button>
+        ))}
+        <div style={{ flex: 1 }} />
+        <input
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          placeholder="Filter…"
+          className="glass-input"
+          style={{ padding: '0.3rem 0.6rem', fontSize: '0.78rem', borderRadius: 6, width: 160, margin: '0.25rem 0' }}
+        />
+      </div>
+
+      {/* Content */}
+      {isLoading && !data ? (
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-dim)' }}>
+          Loading…
+        </div>
+      ) : !data ? (
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-dim)' }}>
+          No data
+        </div>
+      ) : tab === 'ga' ? (
+        <StatTable entries={sortedGa} total={data.total} sortKey={sortKey} sortDir={sortDir} onSort={handleSort} searchQuery={searchQuery} />
+      ) : tab === 'pa' ? (
+        <StatTable entries={sortedPa} total={data.total} sortKey={sortKey} sortDir={sortDir} onSort={handleSort} searchQuery={searchQuery} />
+      ) : (
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0.25rem 0' }}>
+          {hierarchy.map(node => (
+            <HierarchyRow key={node.key} node={node} maxCount={hierarchyMaxCount} total={data.total} depth={0} searchQuery={searchQuery} />
+          ))}
+          {hierarchy.length === 0 && (
+            <div style={{ textAlign: 'center', color: 'var(--text-dim)', padding: '3rem', fontSize: '0.85rem' }}>No data</div>
+          )}
+        </div>
+      )}
+
+      <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};

--- a/frontend/src/components/StatisticsOverlay.tsx
+++ b/frontend/src/components/StatisticsOverlay.tsx
@@ -48,7 +48,7 @@ const StatTable: React.FC<StatTableProps> = ({ entries, total, sortKey, sortDir,
   );
   const maxCount = entries[0]?.count ?? 1;
 
-  const SortArrow = ({ k }: { k: SortKey }) =>
+  const renderSortArrow = (k: SortKey) =>
     sortKey === k ? <span style={{ color: 'var(--accent-primary)', marginLeft: 2 }}>{sortDir === 'desc' ? '↓' : '↑'}</span> : null;
 
   return (
@@ -58,14 +58,14 @@ const StatTable: React.FC<StatTableProps> = ({ entries, total, sortKey, sortDir,
           <tr style={{ borderBottom: '1px solid var(--border-color)' }}>
             <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', color: 'var(--text-dim)', fontWeight: 600, whiteSpace: 'nowrap', cursor: 'pointer', userSelect: 'none' }}
               onClick={() => onSort('address')}>
-              Address <SortArrow k="address" />
+              Address {renderSortArrow('address')}
             </th>
             <th style={{ padding: '0.5rem 0.75rem', textAlign: 'left', color: 'var(--text-dim)', fontWeight: 600 }}>
               Name
             </th>
             <th style={{ padding: '0.5rem 0.75rem', textAlign: 'right', color: 'var(--text-dim)', fontWeight: 600, whiteSpace: 'nowrap', cursor: 'pointer', userSelect: 'none' }}
               onClick={() => onSort('count')}>
-              Count <SortArrow k="count" />
+              Count {renderSortArrow('count')}
             </th>
             <th style={{ padding: '0.5rem 0.75rem', color: 'var(--text-dim)', fontWeight: 600, width: '30%' }}>Share</th>
           </tr>
@@ -238,6 +238,7 @@ export const StatisticsOverlay: React.FC<StatisticsOverlayProps> = ({ filterOpti
   const [sortKey, setSortKey] = useState<SortKey>('count');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
   const [searchQuery, setSearchQuery] = useState('');
+  const [timeAgo, setTimeAgo] = useState<string | null>(null);
 
   const fetchStats = useCallback(() => {
     setIsLoading(true);
@@ -251,7 +252,24 @@ export const StatisticsOverlay: React.FC<StatisticsOverlayProps> = ({ filterOpti
       .finally(() => setIsLoading(false));
   }, []);
 
-  useEffect(() => { fetchStats(); }, [fetchStats]);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchStats();
+  }, [fetchStats]);
+
+  useEffect(() => {
+    if (!lastFetchedAt) return;
+    const update = () => {
+      const diffSecs = Math.round((Date.now() - lastFetchedAt.getTime()) / 1000);
+      setTimeAgo(`${diffSecs}s ago`);
+    };
+    const timeout = setTimeout(update, 0);
+    const interval = setInterval(update, 1000);
+    return () => {
+      clearTimeout(timeout);
+      clearInterval(interval);
+    };
+  }, [lastFetchedAt]);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) setSortDir(d => d === 'desc' ? 'asc' : 'desc');
@@ -286,10 +304,6 @@ export const StatisticsOverlay: React.FC<StatisticsOverlayProps> = ({ filterOpti
     { id: 'pa', label: 'Physical Addresses' },
     { id: 'hierarchy', label: 'GA Hierarchy' },
   ];
-
-  const timeAgo = lastFetchedAt
-    ? `${Math.round((Date.now() - lastFetchedAt.getTime()) / 1000)}s ago`
-    : null;
 
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useEffect } from 'react';
 import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
-import { ChevronUp, ChevronDown, Filter, LineChart, X } from 'lucide-react';
+import { ChevronUp, ChevronDown, Filter, LineChart, X, Clock } from 'lucide-react';
 import type { ActiveFilters } from '../types/filters';
 
 export type SortKey = 'timestamp' | 'source_address' | 'target_address' | 'simplified_type' | 'dpt_name' | 'value_numeric';
@@ -20,6 +20,7 @@ interface TelegramTableProps {
   activeFilters: ActiveFilters;
   onQuickFilter: (key: 'sources' | 'targets' | 'types' | 'dpts', value: string | number) => void;
   onQuickVisualize: (targetAddress: string) => void;
+  onQuickLastSeen?: (address: string, mode: 'ga' | 'pa') => void;
 }
 
 const getTypeColor = (type?: string | null) => {
@@ -47,7 +48,7 @@ const getDPTLabel = (dpt_main: number | null) => {
 };
 
 export const TelegramTable: React.FC<TelegramTableProps> = ({
-  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize
+  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -238,6 +239,15 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                         <Filter className="filter-icon" size={12} />
                         <X className="cancel-icon" size={12} />
                       </button>
+                      {onQuickLastSeen && (
+                        <button
+                          className="quick-last-seen-btn"
+                          onClick={(e) => { e.stopPropagation(); onQuickLastSeen(t.source_address, 'pa'); }}
+                          title="Show last seen values for this device"
+                        >
+                          <Clock size={12} />
+                        </button>
+                      )}
                     </div>
                     {visibleColumns.sourceName && (
                       <div className="subtitle-name" title={t.source_name || undefined} style={{ fontSize: '0.7rem', color: 'var(--text-dim)', marginTop: '0.15rem', maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -260,6 +270,15 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                         <Filter className="filter-icon" size={12} />
                         <X className="cancel-icon" size={12} />
                       </button>
+                      {onQuickLastSeen && (
+                        <button
+                          className="quick-last-seen-btn"
+                          onClick={(e) => { e.stopPropagation(); onQuickLastSeen(t.target_address, 'ga'); }}
+                          title="Show last seen values for this GA"
+                        >
+                          <Clock size={12} />
+                        </button>
+                      )}
                     </div>
                     {visibleColumns.targetName && (
                       <div className="subtitle-name" title={t.target_name || undefined} style={{ fontSize: '0.7rem', color: 'var(--text-main)', fontWeight: 500, marginTop: '0.15rem', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -343,7 +362,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
 // Add styles for quick filter buttons
 const style = document.createElement('style');
 style.textContent = `
-  .quick-filter-btn, .quick-visualize-btn {
+  .quick-filter-btn, .quick-visualize-btn, .quick-last-seen-btn {
     background: transparent;
     border: none;
     cursor: pointer;
@@ -377,19 +396,24 @@ style.textContent = `
   }
 
   .log-row:hover .quick-filter-btn:not(.active),
-  .log-row:hover .quick-visualize-btn {
+  .log-row:hover .quick-visualize-btn,
+  .log-row:hover .quick-last-seen-btn {
     opacity: 0.6;
   }
 
-  .quick-filter-btn:hover, .quick-visualize-btn:hover {
+  .quick-filter-btn:hover, .quick-visualize-btn:hover, .quick-last-seen-btn:hover {
     opacity: 1 !important;
-    background: rgba(255, 255, 255, 0.1);
+    background: var(--bg-hover);
     color: var(--accent-primary);
     transform: scale(1.1);
   }
 
   .quick-visualize-btn:hover {
     color: #10b981;
+  }
+
+  .quick-last-seen-btn:hover {
+    color: var(--accent-primary);
   }
 `;
 document.head.appendChild(style);


### PR DESCRIPTION
Closes #90

## Summary
- New `GET /api/statistics` backend endpoint using a raw SQL `GROUP BY` query joining `telegrams` → `string_lookup` (twice) to resolve source/destination addresses, then aggregates counts by GA and PA in Python
- New `StatisticsOverlay` frontend component with three tabs:
  - **Group Addresses** — flat sortable table of all GAs by telegram count with proportional bar
  - **Physical Addresses** — same for source PAs
  - **GA Hierarchy** — collapsible 3-level tree (main group → sub-group → leaf GA) with rollup counts
- `BarChart2` toolbar button in the live view header; mutually exclusive with Visualizer and Last Seen overlays
- All styling uses CSS variables (theme-aware)

## Test plan
- [ ] Open Group Monitor, click the BarChart2 icon in the toolbar
- [ ] Verify three tabs render with correct counts for all GAs/PAs
- [ ] Verify clicking column headers sorts by address / count
- [ ] Verify the search/filter input filters all three tabs
- [ ] Verify GA Hierarchy tree expands/collapses and rollup counts match GA tab totals
- [ ] Verify opening Visualizer or Last Seen closes Statistics and vice versa
- [ ] Verify Refresh button re-fetches and updates the "Updated Xs ago" timestamp
- [ ] Verify light and dark themes both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)