### PR TITLE
fix(addon): use valid MDI icon for sidebar panel

### DIFF
--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -11,7 +11,7 @@ arch:
 ingress: true
 ingress_port: 8000
 ingress_stream: true
-panel_icon: mdi:knx
+panel_icon: mdi:chart-timeline-variant
 panel_title: "Spectrum KNX"
 panel_admin: true
 options:


### PR DESCRIPTION
Since `mdi:knx` is not a standard Material Design Icon, the sidebar panel shows no icon. This PR updates the panel icon to `mdi:chart-timeline-variant` (which matches the Spectrum KNX logo and represents the packet timeline/analyzer view) to resolve this.