### PR TITLE
feat: database info and purge maintenance screen

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: verify
+description: Build, launch, and drive SpectrumKNX locally (backend + frontend) to verify changes end-to-end.
+---
+
+# Verify SpectrumKNX changes
+
+## Backend (FastAPI, no KNX gateway needed)
+
+Runs fine without a KNX gateway (daemon logs connection errors but the API works).
+Use a throwaway sqlite DB to avoid needing Postgres:
+
+```bash
+cd backend
+DATABASE_URL="sqlite+aiosqlite:////abs/path/to/test.db" venv/bin/uvicorn main:app --port 8321
+```
+
+Seed telegrams through the storage library (NOT `seed_data.py` — that targets the
+legacy `models.py` schema, not the knx-telegram-store schema):
+
+```python
+from knx_telegram_store.backends.sqlite import SqliteStore  # backend/venv has it
+# store.store_many([StoredTelegram(...), ...]) after await store.initialize()
+```
+
+## Frontend (Vite dev server, proxies /api and /ws)
+
+```bash
+cd frontend
+VITE_BACKEND_URL=http://localhost:8321 npx vite --port 5199
+```
+
+## Driving the UI headlessly
+
+Playwright's bundled chromium is not installed and `--with-deps` needs sudo;
+system Chrome works: `npm i playwright` in a scratch dir, then
+`chromium.launch({ channel: 'chrome' })`. Toolbar overlays are reached via
+`button[title="..."]` (e.g. "Database maintenance", "Traffic statistics").
+
+## Gotchas
+
+- Timestamps from sqlite round-trip as naive UTC ISO strings; the frontend
+  renders them via `new Date(ts)`, i.e. shifted to local time. App-wide behavior.
+- `ruff check backend` has 3 pre-existing I001 import-order errors on main
+  (api.py, knx_daemon.py, tests/test_api.py) — not a regression signal.

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,8 +1,9 @@
 import os
 import subprocess
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel
 from sqlalchemy import text
 from xknx.telegram.address import IndividualAddress
 
@@ -299,6 +300,65 @@ async def get_statistics():
             pa_name_map[ia_str] = data.get("name", "")
 
     return _aggregate_statistics(rows, ga_name_map, pa_name_map)
+
+
+@router.get("/api/database/info")
+async def get_database_info():
+    """Returns database stats (size, count, covered time range) and maintenance capabilities."""
+    stats = await store.get_stats()
+    caps = store.capabilities
+    return {
+        "backend": stats.backend,
+        "telegram_count": stats.telegram_count,
+        "oldest_timestamp": stats.oldest_timestamp,
+        "newest_timestamp": stats.newest_timestamp,
+        "size_bytes": stats.size_bytes,
+        "retention_days": stats.retention_days,
+        "supports_size_stats": caps.supports_size_stats,
+        "supports_optimize": caps.supports_optimize,
+    }
+
+
+class PurgeRequest(BaseModel):
+    older_than: datetime | None = None
+    purge_all: bool = False
+    dry_run: bool = False
+
+
+@router.post("/api/database/purge")
+async def purge_database(request: PurgeRequest):
+    """Deletes telegrams older than a cutoff (or all of them).
+
+    With dry_run=true, only returns how many telegrams would be deleted so the
+    frontend can ask for confirmation first.
+    """
+    if request.purge_all:
+        count = (await store.get_stats()).telegram_count
+        if not request.dry_run:
+            await store.clear()
+        return {"deleted": count, "dry_run": request.dry_run}
+
+    if request.older_than is None:
+        raise HTTPException(status_code=400, detail="Either older_than or purge_all must be given")
+
+    cutoff = request.older_than
+    if cutoff.tzinfo is None:
+        cutoff = cutoff.replace(tzinfo=UTC)
+
+    deleted = await store.evict_older_than(cutoff, dry_run=request.dry_run)
+    return {"deleted": deleted, "dry_run": request.dry_run}
+
+
+@router.post("/api/database/optimize")
+async def optimize_database():
+    """Reclaims disk space freed by deletions (VACUUM). May take a while on large databases."""
+    if not store.capabilities.supports_optimize:
+        raise HTTPException(status_code=400, detail="Backend does not support optimization")
+
+    size_before = (await store.get_stats()).size_bytes
+    await store.optimize()
+    size_after = (await store.get_stats()).size_bytes
+    return {"size_bytes_before": size_before, "size_bytes_after": size_after}
 
 
 @router.get("/api/project")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.4.0
+knx-telegram-store==0.6.0
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -593,3 +593,97 @@ def test_upload_project_empty_password(monkeypatch, tmp_path):
     response = client.post("/api/project/upload", data={"password": ""}, files={"file": ("test.knxproj", b"dummy")})
     assert response.status_code == 200
     m.assert_any_call(os.path.join("/project", "knx_project_password"), "w", encoding="utf-8")
+
+
+def _make_stats(count=100, size=4096):
+    from knx_telegram_store import StoreStats
+
+    return StoreStats(
+        telegram_count=count,
+        oldest_timestamp=datetime(2026, 1, 1, tzinfo=UTC),
+        newest_timestamp=datetime(2026, 7, 1, tzinfo=UTC),
+        size_bytes=size,
+        backend="sqlite",
+        retention_days=30,
+    )
+
+
+@patch("database.store.get_stats", new_callable=AsyncMock)
+def test_database_info(mock_stats):
+    mock_stats.return_value = _make_stats()
+
+    response = client.get("/api/database/info")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["backend"] == "sqlite"
+    assert data["telegram_count"] == 100
+    assert data["size_bytes"] == 4096
+    assert data["oldest_timestamp"].startswith("2026-01-01")
+    assert data["newest_timestamp"].startswith("2026-07-01")
+    assert data["retention_days"] == 30
+    # Real store capabilities (SQL backend) support both maintenance features
+    assert data["supports_size_stats"] is True
+    assert data["supports_optimize"] is True
+
+
+@patch("database.store.evict_older_than", new_callable=AsyncMock)
+def test_database_purge_dry_run(mock_evict):
+    mock_evict.return_value = 42
+
+    response = client.post(
+        "/api/database/purge",
+        json={"older_than": "2026-06-01T00:00:00+00:00", "dry_run": True},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"deleted": 42, "dry_run": True}
+
+    args, kwargs = mock_evict.call_args
+    assert args[0] == datetime(2026, 6, 1, tzinfo=UTC)
+    assert kwargs["dry_run"] is True
+
+
+@patch("database.store.evict_older_than", new_callable=AsyncMock)
+def test_database_purge_naive_cutoff_treated_as_utc(mock_evict):
+    mock_evict.return_value = 7
+
+    response = client.post(
+        "/api/database/purge",
+        json={"older_than": "2026-06-01T00:00:00"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"deleted": 7, "dry_run": False}
+    assert mock_evict.call_args[0][0] == datetime(2026, 6, 1, tzinfo=UTC)
+
+
+def test_database_purge_requires_cutoff_or_all():
+    response = client.post("/api/database/purge", json={})
+    assert response.status_code == 400
+
+
+@patch("database.store.clear", new_callable=AsyncMock)
+@patch("database.store.get_stats", new_callable=AsyncMock)
+def test_database_purge_all(mock_stats, mock_clear):
+    mock_stats.return_value = _make_stats(count=555)
+
+    # Dry run: report count, don't clear
+    response = client.post("/api/database/purge", json={"purge_all": True, "dry_run": True})
+    assert response.status_code == 200
+    assert response.json() == {"deleted": 555, "dry_run": True}
+    mock_clear.assert_not_called()
+
+    # Real purge
+    response = client.post("/api/database/purge", json={"purge_all": True})
+    assert response.status_code == 200
+    assert response.json() == {"deleted": 555, "dry_run": False}
+    mock_clear.assert_awaited_once()
+
+
+@patch("database.store.optimize", new_callable=AsyncMock)
+@patch("database.store.get_stats", new_callable=AsyncMock)
+def test_database_optimize(mock_stats, mock_optimize):
+    mock_stats.side_effect = [_make_stats(size=8192), _make_stats(size=2048)]
+
+    response = client.post("/api/database/optimize")
+    assert response.status_code == 200
+    assert response.json() == {"size_bytes_before": 8192, "size_bytes_after": 2048}
+    mock_optimize.assert_awaited_once()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useWebSocket, type Telegram } from './hooks/useWebSocket';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigCookie, writeSortConfigCookie } from './utils/sortConfig';
-import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, ChevronDown, AlertTriangle, Sun, Moon, Monitor } from 'lucide-react';
+import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor } from 'lucide-react';
 import { getCookie, setCookie } from './utils/cookies';
 import { useTheme } from './hooks/useTheme';
 import { apiUrl, wsUrl } from './utils/basePath';
@@ -15,6 +15,7 @@ import { KeysUploadWizard } from './components/KeysUploadWizard';
 import { LastSeenOverlay } from './components/LastSeenOverlay';
 import { StatisticsOverlay } from './components/StatisticsOverlay';
 import { BuildingOverlay } from './components/BuildingOverlay';
+import { DatabaseOverlay } from './components/DatabaseOverlay';
 import {
   DEFAULT_FILTERS,
   hasActiveFilters,
@@ -128,6 +129,7 @@ function App() {
   const [lastSeenMode, setLastSeenMode] = useState<'ga' | 'pa'>('ga');
   const [isStatisticsOpen, setIsStatisticsOpen] = useState(false);
   const [isBuildingOpen, setIsBuildingOpen] = useState(false);
+  const [isDatabaseOpen, setIsDatabaseOpen] = useState(false);
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
   const [projectStatus, setProjectStatus] = useState<{
     upload_feature_active: boolean;
@@ -350,6 +352,7 @@ function App() {
     setIsLastSeenOpen(false);
     setIsStatisticsOpen(false);
     setIsBuildingOpen(false);
+    setIsDatabaseOpen(false);
   };
 
   const handleQuickLastSeen = useCallback((address: string | string[], mode: 'ga' | 'pa') => {
@@ -359,6 +362,7 @@ function App() {
     setIsVisualizerOpen(false);
     setIsStatisticsOpen(false);
     setIsBuildingOpen(false);
+    setIsDatabaseOpen(false);
   }, []);
 
   // Add all of a KO's connected group addresses to the target filter (union).
@@ -531,7 +535,7 @@ function App() {
 
                 <button
                   className="icon-button"
-                  onClick={() => { setIsVisualizerOpen(v => !v); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsBuildingOpen(false); }}
+                  onClick={() => { setIsVisualizerOpen(v => !v); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsBuildingOpen(false); setIsDatabaseOpen(false); }}
                   title="Visualize data"
                   style={{ color: isVisualizerOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
                 >
@@ -539,7 +543,7 @@ function App() {
                 </button>
                 <button
                   className="icon-button"
-                  onClick={() => { setIsStatisticsOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsBuildingOpen(false); }}
+                  onClick={() => { setIsStatisticsOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsBuildingOpen(false); setIsDatabaseOpen(false); }}
                   title="Traffic statistics"
                   style={{ color: isStatisticsOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
                 >
@@ -547,11 +551,19 @@ function App() {
                 </button>
                 <button
                   className="icon-button"
-                  onClick={() => { setIsBuildingOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsStatisticsOpen(false); }}
+                  onClick={() => { setIsBuildingOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsDatabaseOpen(false); }}
                   title="Building structure"
                   style={{ color: isBuildingOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
                 >
                   <Building2 size={18} />
+                </button>
+                <button
+                  className="icon-button"
+                  onClick={() => { setIsDatabaseOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsBuildingOpen(false); }}
+                  title="Database maintenance"
+                  style={{ color: isDatabaseOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
+                >
+                  <Database size={18} />
                 </button>
                 <div style={{ width: 1, height: 18, background: 'var(--border-color)' }} />
 
@@ -811,6 +823,8 @@ function App() {
                     onFilterGAs={handleFilterGAs}
                     onLastSeen={handleQuickLastSeen}
                   />
+                ) : isDatabaseOpen ? (
+                  <DatabaseOverlay onClose={() => setIsDatabaseOpen(false)} />
                 ) : (
                   <TelegramTable
                     telegrams={filteredLiveTelegrams}

--- a/frontend/src/components/DatabaseOverlay.tsx
+++ b/frontend/src/components/DatabaseOverlay.tsx
@@ -1,0 +1,314 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { X, RefreshCw, Database, Trash2, HardDrive, AlertTriangle } from 'lucide-react';
+import { apiUrl } from '../utils/basePath';
+
+interface DatabaseInfo {
+  backend: string;
+  telegram_count: number;
+  oldest_timestamp: string | null;
+  newest_timestamp: string | null;
+  size_bytes: number | null;
+  retention_days: number | null;
+  supports_size_stats: boolean;
+  supports_optimize: boolean;
+}
+
+interface PurgePreview {
+  count: number;
+  cutoff: string | null; // null = purge all
+}
+
+interface DatabaseOverlayProps {
+  onClose: () => void;
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return 'n/a';
+  if (bytes >= 1_073_741_824) return `${(bytes / 1_073_741_824).toFixed(2)} GB`;
+  if (bytes >= 1_048_576) return `${(bytes / 1_048_576).toFixed(1)} MB`;
+  if (bytes >= 1_024) return `${(bytes / 1_024).toFixed(1)} kB`;
+  return `${bytes} B`;
+}
+
+function formatTimestamp(ts: string | null): string {
+  if (!ts) return '—';
+  return new Date(ts).toLocaleString();
+}
+
+const PRESETS = [
+  { label: '30 days', days: 30 },
+  { label: '90 days', days: 90 },
+  { label: '1 year', days: 365 },
+];
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: '0.75rem', color: 'var(--text-dim)', textTransform: 'uppercase',
+  marginBottom: '0.75rem', letterSpacing: '0.05em',
+};
+
+const InfoTile: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div style={{ background: 'var(--bg-subtle)', border: '1px solid var(--border-color)', borderRadius: 8, padding: '0.75rem 1rem' }}>
+    <div style={{ fontSize: '0.7rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.3rem' }}>
+      {label}
+    </div>
+    <div style={{ fontSize: '0.95rem', color: 'var(--text-main)', fontWeight: 600, fontFamily: "'JetBrains Mono', monospace" }}>
+      {value}
+    </div>
+  </div>
+);
+
+export const DatabaseOverlay: React.FC<DatabaseOverlayProps> = ({ onClose }) => {
+  const [info, setInfo] = useState<DatabaseInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [cutoffDate, setCutoffDate] = useState('');
+  const [preview, setPreview] = useState<PurgePreview | null>(null);
+  const [isPurging, setIsPurging] = useState(false);
+  const [isOptimizing, setIsOptimizing] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchInfo = useCallback(() => {
+    setIsLoading(true);
+    fetch(apiUrl('/api/database/info'))
+      .then(r => r.json())
+      .then((d: DatabaseInfo) => setInfo(d))
+      .catch(() => setError('Failed to load database info'))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchInfo();
+  }, [fetchInfo]);
+
+  const purgeBody = (cutoff: string | null, dryRun: boolean) =>
+    cutoff === null
+      ? { purge_all: true, dry_run: dryRun }
+      : { older_than: cutoff, dry_run: dryRun };
+
+  const requestPreview = useCallback((cutoff: string | null) => {
+    setMessage(null);
+    setError(null);
+    setIsPurging(true);
+    fetch(apiUrl('/api/database/purge'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(purgeBody(cutoff, true)),
+    })
+      .then(r => { if (!r.ok) throw new Error(); return r.json(); })
+      .then(d => setPreview({ count: d.deleted, cutoff }))
+      .catch(() => setError('Failed to compute purge preview'))
+      .finally(() => setIsPurging(false));
+  }, []);
+
+  const confirmPurge = useCallback(() => {
+    if (!preview) return;
+    setIsPurging(true);
+    setError(null);
+    fetch(apiUrl('/api/database/purge'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(purgeBody(preview.cutoff, false)),
+    })
+      .then(r => { if (!r.ok) throw new Error(); return r.json(); })
+      .then(d => {
+        setMessage(
+          `Deleted ${d.deleted.toLocaleString()} telegrams.` +
+          (info?.supports_optimize ? ' Run "Reclaim space" below to shrink the database.' : ''),
+        );
+        setPreview(null);
+        fetchInfo();
+      })
+      .catch(() => setError('Purge failed'))
+      .finally(() => setIsPurging(false));
+  }, [preview, info, fetchInfo]);
+
+  const runOptimize = useCallback(() => {
+    setIsOptimizing(true);
+    setMessage(null);
+    setError(null);
+    fetch(apiUrl('/api/database/optimize'), { method: 'POST' })
+      .then(r => { if (!r.ok) throw new Error(); return r.json(); })
+      .then(d => {
+        const freed = (d.size_bytes_before ?? 0) - (d.size_bytes_after ?? 0);
+        setMessage(freed > 0 ? `Reclaimed ${formatBytes(freed)} of disk space.` : 'Database is already compact.');
+        fetchInfo();
+      })
+      .catch(() => setError('Optimization failed'))
+      .finally(() => setIsOptimizing(false));
+  }, [fetchInfo]);
+
+  const presetCutoff = (days: number): string => {
+    const d = new Date();
+    d.setDate(d.getDate() - days);
+    return d.toISOString();
+  };
+
+  const busy = isPurging || isOptimizing;
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: '0.75rem',
+        padding: '0.75rem 1rem', borderBottom: '1px solid var(--border-color)',
+        flexShrink: 0, background: 'var(--bg-subtle)',
+      }}>
+        <Database size={16} style={{ color: 'var(--accent-primary)', flexShrink: 0 }} />
+        <span style={{ fontWeight: 700, fontSize: '0.9rem', color: 'var(--text-main)' }}>Database Maintenance</span>
+        {info && (
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-dim)', background: 'var(--bg-tag)', padding: '0.15rem 0.5rem', borderRadius: '999px', border: '1px solid var(--border-color)' }}>
+            {info.backend}
+          </span>
+        )}
+        <button
+          onClick={fetchInfo}
+          disabled={isLoading}
+          title="Refresh"
+          style={{ background: 'transparent', border: 'none', cursor: isLoading ? 'not-allowed' : 'pointer', color: 'var(--text-dim)', padding: '0.2rem', display: 'flex', marginLeft: 'auto' }}
+        >
+          <RefreshCw size={14} style={isLoading ? { animation: 'spin 1s linear infinite' } : undefined} />
+        </button>
+        <button onClick={onClose} style={{ background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--text-dim)', padding: '0.2rem', display: 'flex' }}>
+          <X size={16} />
+        </button>
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '1.5rem' }}>
+        <div style={{ maxWidth: 720, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+          {!info && isLoading && (
+            <div style={{ textAlign: 'center', color: 'var(--text-dim)', padding: '3rem' }}>Loading…</div>
+          )}
+
+          {info && (
+            <>
+              {/* Info tiles */}
+              <div>
+                <h3 style={sectionTitleStyle}>Storage</h3>
+                <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '0.75rem' }}>
+                  <InfoTile label="Telegrams" value={info.telegram_count.toLocaleString()} />
+                  <InfoTile label="Size" value={info.supports_size_stats ? formatBytes(info.size_bytes) : 'n/a'} />
+                  <InfoTile label="Oldest telegram" value={formatTimestamp(info.oldest_timestamp)} />
+                  <InfoTile label="Newest telegram" value={formatTimestamp(info.newest_timestamp)} />
+                  <InfoTile label="Retention" value={info.retention_days ? `${info.retention_days} days` : 'unlimited'} />
+                </div>
+              </div>
+
+              {/* Purge */}
+              <div>
+                <h3 style={sectionTitleStyle}>Purge old telegrams</h3>
+                <div style={{ background: 'var(--bg-subtle)', border: '1px solid var(--border-color)', borderRadius: 8, padding: '1rem' }}>
+                  <div style={{ fontSize: '0.8rem', color: 'var(--text-dim)', marginBottom: '0.75rem' }}>
+                    Delete telegrams recorded before a date. You will see how many telegrams are affected before anything is deleted.
+                  </div>
+                  <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+                    {PRESETS.map(p => (
+                      <button
+                        key={p.days}
+                        className="glass-button"
+                        disabled={busy}
+                        onClick={() => requestPreview(presetCutoff(p.days))}
+                        style={{ padding: '0.4rem 0.8rem', fontSize: '0.8rem', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--bg-tag)', color: 'var(--text-main)', cursor: busy ? 'not-allowed' : 'pointer' }}
+                      >
+                        Older than {p.label}
+                      </button>
+                    ))}
+                    <span style={{ color: 'var(--text-dim)', fontSize: '0.8rem' }}>or before</span>
+                    <input
+                      type="date"
+                      value={cutoffDate}
+                      onChange={e => setCutoffDate(e.target.value)}
+                      className="glass-input"
+                      style={{ padding: '0.35rem 0.6rem', fontSize: '0.8rem', borderRadius: 6 }}
+                    />
+                    <button
+                      className="glass-button"
+                      disabled={busy || !cutoffDate}
+                      onClick={() => requestPreview(new Date(cutoffDate).toISOString())}
+                      style={{ padding: '0.4rem 0.8rem', fontSize: '0.8rem', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--bg-tag)', color: 'var(--text-main)', cursor: busy || !cutoffDate ? 'not-allowed' : 'pointer' }}
+                    >
+                      Preview
+                    </button>
+                    <div style={{ flex: 1 }} />
+                    <button
+                      disabled={busy}
+                      onClick={() => requestPreview(null)}
+                      title="Delete all stored telegrams"
+                      style={{ padding: '0.4rem 0.8rem', fontSize: '0.8rem', borderRadius: 6, border: '1px solid var(--error)', background: 'transparent', color: 'var(--error)', cursor: busy ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', gap: '0.35rem' }}
+                    >
+                      <Trash2 size={13} /> Delete all
+                    </button>
+                  </div>
+
+                  {/* Confirmation */}
+                  {preview && (
+                    <div style={{ marginTop: '1rem', padding: '0.75rem 1rem', border: '1px solid var(--error)', borderRadius: 8, background: 'rgba(239, 68, 68, 0.08)', display: 'flex', alignItems: 'center', gap: '0.75rem', flexWrap: 'wrap' }}>
+                      <AlertTriangle size={16} style={{ color: 'var(--error)', flexShrink: 0 }} />
+                      <span style={{ fontSize: '0.85rem', color: 'var(--text-main)', flex: 1 }}>
+                        {preview.count === 0
+                          ? 'No telegrams match this cutoff.'
+                          : preview.cutoff === null
+                            ? <>This will permanently delete <b>all {preview.count.toLocaleString()} telegrams</b>.</>
+                            : <>This will permanently delete <b>{preview.count.toLocaleString()} telegrams</b> recorded before {formatTimestamp(preview.cutoff)}.</>}
+                      </span>
+                      <button
+                        onClick={() => setPreview(null)}
+                        style={{ padding: '0.35rem 0.75rem', fontSize: '0.8rem', borderRadius: 6, border: '1px solid var(--border-color)', background: 'transparent', color: 'var(--text-dim)', cursor: 'pointer' }}
+                      >
+                        Cancel
+                      </button>
+                      {preview.count > 0 && (
+                        <button
+                          disabled={isPurging}
+                          onClick={confirmPurge}
+                          style={{ padding: '0.35rem 0.75rem', fontSize: '0.8rem', fontWeight: 600, borderRadius: 6, border: 'none', background: 'var(--error)', color: 'white', cursor: isPurging ? 'not-allowed' : 'pointer' }}
+                        >
+                          {isPurging ? 'Deleting…' : `Delete ${preview.count.toLocaleString()} telegrams`}
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Optimize */}
+              {info.supports_optimize && (
+                <div>
+                  <h3 style={sectionTitleStyle}>Reclaim space</h3>
+                  <div style={{ background: 'var(--bg-subtle)', border: '1px solid var(--border-color)', borderRadius: 8, padding: '1rem', display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap' }}>
+                    <div style={{ fontSize: '0.8rem', color: 'var(--text-dim)', flex: 1, minWidth: 260 }}>
+                      Deleting telegrams does not shrink the database on disk by itself. Reclaiming space compacts the
+                      database (VACUUM); this can take a while and briefly blocks writes on large databases.
+                    </div>
+                    <button
+                      disabled={busy}
+                      onClick={runOptimize}
+                      style={{ padding: '0.45rem 0.9rem', fontSize: '0.8rem', fontWeight: 600, borderRadius: 6, border: '1px solid var(--accent-primary)', background: 'transparent', color: 'var(--accent-primary)', cursor: busy ? 'not-allowed' : 'pointer', display: 'flex', alignItems: 'center', gap: '0.4rem' }}
+                    >
+                      <HardDrive size={14} /> {isOptimizing ? 'Reclaiming…' : 'Reclaim space'}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Result / error messages */}
+              {message && (
+                <div style={{ padding: '0.75rem 1rem', borderRadius: 8, border: '1px solid var(--success)', color: 'var(--success)', fontSize: '0.85rem' }}>
+                  {message}
+                </div>
+              )}
+              {error && (
+                <div style={{ padding: '0.75rem 1rem', borderRadius: 8, border: '1px solid var(--error)', color: 'var(--error)', fontSize: '0.85rem' }}>
+                  {error}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};


### PR DESCRIPTION
Closes #135

## What

Adds a **Database Maintenance** overlay (toolbar icon next to statistics) that shows what's in the telegram database and lets you clean it up:

- **Storage info tiles**: backend type, size on disk, telegram count, oldest/newest telegram, configured retention
- **Purge**: presets (30/90/365 days) or a custom cutoff date — always dry-run first, showing *"This will permanently delete N telegrams recorded before …"* with an explicit confirm step; plus a delete-all action
- **Reclaim space**: compacts the database (VACUUM) and reports how much disk space was freed, since row deletion alone doesn't shrink the file

## How

Built on [knx-telegram-store 0.6.0](https://github.com/XKNX/knx-telegram-store/releases/tag/v0.6.0), which adds `get_stats()` and `optimize()` across both storage backends (SQLite via `page_count × page_size` + VACUUM; Postgres/TimescaleDB via `hypertable_size()` + VACUUM). Capability flags (`supports_size_stats`, `supports_optimize`) gate the UI so unsupported backends hide the affected controls.

New endpoints:
- `GET /api/database/info`
- `POST /api/database/purge` — `{older_than | purge_all, dry_run}`, returns `{deleted, dry_run}`
- `POST /api/database/optimize` — returns size before/after

## Testing

- 6 new API tests (58 backend tests pass), frontend build/lint/tests clean
- Verified end-to-end against a live backend seeded with 20k telegrams: dry-run counts match actual deletions, VACUUM shrank the DB 3.1 MB → 1.5 MB, and the full purge + reclaim flow was driven through the real UI (Playwright)
- Library-side stats/optimize also integration-checked against a live TimescaleDB container

Note: timestamps display in local time from naive UTC strings — consistent with existing app-wide behavior (`/api/telegrams` does the same); worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)