### PR TITLE
chore: prepare 1.7.1 release

### DIFF
--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 1.7.1
+
+### Added
+
+- **Building Structure**: filter buttons to add all group addresses of a whole device or of a single channel to the target filter, in addition to the existing per-KO and source-PA filters (#119).
+- **Traffic Statistics**: the Group Addresses and Physical Addresses tabs are now drill-down trees — expand a GA to see which devices (PAs) sent to it, or expand a PA to see the group addresses it wrote to, each with its share of the traffic (#121).
+- Home Assistant add-on icon and logo so the add-on is recognisable in the store and supervisor (#123).
+
+### Changed
+
+- **Building Structure**: the expand/collapse state of the tree is now remembered when leaving and returning to the view (#118).
+- **Building Structure**: "Show last seen values" on a communication object now covers all of its connected group addresses instead of only the first one, tagging each row with the matching GA (#120).
+
+### Fixed
+
+- Telegram table: widening the Source and Target columns now reveals more of the device/GA name instead of truncating at a fixed width (#117).

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.7.0"
+version: "1.7.1"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Release prep for **1.7.1**, following #124 (which merged the actual fixes/features).

- Bumps the add-on version `1.7.0 → 1.7.1` in `ha-addon/config.yaml`
- Adds `ha-addon/CHANGELOG.md` (rendered by the HA Supervisor on the add-on page) summarising the 1.7.1 changes:
  - #117 column truncation fix
  - #118 / #119 / #120 building-structure improvements
  - #121 traffic-statistics drill-down
  - #123 add-on icon/logo

No code changes — those already landed via #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)