### PR TITLE
End-user README.txt in the Windows release zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,8 @@ jobs:
       - name: Zip bundle
         shell: pwsh
         run: |
+          # Get/Set-Content rewrites the README with CRLF line endings
+          Get-Content packaging/windows/README.txt | Set-Content dist/windows/spectrum-knx/README.txt
           $version = $env:GITHUB_REF_NAME -replace '^v', ''
           Compress-Archive -Path dist/windows/spectrum-knx -DestinationPath "dist/spectrum-knx-$version-windows-x64.zip"
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -188,7 +188,8 @@ and the service user; `apt remove` keeps them.
 
 Unzip `spectrum-knx-<version>-windows-x64.zip` anywhere and run
 `spectrum-knx.exe`: a console window shows the logs and the browser opens the
-UI (default `http://localhost:8000`).
+UI (default `http://localhost:8000`). A `README.txt` with the full setup
+guide is included in the zip.
 
 - Configuration lives in the `.env` file created next to the exe on first run
   (same variables as [Section 5](#5-configuration-variables-docker--kubernetes)).
@@ -196,8 +197,8 @@ UI (default `http://localhost:8000`).
   `%LOCALAPPDATA%\SpectrumKNX\`.
 - Windows Firewall asks for network permission on first start — required for
   gateway discovery and KNX routing (multicast).
-- To upgrade, replace the unzipped folder; the `.env` next to the exe and the
-  data directory are untouched.
+- To upgrade, unzip the new version and copy your `.env` next to the new exe;
+  the data directory in `%LOCALAPPDATA%` is untouched by upgrades.
 
 ---
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -113,7 +113,10 @@ Steps:
 Steps:
 
 - [x] `packaging/windows/`: `launcher.py`, `spectrum-knx.spec`, `env.template`,
-      `spectrum-knx.ico` (generated from `frontend/public/favicon.svg`).
+      `spectrum-knx.ico` (generated from `frontend/public/favicon.svg`), and
+      `README.txt` — an end-user setup guide (config via `.env`, data
+      locations, firewall, upgrade/uninstall) that the release workflow copies
+      into the zip next to the exe (converted to CRLF).
       *Notes: the launcher finalizes the environment (defaults →
       `%LOCALAPPDATA%\SpectrumKNX`) before importing the backend, because
       `database.py` reads env at import time. `env.template` ships inside

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -1,0 +1,136 @@
+=============================================================================
+ Spectrum KNX for Windows
+ A professional KNX bus monitor and analyzer
+ https://github.com/martinhoefling/SpectrumKNX
+=============================================================================
+
+
+GETTING STARTED
+---------------
+
+1. Unzip this folder anywhere you like (e.g. C:\Program Files\SpectrumKNX
+   or your Desktop).
+
+2. Double-click  spectrum-knx.exe
+
+   - A console window opens and shows the log output. Keep it open;
+     closing it stops Spectrum KNX.
+   - Your browser opens the web interface automatically
+     (default: http://localhost:8000).
+   - On first start, Windows Firewall asks for network permission.
+     Allow it — it is required to discover KNX/IP gateways and to
+     receive KNX routing (multicast) traffic.
+
+3. On first use the web interface asks for your ETS project file
+   (.knxproj) so group addresses get readable names. Upload it in the
+   wizard (enter the project password if it has one).
+
+To stop Spectrum KNX, press Ctrl+C in the console window or close it.
+
+
+CONFIGURATION (.env FILE)
+-------------------------
+
+On first start, a configuration file named
+
+    .env
+
+is created NEXT TO spectrum-knx.exe (in this folder). Open it with any
+text editor (e.g. Notepad). Every setting is a KEY=VALUE line; lines
+starting with # are comments/disabled. Restart Spectrum KNX after
+changing it.
+
+The most important settings:
+
+  Web interface
+    BIND_HOST=127.0.0.1     only this PC can open the UI (default)
+    BIND_HOST=0.0.0.0       other devices on your network can open it
+    BIND_PORT=8000          change if port 8000 is already in use
+
+  KNX connection
+    KNX_CONNECTION_TYPE=automatic
+        Scans the network for a KNX/IP gateway. Other values:
+        tunneling, tunneling_tcp, tunneling_tcp_secure, routing,
+        routing_secure
+
+    For tunneling (recommended if you have a KNX/IP interface):
+        KNX_CONNECTION_TYPE=tunneling
+        KNX_GATEWAY_IP=192.168.1.10
+        #KNX_GATEWAY_PORT=3671
+
+    For routing (KNX/IP router, multicast):
+        KNX_CONNECTION_TYPE=routing
+        #KNX_MULTICAST_GROUP=224.0.23.12
+        #KNX_MULTICAST_PORT=3671
+        #KNX_INDIVIDUAL_ADDRESS=15.15.250
+
+    For KNX IP Secure, export a .knxkeys file from ETS:
+        KNX_CONNECTION_TYPE=tunneling_tcp_secure
+        KNX_KNXKEYS_FILE=C:/SpectrumKNX/keys.knxkeys
+        KNX_KNXKEYS_PASSWORD=your_keys_password
+
+  Logging
+    LOG_LEVEL=info          use debug for troubleshooting
+
+The full list of settings is documented in DEPLOYMENT.md in the
+repository: https://github.com/martinhoefling/SpectrumKNX
+
+
+WHERE YOUR DATA IS STORED
+-------------------------
+
+  Telegram database (SQLite)
+      %LOCALAPPDATA%\SpectrumKNX\spectrum-knx.db
+      (usually C:\Users\<you>\AppData\Local\SpectrumKNX\)
+
+  Uploaded ETS project file
+      %LOCALAPPDATA%\SpectrumKNX\knx_project.knxproj
+
+  Configuration
+      .env file next to spectrum-knx.exe (this folder)
+
+You can override the storage locations in the .env file
+(DATABASE_URL and KNX_PROJECT_PATH — use forward slashes in paths).
+
+
+UPGRADING
+---------
+
+1. Stop Spectrum KNX.
+2. If you changed the .env file, keep a copy of it.
+3. Unzip the new version (replacing or next to the old folder) and copy
+   your .env back next to the new spectrum-knx.exe.
+
+Your telegram history and the uploaded project file live in
+%LOCALAPPDATA%\SpectrumKNX and are not touched by an upgrade.
+
+
+UNINSTALLING
+------------
+
+1. Delete this folder.
+2. To also remove your recorded telegram history and uploaded project
+   file, delete  %LOCALAPPDATA%\SpectrumKNX
+
+
+TROUBLESHOOTING
+---------------
+
+- The browser shows "connection refused":
+  Check the console window — the URL and any errors are printed there.
+  If port 8000 is taken by another program, set a different BIND_PORT
+  in .env and restart.
+
+- No KNX gateway found / no telegrams:
+  Make sure the firewall permission was granted (Windows Settings >
+  Firewall > Allowed apps, look for spectrum-knx). With multiple
+  network adapters (VPN, virtualization), set KNX_LOCAL_IP in .env to
+  the IP of the adapter that reaches your KNX installation. If
+  automatic discovery fails, configure the gateway explicitly with
+  KNX_CONNECTION_TYPE=tunneling and KNX_GATEWAY_IP.
+
+- More detail in the logs:
+  Set LOG_LEVEL=debug in .env and restart.
+
+- Bug reports and questions:
+  https://github.com/martinhoefling/SpectrumKNX/issues


### PR DESCRIPTION
Adds `packaging/windows/README.txt`, a plain-text setup guide shipped inside the Windows zip next to `spectrum-knx.exe`:

- quick start (run the exe, browser opens, firewall prompt, project upload)
- `.env` configuration with concrete KNX connection examples (tunneling, routing, IP Secure)
- where data lives (`%LOCALAPPDATA%\SpectrumKNX`) and how to override paths
- upgrade (keep your `.env`, data dir untouched), uninstall, troubleshooting

The `build-windows` release job copies it into the bundle (CRLF-converted via `Get-Content | Set-Content`) before `Compress-Archive`. DEPLOYMENT.md's upgrade note corrected accordingly (replacing the folder does not preserve `.env` — copy it over) and PACKAGING.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PS7vPZHtQbfybtcviyAuyb