### PR TITLE
Hide "Reclaim space" for PostgreSQL (knx-telegram-store 0.7.1)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.7.0
+knx-telegram-store==0.7.1
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Database Maintenance**: "Reclaim space" is no longer offered on the PostgreSQL backend — plain `VACUUM` cannot shrink PostgreSQL's files, so the button visibly did nothing. SQLite is unaffected (knx-telegram-store 0.7.1).
+
 ## 1.9.1
 
 ### Fixed


### PR DESCRIPTION
On PostgreSQL the maintenance screen's **Reclaim space** button visibly did nothing: it runs plain `VACUUM`, which only marks dead tuples reusable and never returns disk space to the OS (only `VACUUM FULL` would, at the cost of an `ACCESS EXCLUSIVE` lock and double disk usage — not UI-button material).

The whole feature is already capability-driven (`supports_optimize` flows from the store through `/api/database/info` into `DatabaseOverlay`), so the fix is upstream: [knx-telegram-store 0.7.1](https://github.com/XKNX/knx-telegram-store/releases/tag/v0.7.1) no longer advertises the optimize capability for the Postgres backend. This PR bumps the pin — the UI section and the API endpoint then disable themselves for PostgreSQL automatically. SQLite is unchanged (`VACUUM` there genuinely shrinks the file).

Verified: with 0.7.1, a Postgres-configured store reports `supports_optimize: false` and sqlite reports `true`; full backend suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PS7vPZHtQbfybtcviyAuyb