### PR TITLE
feat(backend): add SQLite storage backend option

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -45,15 +45,21 @@ KNX_GATEWAY_PORT=3671
 # KNX_SECURE_LATENCY_MS=1000
 
 # --- Database Configuration ---
-# These are used by the TimescaleDB container AND the backend
+# Choose the storage backend: POSTGRES (default) or SQLITE.
+# SQLITE requires no external database and stores data in a local file.
+# DB_BACKEND=POSTGRES
+
+# PostgreSQL settings (used when DB_BACKEND=POSTGRES)
 POSTGRES_USER=knxuser
 POSTGRES_PASSWORD=knxpassword
 POSTGRES_DB=knx_analyzer
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
 
-# Optional override: Provide a full SQLAlchemy connection string
+# Optional override: Provide a full SQLAlchemy connection string.
+# Set this to a sqlite+aiosqlite:/// URL to use SQLite instead of PostgreSQL.
 # DATABASE_URL=postgresql+asyncpg://knxuser:knxpassword@db:5432/knx_analyzer
+# DATABASE_URL=sqlite+aiosqlite:////data/spectrum_knx.db
 
 # --- Application Settings ---
 # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -5,7 +5,7 @@ Spectrum KNX is designed as a modular 12-factor application, making it agnostic 
 ## Prerequisites
 No matter the deployment, you will need:
 1. An ETS project file (`.knxproj`) parsed by the backend to translate KNX payloads.
-2. A running PostgreSQL database with the **TimescaleDB** extension installed.
+2. A database backend — either PostgreSQL with the **TimescaleDB** extension (default), or SQLite (no external database required).
 
 ---
 
@@ -21,7 +21,7 @@ docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
 ## 2. Home Assistant Add-on
 
-Spectrum KNX can be installed as a native **Home Assistant Add-on**. This is the easiest way to run it alongside an existing Home Assistant installation. The Add-on bundles everything (PostgreSQL + TimescaleDB + Backend + Frontend) into a single container managed by the HA Supervisor.
+Spectrum KNX can be installed as a native **Home Assistant Add-on**. This is the easiest way to run it alongside an existing Home Assistant installation. The Add-on bundles everything (Backend + Frontend, plus PostgreSQL + TimescaleDB when needed) into a single container managed by the HA Supervisor.
 
 ### 2.1 Installation
 
@@ -45,6 +45,7 @@ After installation, go to the **Configuration** tab of the Add-on. The following
 | `KNX_GATEWAY_IP` | IP address of your KNX IP Gateway/Router. Use `AUTO` to scan the network automatically. | `AUTO` |
 | `KNX_GATEWAY_PORT` | Port of your KNX IP Gateway. | `3671` |
 | `LOG_LEVEL` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). | `INFO` |
+| `DB_BACKEND` | Storage backend: `POSTGRES` (PostgreSQL + TimescaleDB) or `SQLITE` (local file, no external database needed). | `POSTGRES` |
 
 Example configuration (YAML view):
 ```yaml
@@ -83,7 +84,8 @@ All data is stored in the Add-on's persistent `/data` directory, which is manage
 
 | Data | Location | Persisted? |
 |---|---|---|
-| PostgreSQL / TimescaleDB | `/data/postgres/` | ✅ Survives restarts & updates |
+| PostgreSQL / TimescaleDB (when `DB_BACKEND=POSTGRES`) | `/data/postgres/` | ✅ Survives restarts & updates |
+| SQLite database (when `DB_BACKEND=SQLITE`) | `/data/spectrum_knx.db` | ✅ Survives restarts & updates |
 | Uploaded `.knxproj` file | `/data/project/` | ✅ Survives restarts & updates |
 | Uploaded project password | `/data/project/` | ✅ Survives restarts & updates |
 | Uploaded `.knxkeys` file | `/data/project/` | ✅ Survives restarts & updates |
@@ -92,6 +94,8 @@ All data is stored in the Add-on's persistent `/data` directory, which is manage
 > **Important:** Uninstalling the Add-on will delete all data. If you want to keep your telegram history, export it before uninstalling.
 
 ### 2.7 Database Access
+This section applies only when `DB_BACKEND=POSTGRES`.
+
 By default, the internal PostgreSQL database is restricted to `127.0.0.1` for security, as the Add-on runs on the host network. This ensures it is not exposed to your local network.
 
 To connect external tools (e.g., Grafana) to the database, you must access it from the same host or use a SSH tunnel to port `5432`.
@@ -124,12 +128,12 @@ You can configure the application via environment variables. These can be set in
 ### DB Connection
 | Variable | Description | Default |
 |---|---|---|
-| `DATABASE_URL` | (Optional) Full SQLAlchemy connection string (must use `postgresql+asyncpg://`) | N/A |
-| `POSTGRES_USER` | Database username | `knxuser` |
-| `POSTGRES_PASSWORD`| Database password | `knxpassword` |
-| `POSTGRES_DB` | Database name | `knx_analyzer` |
-| `POSTGRES_HOST` | Database host | `db` |
-| `POSTGRES_PORT` | Database port | `5432` |
+| `DATABASE_URL` | Full SQLAlchemy connection string. Use `postgresql+asyncpg://...` for PostgreSQL or `sqlite+aiosqlite:////path/to/file.db` for SQLite. When set, `POSTGRES_*` variables are ignored. | N/A |
+| `POSTGRES_USER` | PostgreSQL username (used when `DATABASE_URL` is not set) | `knxuser` |
+| `POSTGRES_PASSWORD`| PostgreSQL password | `knxpassword` |
+| `POSTGRES_DB` | PostgreSQL database name | `knx_analyzer` |
+| `POSTGRES_HOST` | PostgreSQL host | `db` |
+| `POSTGRES_PORT` | PostgreSQL port | `5432` |
 
 ### KNX Settings
 | Variable | Description | Default |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ This document provides instructions for setting up the development environment, 
 - **Framework:** [FastAPI](https://fastapi.tiangolo.com/)
 - **KNX Integration:** [xknx](https://xknx.io/) for bus communication and [xknxproject](https://github.com/XKNX/xknxproject) for ETS project parsing.
 - **ORM:** [SQLAlchemy](https://www.sqlalchemy.org/) (Async)
-- **Database Driver:** `asyncpg`
+- **Database Driver:** `asyncpg` (PostgreSQL) or `aiosqlite` (SQLite)
 
 ### Frontend
 - **Framework:** [React](https://react.dev/) + [Vite](https://vitejs.dev/)
@@ -20,7 +20,7 @@ This document provides instructions for setting up the development environment, 
 - **Styling:** Vanilla CSS (Modern CSS variables, Flexbox/Grid)
 
 ### Storage & Infrastructure
-- **Database:** [PostgreSQL 15](https://www.postgresql.org/) with [TimescaleDB](https://www.timescale.com/) extension.
+- **Database:** [PostgreSQL 15](https://www.postgresql.org/) with [TimescaleDB](https://www.timescale.com/) (default), or SQLite via `aiosqlite` for lightweight setups.
 - **Containerization:** [Docker](https://www.docker.com/) & [Docker Compose](https://docs.docker.com/compose/).
 
 ---
@@ -38,8 +38,8 @@ Copy the example environment file and adjust the values as needed:
 cp .env_example .env
 ```
 Key variables:
-- `DATABASE_URL`: (Optional) Full connection string for the PostgreSQL database (must start with `postgresql+asyncpg://`).
-- `POSTGRES_USER/PASSWORD/DB`: Individual credentials used if `DATABASE_URL` is omitted.
+- `DATABASE_URL`: (Optional) Full SQLAlchemy connection string. Use `postgresql+asyncpg://...` for PostgreSQL or `sqlite+aiosqlite:////path/to/file.db` for SQLite.
+- `POSTGRES_USER/PASSWORD/DB`: Individual PostgreSQL credentials used when `DATABASE_URL` is omitted and the PostgreSQL backend is active.
 - `KNX_PASSWORD`: Password for your ETS project export.
 - `KNX_PROJECT_PATH`: Path to the `.knxproj` file inside the container.
 - `KNX_GATEWAY_IP`: IP of your KNX interface (or `AUTO`). See `DEPLOYMENT.md` for advanced connection settings.
@@ -47,10 +47,16 @@ Key variables:
 - `VITE_BACKEND_URL`: (Frontend only) The URL of the backend API (default: `http://localhost:8000`).
 
 ### 3. Database Setup
-The easiest way to run the database is via Docker Compose. This will start TimescaleDB. The backend automatically creates the schema on first startup via the `knx-telegram-store` library.
+The backend supports two storage backends selected via `DATABASE_URL`:
 
+**PostgreSQL + TimescaleDB (default):** Start the database via Docker Compose. The backend automatically creates the schema on first startup.
 ```bash
 docker-compose up -d db
+```
+
+**SQLite (no external database required):** Set `DATABASE_URL` to a `sqlite+aiosqlite://` URL and skip the database container entirely.
+```bash
+export DATABASE_URL="sqlite+aiosqlite:///spectrum_knx.db"
 ```
 
 ### 4. Running the Backend

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![Spectrum KNX Dashboard](assets/dashboard.png)
 
-Spectrum KNX is a dedicated tool to record, store, search, and visualize KNX bus telegrams indefinitely. Built for speed and reliability, it merges a robust TimescaleDB backend with a premium, real-time React web interface.
+Spectrum KNX is a dedicated tool to record, store, search, and visualize KNX bus telegrams indefinitely. Built for speed and reliability, it supports both a TimescaleDB backend for long-term time-series storage and a lightweight SQLite backend for simple setups — paired with a premium, real-time React web interface.
 
 ## 📺 Demo in Action
 
@@ -49,7 +49,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for local setup, [DEPLOYMENT.md](DEPLOYMENT
 
 ## 🛠 Tech Stack
 - **Backend:** Python 3.14+, FastAPI, `xknx`, WebSocket Streaming
-- **Database:** PostgreSQL + TimescaleDB
+- **Database:** PostgreSQL + TimescaleDB, or SQLite (via `aiosqlite`)
 - **Frontend:** React, TypeScript, Vite, TanStack Table, uPlot
 
 ## 🤝 Contributing

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,6 +1,6 @@
 import os
 
-from knx_telegram_store.buffered import BufferedPostgresStore
+from knx_telegram_store.buffered import BufferedPostgresStore, BufferedSqliteStore
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 # Uses env var or defaults to the docker-compose settings
@@ -16,8 +16,14 @@ DATABASE_URL = os.getenv("DATABASE_URL", f"postgresql+asyncpg://{DB_USER}:{DB_PA
 
 engine = create_async_engine(DATABASE_URL, echo=False)
 
-# Global Telegram Store — BufferedPostgresStore combines buffering and persistence
-store = BufferedPostgresStore(DATABASE_URL, flush_interval=1.0)
+_SQLITE_PREFIX = "sqlite+aiosqlite:///"
+
+if DATABASE_URL.startswith(_SQLITE_PREFIX):
+    # Strip the URL scheme to get the file path (absolute paths keep their leading /)
+    _db_path = DATABASE_URL[len(_SQLITE_PREFIX):]
+    store = BufferedSqliteStore(_db_path, flush_interval=1.0)
+else:
+    store = BufferedPostgresStore(DATABASE_URL, flush_interval=1.0)
 
 AsyncSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
 

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -31,6 +31,7 @@ options:
   KNX_SECURE_BACKBONE_KEY: ""
   KNX_SECURE_LATENCY_MS: 0
   LOG_LEVEL: "INFO"
+  DB_BACKEND: "POSTGRES"
 schema:
   KNX_GATEWAY_IP: "str"
   KNX_GATEWAY_PORT: "port"
@@ -48,5 +49,6 @@ schema:
   KNX_SECURE_BACKBONE_KEY: "str?"
   KNX_SECURE_LATENCY_MS: "int?"
   LOG_LEVEL: "list(DEBUG|INFO|WARNING|ERROR|CRITICAL)"
+  DB_BACKEND: "list(POSTGRES|SQLITE)"
 ports_description:
-  "5432/tcp": "PostgreSQL TimescaleDB (Internal Only)"
+  "5432/tcp": "PostgreSQL TimescaleDB (Internal Only, unused when DB_BACKEND=SQLITE)"

--- a/ha-addon/rootfs/etc/services.d/postgres/run
+++ b/ha-addon/rootfs/etc/services.d/postgres/run
@@ -1,4 +1,12 @@
 #!/usr/bin/with-contenv bashio
+
+# Skip PostgreSQL entirely when using the SQLite backend
+DB_BACKEND=$(bashio::config 'DB_BACKEND' 'POSTGRES')
+if [ "$DB_BACKEND" = "SQLITE" ]; then
+    bashio::log.info "SQLite backend selected — PostgreSQL will not be started."
+    exec sleep infinity
+fi
+
 # ── Persistent data directory ─────────────────────────────────────────────────
 # Home Assistant persists /data across container restarts and updates.
 # We store PostgreSQL data and KNX project files there.

--- a/ha-addon/rootfs/etc/services.d/spectrum_knx/run
+++ b/ha-addon/rootfs/etc/services.d/spectrum_knx/run
@@ -1,14 +1,20 @@
 #!/usr/bin/with-contenv bashio
 
-# Wait for Postgres to be ready
-bashio::log.info "Waiting for PostgreSQL to start..."
-until s6-setuidgid postgres /usr/lib/postgresql/15/bin/pg_isready -h 127.0.0.1 -p 5432; do
-    sleep 1
-done
-bashio::log.info "PostgreSQL is ready!"
+# Read DB_BACKEND early — it controls whether we wait for PostgreSQL
+DB_BACKEND=$(bashio::config 'DB_BACKEND' 'POSTGRES')
 
-# DB Configuration
-export POSTGRES_HOST=127.0.0.1
+if [ "$DB_BACKEND" = "SQLITE" ]; then
+    bashio::log.info "SQLite backend selected — skipping PostgreSQL wait."
+    export DATABASE_URL="sqlite+aiosqlite:////data/spectrum_knx.db"
+else
+    # Wait for Postgres to be ready
+    bashio::log.info "Waiting for PostgreSQL to start..."
+    until s6-setuidgid postgres /usr/lib/postgresql/15/bin/pg_isready -h 127.0.0.1 -p 5432; do
+        sleep 1
+    done
+    bashio::log.info "PostgreSQL is ready!"
+    export POSTGRES_HOST=127.0.0.1
+fi
 
 # Read KNX options from Add-on config if provided
 for var in KNX_PROJECT_PATH KNX_PASSWORD KNX_GATEWAY_IP KNX_GATEWAY_PORT KNX_CONNECTION_TYPE KNX_LOCAL_IP KNX_INDIVIDUAL_ADDRESS KNX_ROUTE_BACK KNX_MULTICAST_GROUP KNX_MULTICAST_PORT KNX_KNXKEYS_FILE KNX_KNXKEYS_PASSWORD KNX_SECURE_USER_ID KNX_SECURE_USER_PASSWORD KNX_SECURE_DEVICE_PASSWORD KNX_SECURE_BACKBONE_KEY KNX_SECURE_LATENCY_MS LOG_LEVEL; do


### PR DESCRIPTION
## Summary

- Adds a `DB_BACKEND` option (`POSTGRES` | `SQLITE`) to the ha-addon config, defaulting to `POSTGRES` so all existing setups are unaffected
- When `SQLITE` is selected, the backend uses `BufferedSqliteStore` (already provided by `knx-telegram-store`) and stores data at `/data/spectrum_knx.db`; PostgreSQL is not started
- For docker-compose / standalone use, set `DATABASE_URL=sqlite+aiosqlite:////path/to/file.db` — no separate env var needed

## Changes

- **`backend/database.py`** — detects `sqlite+aiosqlite://` URL prefix and instantiates `BufferedSqliteStore` instead of `BufferedPostgresStore`
- **`ha-addon/config.yaml`** — adds `DB_BACKEND: list(POSTGRES|SQLITE)` option, default `POSTGRES`
- **`ha-addon/rootfs/.../postgres/run`** — skips PostgreSQL startup (`exec sleep infinity`) when `DB_BACKEND=SQLITE`
- **`ha-addon/rootfs/.../spectrum_knx/run`** — skips PG readiness wait and exports the SQLite `DATABASE_URL` when `DB_BACKEND=SQLITE`
- **`.env_example`** — documents `DB_BACKEND` and the SQLite `DATABASE_URL` form

## Notes

- No changes to the Dockerfile or PostgreSQL container setup — existing POSTGRES installs are fully unaffected
- The SQLite schema and migrations are handled by `knx-telegram-store`'s `SqliteStore.initialize()`; `aiosqlite` is already a dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)