### PR TITLE
feat: telegram log import/export for offline analysis (#99)

### DIFF
--- a/DESIGN_IMPORT_EXPORT.md
+++ b/DESIGN_IMPORT_EXPORT.md
@@ -1,0 +1,170 @@
+# Telegram Import / Export (Offline Analysis) — Design & Implementation Plan
+
+Implements [SpectrumKNX#99](https://github.com/martinhoefling/SpectrumKNX/issues/99): import
+historical KNX bus recordings (ETS6 group-monitor exports, Gira IP-Router data-logger dumps)
+into the telegram store for offline analysis, plus export of a telegram selection back to the
+ETS6 XML format.
+
+## 1. Source Formats (validated against real samples)
+
+Both sources share the **same XML container schema** `http://knx.org/xml/telegrams/01`
+(`<CommunicationLog>` with `<Telegram Timestamp=... Service=... FrameFormat="CommonEmi"
+RawData=... />`), but differ in the cEMI frame type inside `RawData`:
+
+| | ETS6 export | Gira data logger |
+|---|---|---|
+| Packaging | single `.xml` file | folder tree `YYYY/MM/DD/YYYY_MM_DD_{LAN,TP1}.xml`, hundreds of files, GBs |
+| Service | `L_Data.ind` | `L_Busmon.ind` |
+| RawData | full cEMI L_Data frame — `xknx.cemi.CEMIFrame.from_knx()` decodes directly | cEMI busmonitor wrapper around a **raw TP1 frame** (incl. bus ACKs and checksum) — xknx raises `UnsupportedCEMIMessage` |
+| Extras | `<RecordStart>`/`<RecordStop>` elements | `<!-- timezone offset -->` comment, `System.txt` syslog (ignored) |
+
+### Busmonitor (TP1) frames — measured facts
+
+* Frame layout after the cEMI additional-info block: `CTRL SRC(2) DST(2) LEN/AT APDU… CHK`.
+  Standard L_Data frames are identified by `(ctrl & 0xD3) == 0x90`; single-byte frames
+  (`0xCC` ACK / `0x0C` NAK / busy) are link-layer acknowledgements and are skipped.
+* Checksum is XOR-complement over the frame; verified `True` on all sampled frames — used to
+  drop corrupted telegrams.
+* Conversion to a plain cEMI `L_Data.ind` (`29 00 ctrl (len_at & 0xF0) src dst len apdu`) was
+  validated: xknx decodes the reconstructed frames with correct addresses and payloads.
+* **LAN/TP1 duplication:** for a sampled day, the LAN file was a **100 % multiset-subset** of
+  the TP1 file (42 999 of 42 999 telegrams matched on `(src, dst, apdu)`), with a median
+  timestamp skew of 6 ms (p95 8 ms, max 23 ms). TP1 additionally carries line-local traffic.
+
+## 2. Where the code lives — library vs. app
+
+`knx-telegram-store` is deliberately **zero-runtime-dependency** and knows nothing about the
+KNX protocol. Decoding frames requires `xknx`; name/DPT enrichment requires `xknxproject`;
+upload + progress requires FastAPI/WebSocket. All of these already live in SpectrumKNX.
+
+**Split:**
+
+* **`knx-telegram-store`** (fits cleanly, stdlib-only): the XML *container* format —
+  a streaming reader and writer for `CommunicationLog` files operating on *raw hex frames*:
+  * `formats/ets_xml.py`: `RawTelegramRecord` (timestamp, service, raw bytes),
+    `iter_communication_log(source)` (incremental `iterparse`, constant memory),
+    `write_communication_log(records, dest, ...)` (streaming writer, ETS6-compatible output).
+  * No decoding, no xknx — usable by any consumer (HA companion, CLI tools).
+* **SpectrumKNX backend** (everything protocol- and app-specific):
+  * `telegram_import.py`: busmon→L_Data adapter, cEMI decode via xknx, enrichment through the
+    existing `parsers.parse_telegram_payload` pipeline + project name map, de-duplication,
+    batched `store_many`, import job state machine.
+  * `api.py`: upload endpoint (xml/zip), job status polling, export download endpoint.
+* **SpectrumKNX frontend**: new *Import / Export* view in the top-left `NavDropdown`.
+
+Export cannot live in the library because `StoredTelegram.raw_data` holds only the **APDU
+payload bytes**, not the original frame — rebuilding a cEMI frame needs xknx re-encoding.
+
+## 3. Import pipeline (backend)
+
+```
+upload (.xml | .zip)
+  └─ stream to temp file (spooled; never fully in memory)
+      └─ enumerate sources: single xml, or zip entries *.xml (System.txt etc. ignored)
+          └─ group entries whose telegram time ranges overlap (peek first Timestamp)
+              └─ per group: k-way merge streams by timestamp
+                  ├─ L_Data.ind  → CEMIFrame.from_knx(raw)
+                  ├─ L_Busmon.ind → TP1 adapter → CEMIFrame.from_knx(reconstructed)
+                  │     (skip ACK/NAK, skip checksum failures — counted)
+                  ├─ window de-dup (cross-media, in-batch)
+                  ├─ idempotency de-dup (vs. store)
+                  ├─ enrich → StoredTelegram (existing parsers.py + project name map)
+                  └─ store.store_many(batch)          # batches of 5 000
+```
+
+* Runs as a single background `asyncio` task; CPU-heavy parsing yields regularly
+  (`await asyncio.sleep(0)` between batches) so the live daemon and API stay responsive.
+* One import job at a time (409 on concurrent start). Cancellable.
+* Zip entries are processed via `zipfile` streams — a multi-GB upload is decompressed
+  incrementally, bounded by one day-group of telegrams in memory (≈100 k telegrams).
+
+### De-duplication (two layers)
+
+1. **Cross-media window de-dup** (within the import): key `(src, dst, apdu-bytes)` inside a
+   sliding **200 ms** window across the merged streams of one overlap group. Collapses the
+   LAN/TP1 pairs measured above (max observed skew 23 ms) while keeping genuinely repeated
+   telegrams (e.g. cyclic transmissions are seconds apart; even dimming steps are ≫200 ms).
+   The earliest timestamp of a pair wins → deterministic output.
+2. **Idempotency de-dup** (against the store): before inserting a batch spanning
+   `[t0, t1]`, query existing telegrams in that range (`TelegramQuery(start_time, end_time)`)
+   and skip exact `(timestamp, source, destination, raw_data, telegramtype)` matches.
+   Because layer 1 is deterministic, re-importing the same file is a no-op.
+
+Imported telegrams land in the **main store** (`direction="Incoming"`), so every existing
+feature (history search, filters, context windows, charts) works on them unchanged — the core
+ask of #99. A separate "dataset" namespace was considered and rejected for now: it would
+require a schema/query extension in the library and UI scoping everywhere; if needed later it
+can be added as a nullable `dataset` column without breaking this design.
+
+### Job state & progress
+
+In-memory singleton `ImportJob`:
+
+```python
+{ "id": str, "state": "running|done|failed|cancelled",
+  "filename": str, "files_total": int, "files_done": int, "current_file": str,
+  "bytes_total": int, "bytes_done": int,          # upload-side progress
+  "telegrams_parsed": int, "telegrams_imported": int,
+  "duplicates_skipped": int, "acks_skipped": int, "errors": int,
+  "started_at": iso, "finished_at": iso|None, "error": str|None }
+```
+
+Progress is **polled** via `GET /api/import/status` (frontend polls ~500 ms while a job is
+running). Polling was chosen over pushing on the existing `/ws/telegrams` socket because the
+job state is trivially small, survives page reloads, and needs no WS protocol change; a WS
+push can be layered on later without API changes.
+
+## 4. HTTP API
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/import` | multipart upload, one `.xml` or `.zip`. Starts the job; `409` if one is running, `403` in `READ_ONLY` (companion) mode. Returns job id. |
+| `GET` | `/api/import/status` | current/last job state (see above); `{"state": "idle"}` if none. |
+| `POST` | `/api/import/cancel` | request cancellation of the running job. |
+| `GET` | `/api/export` | same filter query params as `/api/telegrams` (+`start_time`/`end_time`); streams an ETS6-compatible `CommunicationLog` XML download. |
+
+Export re-encodes each `StoredTelegram` into a cEMI `L_Data.ind` frame via xknx
+(`GroupValueWrite/Response` from `raw_data`/`payload` + DPT heuristics, `GroupValueRead`
+empty) and feeds the library's `write_communication_log`. Round-trip fidelity: addresses,
+type, APDU and timestamp are exact; original bus-monitor metadata (ACKs, checksums,
+connection name) is not reproduced.
+
+## 5. Frontend — “Import / Export” view
+
+* New entry in the top-left `NavDropdown` (`App.tsx`): `{ id: 'import', label: 'Import / Export', icon: FolderInput }` alongside Group Monitor / History Search / Settings.
+* New component `ImportExportView.tsx` (full-pane view like live/history, not an overlay):
+  * **Import card** — drag-&-drop / file picker (`.xml`, `.zip`); shows selected file, size;
+    *Start import* button. Disabled with an explanatory note in companion/read-only mode.
+  * **Progress card** — while running: overall progress bar (files done / total; bytes for
+    single files), current file name, live counters (parsed / imported / duplicates /
+    ACKs skipped / errors), cancel button. Terminal states render a summary (and error
+    details on failure). Poll `GET /api/import/status` every 500 ms; on mount, pick up any
+    already-running job (page-reload safe).
+  * **Export card** — time-range picker + optional source/destination/type filters; *Download
+    ETS6 XML* button hitting `/api/export`.
+* Styling reuses `glass` cards / `nav-item` conventions from existing overlays.
+
+## 6. Implementation plan
+
+1. **Library** (`knx-telegram-store`, minor version bump → 0.6.0):
+   `formats/ets_xml.py` + unit tests (parse ETS6 fixture incl. `RecordStart`, parse Gira
+   fixture incl. timezone comment, writer round-trip). Dev-install (`pip install -e`) into the
+   SpectrumKNX backend venv (currently pins 0.3.2 from PyPI — the two known pre-existing
+   daemon-test failures stem from that pin and are unaffected by this feature).
+2. **Backend importer** (`backend/telegram_import.py`): TP1 busmon adapter (+checksum),
+   frame→`StoredTelegram` via existing parser pipeline, overlap grouping + k-way merge,
+   window & idempotency de-dup, batched writes, `ImportJob` state machine.
+3. **API** (`backend/api.py`): the four endpoints above, READ_ONLY gating consistent with
+   `/api/project/upload`.
+4. **Frontend**: `NavDropdown` entry + `ImportExportView.tsx` + status polling hook.
+5. **Tests / validation**: unit tests for adapter, de-dup and job flow (backend), format
+   round-trip (library); end-to-end: import the ETS6 sample and one full Gira day
+   (TP1+LAN ≈ 87 k raw → expect ≈ 44 k stored, 43 k duplicates skipped), then re-import
+   → 0 new rows.
+
+## 7. Out of scope / future work
+
+* Optional `dataset` tag column for isolating imports from live capture.
+* Fuzzy de-dup against *live-captured* history (live daemon timestamps ≠ logger timestamps).
+* WS push for progress; multi-job queue.
+* Import of `.knxproj` alongside logs (already covered by the existing project upload).

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,13 +1,19 @@
+import dataclasses
 import os
 import subprocess
+import tempfile
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from fastapi.responses import StreamingResponse
+from knx_telegram_store.formats import COMMUNICATION_LOG_FOOTER, COMMUNICATION_LOG_HEADER, format_telegram_element
 from pydantic import BaseModel
 from sqlalchemy import text
 from xknx.telegram.address import IndividualAddress
 
 import knx_daemon  # import global config
+import telegram_export
+import telegram_import
 from database import READ_ONLY, engine, store
 from knx_telegram_store import TelegramQuery
 from parsers import (
@@ -18,6 +24,8 @@ from parsers import (
 from ws_manager import manager
 
 router = APIRouter()
+
+EXPORT_PAGE_SIZE = 10_000
 
 
 def get_backend_version() -> str:
@@ -628,6 +636,98 @@ async def upload_knxkeys(file: UploadFile = File(...), password: str = Form(""))
     await knx_daemon._reconnect_knx()
 
     return {"status": "ok", "message": "KNX keys file uploaded. Reconnecting to bus..."}
+
+
+# ── Telegram log import / export (see DESIGN_IMPORT_EXPORT.md) ──────────────
+
+
+@router.get("/api/import/status")
+async def get_import_status():
+    """Returns the state of the current/last telegram log import job."""
+    job = telegram_import.current_job
+    state = job.to_dict() if job else {"state": "idle"}
+    return state | {"read_only": READ_ONLY}
+
+
+@router.post("/api/import")
+async def start_telegram_import(file: UploadFile = File(...)):
+    """Uploads a telegram log (.xml or .zip of .xml) and starts a background import."""
+    if READ_ONLY:
+        raise HTTPException(status_code=403, detail="Import is unavailable in read-only companion mode")
+    if not file.filename or not file.filename.lower().endswith((".xml", ".zip")):
+        raise HTTPException(status_code=400, detail="File must be a .xml or .zip telegram log")
+
+    suffix = os.path.splitext(file.filename)[1].lower()
+    upload = tempfile.NamedTemporaryFile(delete=False, prefix="knx-import-", suffix=suffix)
+    try:
+        while chunk := await file.read(1024 * 1024):
+            upload.write(chunk)
+    finally:
+        upload.close()
+
+    try:
+        job = telegram_import.start_import(store, upload.name, file.filename)
+    except RuntimeError as e:
+        os.unlink(upload.name)
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    return job.to_dict()
+
+
+@router.post("/api/import/cancel")
+async def cancel_telegram_import():
+    """Requests cancellation of the running import job."""
+    if not telegram_import.cancel_import():
+        raise HTTPException(status_code=404, detail="No import is running")
+    return {"status": "ok"}
+
+
+@router.get("/api/export")
+async def export_telegrams(
+    source_address: str | None = None,
+    target_address: str | None = None,
+    telegram_type: str | None = None,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    limit: int = 500_000,
+):
+    """Streams matching telegrams as an ETS6-compatible CommunicationLog XML file."""
+    type_map_reverse = {"Write": "GroupValueWrite", "Read": "GroupValueRead", "Response": "GroupValueResponse"}
+    query = TelegramQuery(
+        sources=[s.strip() for s in source_address.split(",")] if source_address else [],
+        destinations=[s.strip() for s in target_address.split(",")] if target_address else [],
+        telegram_types=[type_map_reverse.get(t.strip(), t.strip()) for t in telegram_type.split(",")]
+        if telegram_type
+        else [],
+        start_time=start_time,
+        end_time=end_time,
+        limit=min(EXPORT_PAGE_SIZE, limit),
+        order_descending=False,
+    )
+
+    async def generate():
+        yield COMMUNICATION_LOG_HEADER
+        offset = 0
+        while offset < limit:
+            page = dataclasses.replace(query, limit=min(EXPORT_PAGE_SIZE, limit - offset), offset=offset)
+            result = await store.query(page, flush_first=True)
+            chunk = "".join(
+                format_telegram_element(record, connection_name="Spectrum KNX Export")
+                for telegram in result.telegrams
+                if (record := telegram_export.stored_to_record(telegram)) is not None
+            )
+            if chunk:
+                yield chunk
+            if not result.limit_reached or len(result.telegrams) == 0:
+                break
+            offset += len(result.telegrams)
+        yield COMMUNICATION_LOG_FOOTER
+
+    filename = f"spectrum-knx-export-{datetime.now(UTC).strftime('%Y%m%d-%H%M%S')}.xml"
+    return StreamingResponse(
+        generate(),
+        media_type="application/xml",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.websocket("/ws/telegrams")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.7.1
+knx-telegram-store==0.8.0
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0

--- a/backend/telegram_export.py
+++ b/backend/telegram_export.py
@@ -1,0 +1,66 @@
+"""Export of stored telegrams as ETS6-compatible ``CommunicationLog`` XML.
+
+``StoredTelegram.raw_data`` holds only the APDU payload bytes, so full cEMI
+frames are re-encoded via xknx. Addresses, telegram type, APDU and timestamp
+are exact; transport-level details of the original capture (hop count,
+bus ACKs) are not reproduced. See DESIGN_IMPORT_EXPORT.md.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+
+from knx_telegram_store.formats import RawTelegramRecord
+from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
+from xknx.dpt import DPTArray, DPTBinary
+from xknx.exceptions import XKNXException
+from xknx.telegram import Telegram as XknxTelegram
+from xknx.telegram.address import GroupAddress, IndividualAddress
+from xknx.telegram.apci import APCI, GroupValueRead, GroupValueResponse, GroupValueWrite
+
+from knx_telegram_store import StoredTelegram
+
+# DPT main numbers whose payload travels inside the APCI byte (DPTBinary, ≤6 bit)
+_BINARY_DPT_MAINS = {1, 2, 3, 23}
+
+
+def _build_apci(telegram: StoredTelegram) -> APCI | None:
+    if telegram.telegramtype == "GroupValueRead":
+        return GroupValueRead()
+    if telegram.telegramtype not in ("GroupValueWrite", "GroupValueResponse"):
+        return None
+    if not telegram.raw_data:
+        return None
+    payload = bytes.fromhex(telegram.raw_data)
+    # Single-byte payloads are ambiguous: DPTBinary (value in the APCI byte)
+    # vs. a one-byte DPTArray. Prefer the DPT metadata; fall back to treating
+    # small unknown values as binary (switches dominate undecoded traffic).
+    if len(payload) == 1 and (
+        telegram.dpt_main in _BINARY_DPT_MAINS or (telegram.dpt_main is None and payload[0] <= DPTBinary.APCI_BITMASK)
+    ):
+        value: DPTArray | DPTBinary = DPTBinary(payload[0])
+    else:
+        value = DPTArray(payload)
+    if telegram.telegramtype == "GroupValueResponse":
+        return GroupValueResponse(value)
+    return GroupValueWrite(value)
+
+
+def stored_to_record(telegram: StoredTelegram) -> RawTelegramRecord | None:
+    """Re-encodes a stored telegram as a raw cEMI log record (None if impossible)."""
+    apci = _build_apci(telegram)
+    if apci is None:
+        return None
+    try:
+        xknx_telegram = XknxTelegram(
+            destination_address=GroupAddress(telegram.destination),
+            source_address=IndividualAddress(telegram.source),
+            payload=apci,
+        )
+        data = CEMILData.init_from_telegram(xknx_telegram, src_addr=IndividualAddress(telegram.source))
+        frame = CEMIFrame(code=CEMIMessageCode.L_DATA_IND, data=data)
+        raw = bytes(frame.to_knx())
+    except (XKNXException, ValueError):
+        return None
+    timestamp = telegram.timestamp if telegram.timestamp.tzinfo else telegram.timestamp.replace(tzinfo=UTC)
+    return RawTelegramRecord(timestamp=timestamp, service="L_Data.ind", raw_data=raw)

--- a/backend/telegram_import.py
+++ b/backend/telegram_import.py
@@ -1,0 +1,381 @@
+"""Import of historical KNX telegram logs (ETS6 / Gira ``CommunicationLog`` XML).
+
+See DESIGN_IMPORT_EXPORT.md. The XML container parsing lives in
+``knx_telegram_store.formats``; this module adds everything protocol- and
+app-specific: busmonitor (TP1) frame conversion, cEMI decoding via xknx,
+enrichment through the shared parser pipeline, de-duplication and the
+background import job with progress reporting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import heapq
+import logging
+import os
+import uuid
+import zipfile
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import IO, Any
+
+from knx_telegram_store.formats import RawTelegramRecord, iter_communication_log
+from xknx.cemi import CEMIFrame
+from xknx.exceptions import XKNXException
+from xknx.telegram import Telegram as XknxTelegram
+from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
+
+import knx_daemon
+from knx_telegram_store import StoredTelegram, TelegramQuery
+from parsers import parse_telegram_payload
+
+logger = logging.getLogger("uvicorn.error")
+
+# Cross-media de-dup window: Gira logs the same telegram on TP1 and LAN with a
+# measured skew of ≤23ms (median 6ms); genuinely repeated telegrams are ≫200ms apart.
+DEDUP_WINDOW = timedelta(milliseconds=200)
+BATCH_SIZE = 5_000
+
+
+# ── Busmonitor (TP1 raw frame) → cEMI L_Data conversion ──────────────────────
+
+
+def busmon_to_ldata(raw: bytes) -> tuple[bytes | None, str]:
+    """Converts a cEMI L_Busmon.ind frame into a plain cEMI L_Data.ind frame.
+
+    Returns ``(cemi_bytes, "data")`` for L_Data frames, or ``(None, kind)``
+    where kind is "ack" (link-layer ACK/NAK/BUSY), "corrupt" (checksum
+    mismatch) or "other" (non-L_Data traffic such as poll frames).
+    """
+    if len(raw) < 2 or raw[0] != 0x2B:
+        return None, "other"
+    additional_info_length = raw[1]
+    tp1 = raw[2 + additional_info_length :]
+    if len(tp1) <= 1:
+        # Single byte: link-layer acknowledgement (0xCC ACK / 0x0C NAK / 0xC0 BUSY)
+        return None, "ack"
+
+    checksum = 0xFF
+    for byte in tp1[:-1]:
+        checksum ^= byte
+    if checksum != tp1[-1]:
+        return None, "corrupt"
+
+    control = tp1[0]
+    if (control & 0xD3) == 0x90 and len(tp1) >= 8:
+        # Standard frame: CTRL SRC(2) DST(2) LEN/AT APDU… CHK
+        length = tp1[5] & 0x0F
+        apdu = tp1[6 : 6 + length + 1]
+        if len(apdu) != length + 1:
+            return None, "corrupt"
+        cemi = bytes([0x29, 0x00, control, tp1[5] & 0xF0]) + tp1[1:5] + bytes([length]) + apdu
+        return cemi, "data"
+    if (control & 0xD3) == 0x10:
+        # Extended frame: CTRL CTRLE SRC(2) DST(2) LEN APDU… CHK — layout after
+        # CTRL already matches cEMI L_Data, only the checksum must go.
+        return bytes([0x29, 0x00]) + tp1[:-1], "data"
+    return None, "other"
+
+
+def record_to_cemi(record: RawTelegramRecord) -> tuple[bytes | None, str]:
+    """Normalizes a log record to a decodable cEMI L_Data frame."""
+    if record.service == "L_Busmon.ind":
+        return busmon_to_ldata(record.raw_data)
+    return record.raw_data, "data"
+
+
+# ── Decoding & enrichment ────────────────────────────────────────────────────
+
+
+def decode_cemi(cemi: bytes) -> XknxTelegram | None:
+    """Decodes a cEMI L_Data frame into an xknx telegram (None if unsupported)."""
+    try:
+        frame = CEMIFrame.from_knx(cemi)
+        telegram = frame.data.telegram()  # type: ignore[union-attr]
+    except (XKNXException, AttributeError, IndexError, ValueError):
+        # ValueError: xknx raises bare ValueErrors for e.g. invalid secure APCI services
+        return None
+    xknx = knx_daemon.xknx_instance
+    if xknx is not None:
+        xknx.group_address_dpt.set_decoded_data(telegram)
+    return telegram
+
+
+def build_stored_telegram(telegram: XknxTelegram, timestamp: datetime) -> StoredTelegram:
+    """Maps an xknx telegram to a StoredTelegram — mirrors the live daemon mapping."""
+    source_addr = str(telegram.source_address)
+    target_addr = str(telegram.destination_address) if telegram.destination_address else "0/0/0"
+
+    value_numeric, value_json, raw_data, _dpt_str, dpt_main, dpt_sub, _unit, _value_formatted, _raw_hex = (
+        parse_telegram_payload(telegram, knx_daemon.xknx_instance)
+    )
+    return StoredTelegram(
+        timestamp=timestamp,
+        source=source_addr,
+        destination=target_addr,
+        telegramtype=type(telegram.payload).__name__,
+        direction="Incoming",
+        dpt_main=dpt_main,
+        dpt_sub=dpt_sub,
+        payload=value_json,
+        value=value_numeric,
+        raw_data=raw_data.hex() if isinstance(raw_data, bytes) else raw_data,
+        source_name=knx_daemon.project_name_map["ia"].get(source_addr) or "",
+        destination_name=knx_daemon.project_name_map["ga"].get(target_addr) or "",
+    )
+
+
+def _dedup_key(telegram: StoredTelegram) -> tuple:
+    """Identity key for idempotency de-dup; timestamps normalized to naive UTC
+    (SQL backends return naive UTC datetimes)."""
+    ts = telegram.timestamp
+    if ts.tzinfo is not None:
+        ts = ts.astimezone(UTC).replace(tzinfo=None)
+    return (ts, telegram.source, telegram.destination, telegram.telegramtype, telegram.raw_data or "")
+
+
+# ── Import sources (single xml / zip of xml) ─────────────────────────────────
+
+
+@dataclass
+class ImportSource:
+    """One parseable XML stream within the upload."""
+
+    name: str
+    open_stream: Callable[[], IO[bytes]]
+
+
+def _list_sources(path: str, filename: str) -> list[ImportSource]:
+    if zipfile.is_zipfile(path):
+        archive = zipfile.ZipFile(path)
+        sources = []
+        for info in archive.infolist():
+            base = os.path.basename(info.filename)
+            if info.is_dir() or not base.lower().endswith(".xml") or base.startswith("."):
+                continue
+
+            def _opener(name: str = info.filename) -> IO[bytes]:
+                return archive.open(name)
+
+            sources.append(ImportSource(name=info.filename, open_stream=_opener))
+        return sources
+    return [ImportSource(name=filename, open_stream=lambda: open(path, "rb"))]
+
+
+def _peek_first_timestamp(source: ImportSource) -> datetime | None:
+    try:
+        with source.open_stream() as stream:
+            for record in iter_communication_log(stream):
+                return record.timestamp
+    except Exception:
+        return None
+    return None
+
+
+def _group_sources(sources: list[ImportSource]) -> list[list[ImportSource]]:
+    """Groups sources that may contain the same telegrams on different media.
+
+    Gira loggers write one LAN and one TP1 file per day; files of the same
+    (UTC) day are merged and de-duplicated together. Sources without a single
+    parseable telegram are kept (their parse errors surface in the job counters).
+    """
+    dated: list[tuple[datetime | None, ImportSource]] = [(_peek_first_timestamp(s), s) for s in sources]
+    groups: dict[Any, list[ImportSource]] = {}
+    for first_ts, source in dated:
+        key = first_ts.date() if first_ts else ("undated", source.name)
+        groups.setdefault(key, []).append(source)
+    return [group for _, group in sorted(groups.items(), key=lambda item: str(item[0]))]
+
+
+# ── Import job ───────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ImportJob:
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    state: str = "running"  # running | done | failed | cancelled
+    filename: str = ""
+    files_total: int = 0
+    files_done: int = 0
+    current_file: str = ""
+    telegrams_parsed: int = 0
+    telegrams_imported: int = 0
+    duplicates_skipped: int = 0
+    acks_skipped: int = 0
+    non_group_skipped: int = 0  # device programming / TPCI control traffic
+    errors: int = 0
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    finished_at: datetime | None = None
+    error: str | None = None
+    cancel_requested: bool = False
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "state": self.state,
+            "filename": self.filename,
+            "files_total": self.files_total,
+            "files_done": self.files_done,
+            "current_file": self.current_file,
+            "telegrams_parsed": self.telegrams_parsed,
+            "telegrams_imported": self.telegrams_imported,
+            "duplicates_skipped": self.duplicates_skipped,
+            "acks_skipped": self.acks_skipped,
+            "non_group_skipped": self.non_group_skipped,
+            "errors": self.errors,
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "error": self.error,
+        }
+
+
+current_job: ImportJob | None = None
+_job_task: asyncio.Task | None = None
+
+
+class _ImportCancelled(Exception):
+    pass
+
+
+def _iter_group_telegrams(group: list[ImportSource], job: ImportJob) -> Iterator[StoredTelegram]:
+    """Merges a group's streams by timestamp, converts, de-dups and enriches.
+
+    Runs in a worker thread (pure CPU + file IO); mutates job counters, which
+    is safe for int increments under the GIL.
+    """
+
+    def _stream(source: ImportSource) -> Iterator[tuple[datetime, bytes]]:
+        try:
+            with source.open_stream() as stream:
+                for record in iter_communication_log(stream):
+                    if job.cancel_requested:
+                        raise _ImportCancelled
+                    job.telegrams_parsed += 1
+                    cemi, kind = record_to_cemi(record)
+                    if cemi is None:
+                        if kind == "ack":
+                            job.acks_skipped += 1
+                        else:
+                            job.errors += 1
+                        continue
+                    yield record.timestamp, cemi
+        except _ImportCancelled:
+            raise
+        except Exception as e:
+            logger.warning(f"Import: failed to parse {source.name}: {e}")
+            job.errors += 1
+
+    job.current_file = ", ".join(os.path.basename(s.name) for s in group)
+    recent: dict[bytes, datetime] = {}
+    last_prune = datetime.min.replace(tzinfo=UTC)
+    for timestamp, cemi in heapq.merge(*(_stream(s) for s in group), key=lambda item: item[0]):
+        # Key excludes msg-code/add-info/ctrl bytes: the router decrements the
+        # hop count when forwarding, so the TP1 and LAN copies of the same
+        # telegram differ in ctrl2. src+dst+len+apdu identifies the telegram.
+        key = cemi[4:]
+        kept_at = recent.get(key)
+        if kept_at is not None and timestamp - kept_at <= DEDUP_WINDOW:
+            job.duplicates_skipped += 1
+            continue
+        recent[key] = timestamp
+        if timestamp - last_prune > timedelta(seconds=5):
+            recent = {frame: ts for frame, ts in recent.items() if timestamp - ts <= DEDUP_WINDOW}
+            last_prune = timestamp
+
+        telegram = decode_cemi(cemi)
+        if telegram is None:
+            job.errors += 1
+            continue
+        if not isinstance(telegram.payload, GroupValueWrite | GroupValueRead | GroupValueResponse):
+            job.non_group_skipped += 1
+            continue
+        yield build_stored_telegram(telegram, timestamp)
+    job.files_done += len(group)
+
+
+def _next_batch(iterator: Iterator[StoredTelegram]) -> list[StoredTelegram]:
+    batch = []
+    for telegram in iterator:
+        batch.append(telegram)
+        if len(batch) >= BATCH_SIZE:
+            break
+    return batch
+
+
+async def _existing_keys(store, start: datetime, end: datetime) -> set[tuple]:
+    """Keys of telegrams already stored in [start, end] for idempotent re-import."""
+    keys: set[tuple] = set()
+    offset = 0
+    while True:
+        result = await store.query(
+            TelegramQuery(start_time=start, end_time=end, limit=BATCH_SIZE * 4, offset=offset, order_descending=False)
+        )
+        keys.update(_dedup_key(t) for t in result.telegrams)
+        if not result.limit_reached:
+            return keys
+        offset += len(result.telegrams)
+
+
+async def _run_import(store, path: str, filename: str, job: ImportJob) -> None:
+    try:
+        sources = await asyncio.to_thread(_list_sources, path, filename)
+        if not sources:
+            raise ValueError("No XML files found in upload")
+        job.files_total = len(sources)
+        groups = await asyncio.to_thread(_group_sources, sources)
+
+        for group in groups:
+            if job.cancel_requested:
+                raise _ImportCancelled
+            iterator = _iter_group_telegrams(group, job)
+            while True:
+                batch = await asyncio.to_thread(_next_batch, iterator)
+                if not batch:
+                    break
+                existing = await _existing_keys(store, batch[0].timestamp, batch[-1].timestamp)
+                fresh = [t for t in batch if _dedup_key(t) not in existing]
+                job.duplicates_skipped += len(batch) - len(fresh)
+                if fresh:
+                    await store.store_many(fresh)
+                    job.telegrams_imported += len(fresh)
+                if job.cancel_requested:
+                    raise _ImportCancelled
+
+        job.state = "done"
+        logger.info(
+            f"Import finished: {job.telegrams_imported} imported, "
+            f"{job.duplicates_skipped} duplicates, {job.errors} errors ({filename})"
+        )
+    except _ImportCancelled:
+        job.state = "cancelled"
+        logger.info(f"Import cancelled ({filename})")
+    except Exception as e:
+        job.state = "failed"
+        job.error = str(e)
+        logger.error(f"Import failed ({filename}): {e}")
+    finally:
+        job.finished_at = datetime.now(UTC)
+        job.current_file = ""
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def start_import(store, path: str, filename: str) -> ImportJob:
+    """Starts a background import of the uploaded file. Raises if one is running."""
+    global current_job, _job_task
+    if current_job is not None and current_job.state == "running":
+        raise RuntimeError("An import is already running")
+    current_job = ImportJob(filename=filename)
+    _job_task = asyncio.get_running_loop().create_task(_run_import(store, path, filename, current_job))
+    return current_job
+
+
+def cancel_import() -> bool:
+    """Requests cancellation of the running import. Returns False if none runs."""
+    if current_job is None or current_job.state != "running":
+        return False
+    current_job.cancel_requested = True
+    return True

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -608,11 +608,37 @@ def _make_stats(count=100, size=4096):
     )
 
 
+def _optimizable_caps():
+    """A writable SQL backend advertising size stats + optimize (e.g. sqlite)."""
+    from knx_telegram_store import StoreCapabilities
+
+    return StoreCapabilities(
+        supports_time_range=True,
+        supports_time_delta=True,
+        supports_pagination=True,
+        supports_count=True,
+        supports_size_stats=True,
+        supports_optimize=True,
+        read_only=False,
+    )
+
+
+def _patch_capabilities(caps):
+    """Pins store.capabilities so these tests don't depend on the ambient DB
+    backend (Postgres correctly reports supports_optimize=False since 0.7.1)."""
+    from unittest.mock import PropertyMock
+
+    import database
+
+    return patch.object(type(database.store), "capabilities", new_callable=PropertyMock, return_value=caps)
+
+
 @patch("database.store.get_stats", new_callable=AsyncMock)
 def test_database_info(mock_stats):
     mock_stats.return_value = _make_stats()
 
-    response = client.get("/api/database/info")
+    with _patch_capabilities(_optimizable_caps()):
+        response = client.get("/api/database/info")
     assert response.status_code == 200
     data = response.json()
     assert data["backend"] == "sqlite"
@@ -621,7 +647,7 @@ def test_database_info(mock_stats):
     assert data["oldest_timestamp"].startswith("2026-01-01")
     assert data["newest_timestamp"].startswith("2026-07-01")
     assert data["retention_days"] == 30
-    # Real store capabilities (SQL backend) support both maintenance features
+    # A writable SQL backend (e.g. sqlite) supports both maintenance features
     assert data["supports_size_stats"] is True
     assert data["supports_optimize"] is True
 
@@ -683,7 +709,8 @@ def test_database_purge_all(mock_stats, mock_clear):
 def test_database_optimize(mock_stats, mock_optimize):
     mock_stats.side_effect = [_make_stats(size=8192), _make_stats(size=2048)]
 
-    response = client.post("/api/database/optimize")
+    with _patch_capabilities(_optimizable_caps()):
+        response = client.post("/api/database/optimize")
     assert response.status_code == 200
     assert response.json() == {"size_bytes_before": 8192, "size_bytes_after": 2048}
     mock_optimize.assert_awaited_once()

--- a/backend/tests/test_api_import_export.py
+++ b/backend/tests/test_api_import_export.py
@@ -1,0 +1,141 @@
+"""API tests for the telegram import/export endpoints (see DESIGN_IMPORT_EXPORT.md)."""
+
+import io
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+import telegram_import
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
+from main import app
+
+client = TestClient(app)
+
+
+def _reset_job():
+    telegram_import.current_job = None
+
+
+# ── /api/import/status ───────────────────────────────────────────────────────
+
+
+def test_import_status_idle():
+    _reset_job()
+    response = client.get("/api/import/status")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "idle"
+    assert "read_only" in body
+
+
+def test_import_status_reports_running_job():
+    telegram_import.current_job = telegram_import.ImportJob(filename="log.xml")
+    try:
+        body = client.get("/api/import/status").json()
+        assert body["state"] == "running"
+        assert body["filename"] == "log.xml"
+    finally:
+        _reset_job()
+
+
+# ── /api/import (upload) ─────────────────────────────────────────────────────
+
+
+def test_import_rejects_bad_extension():
+    _reset_job()
+    response = client.post("/api/import", files={"file": ("log.txt", b"nope", "text/plain")})
+    assert response.status_code == 400
+
+
+@patch("api.READ_ONLY", True)
+def test_import_forbidden_in_read_only():
+    response = client.post("/api/import", files={"file": ("log.xml", b"<x/>", "application/xml")})
+    assert response.status_code == 403
+
+
+@patch("api.telegram_import.start_import")
+def test_import_starts_job(mock_start):
+    _reset_job()
+    mock_start.return_value = telegram_import.ImportJob(filename="log.xml")
+    response = client.post(
+        "/api/import", files={"file": ("log.xml", b"<CommunicationLog/>", "application/xml")}
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == "running"
+    assert mock_start.called
+    # The upload was spooled to a real temp path that is handed to the importer.
+    assert mock_start.call_args[0][1].endswith(".xml")
+
+
+@patch("api.telegram_import.start_import", side_effect=RuntimeError("An import is already running"))
+def test_import_conflict_when_running(mock_start):
+    _reset_job()
+    response = client.post(
+        "/api/import", files={"file": ("log.xml", b"<CommunicationLog/>", "application/xml")}
+    )
+    assert response.status_code == 409
+
+
+# ── /api/import/cancel ───────────────────────────────────────────────────────
+
+
+def test_cancel_when_none_running():
+    _reset_job()
+    assert client.post("/api/import/cancel").status_code == 404
+
+
+def test_cancel_running_job():
+    telegram_import.current_job = telegram_import.ImportJob(filename="log.xml")
+    try:
+        assert client.post("/api/import/cancel").status_code == 200
+        assert telegram_import.current_job.cancel_requested is True
+    finally:
+        _reset_job()
+
+
+# ── /api/export ──────────────────────────────────────────────────────────────
+
+
+@patch("database.store.query", new_callable=AsyncMock)
+def test_export_streams_communication_log(mock_query):
+    mock_query.return_value = TelegramQueryResult(
+        telegrams=[
+            StoredTelegram(
+                timestamp=datetime(2026, 3, 5, 0, 0, 0, tzinfo=UTC),
+                source="1.0.18",
+                destination="2/4/61",
+                telegramtype="GroupValueWrite",
+                direction="Incoming",
+                dpt_main=5,
+                dpt_sub=1,
+                payload=None,
+                value=200.0,
+                raw_data="00c8",
+            )
+        ],
+        total_count=1,
+        limit_reached=False,
+    )
+
+    response = client.get("/api/export?start_time=2026-03-05T00:00:00Z")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/xml")
+    assert "attachment" in response.headers["content-disposition"]
+    body = response.text
+    assert "<CommunicationLog" in body and "</CommunicationLog>" in body
+    assert "L_Data.ind" in body
+    # Re-parse the exported XML to confirm it round-trips through the library reader.
+    from knx_telegram_store.formats import iter_communication_log
+
+    records = list(iter_communication_log(io.BytesIO(body.encode())))
+    assert len(records) == 1
+    assert records[0].service == "L_Data.ind"
+
+
+@patch("database.store.query", new_callable=AsyncMock)
+def test_export_empty_still_valid_xml(mock_query):
+    mock_query.return_value = TelegramQueryResult(telegrams=[], total_count=0, limit_reached=False)
+    body = client.get("/api/export").text
+    assert body.startswith("<?xml")
+    assert "<CommunicationLog" in body and "</CommunicationLog>" in body

--- a/backend/tests/test_telegram_export.py
+++ b/backend/tests/test_telegram_export.py
@@ -1,0 +1,116 @@
+"""Tests for the telegram exporter (see DESIGN_IMPORT_EXPORT.md).
+
+The exporter re-encodes a ``StoredTelegram`` (which keeps only the APDU payload)
+into a full cEMI ``L_Data.ind`` frame via xknx and wraps it in a
+``CommunicationLog`` record. These tests pin the APCI reconstruction rules and
+verify an export→re-import round trip preserves addresses, type and payload.
+"""
+
+import io
+from datetime import UTC, datetime
+
+import telegram_export as te
+from telegram_import import decode_cemi
+from knx_telegram_store import StoredTelegram
+from knx_telegram_store.formats import format_telegram_element, iter_communication_log
+
+
+def _stored(**kw) -> StoredTelegram:
+    base = dict(
+        timestamp=datetime(2026, 3, 5, 0, 0, 0, tzinfo=UTC),
+        source="1.1.1",
+        destination="1/2/3",
+        telegramtype="GroupValueWrite",
+        direction="Incoming",
+        dpt_main=1,
+        dpt_sub=1,
+        payload=None,
+        value=1.0,
+        raw_data="01",
+    )
+    base.update(kw)
+    return StoredTelegram(**base)
+
+
+# ── APCI reconstruction ──────────────────────────────────────────────────────
+
+
+def test_build_apci_read_has_no_payload():
+    apci = te._build_apci(_stored(telegramtype="GroupValueRead", raw_data=None))
+    assert type(apci).__name__ == "GroupValueRead"
+
+
+def test_build_apci_binary_payload_uses_dptbinary():
+    # 1-bit DPT, single byte within the APCI mask → carried inside the APCI byte.
+    apci = te._build_apci(_stored(telegramtype="GroupValueWrite", dpt_main=1, raw_data="01"))
+    assert type(apci.value).__name__ == "DPTBinary"
+
+
+def test_build_apci_multibyte_payload_uses_dptarray():
+    apci = te._build_apci(_stored(telegramtype="GroupValueWrite", dpt_main=5, raw_data="00c8"))
+    assert type(apci.value).__name__ == "DPTArray"
+    assert apci.value.value == (0x00, 0xC8)
+
+
+def test_build_apci_response_type():
+    apci = te._build_apci(_stored(telegramtype="GroupValueResponse", dpt_main=1, raw_data="01"))
+    assert type(apci).__name__ == "GroupValueResponse"
+
+
+def test_build_apci_unknown_type_returns_none():
+    assert te._build_apci(_stored(telegramtype="IndividualAddressRead", raw_data="01")) is None
+
+
+def test_build_apci_write_without_payload_returns_none():
+    assert te._build_apci(_stored(telegramtype="GroupValueWrite", raw_data=None)) is None
+
+
+# ── stored_to_record ─────────────────────────────────────────────────────────
+
+
+def test_stored_to_record_produces_ldata_ind():
+    record = te.stored_to_record(_stored(source="1.0.18", destination="2/4/61", dpt_main=5, raw_data="00c8"))
+    assert record is not None
+    assert record.service == "L_Data.ind"
+    assert record.raw_data.startswith(bytes([0x29, 0x00]))  # cEMI L_Data.ind message code
+
+
+def test_stored_to_record_naive_timestamp_made_utc_aware():
+    record = te.stored_to_record(_stored(timestamp=datetime(2026, 3, 5, 12, 0, 0)))
+    assert record.timestamp.tzinfo is not None
+    assert record.timestamp == datetime(2026, 3, 5, 12, 0, 0, tzinfo=UTC)
+
+
+def test_stored_to_record_unencodable_returns_none():
+    # A group-write with no payload cannot be re-encoded.
+    assert te.stored_to_record(_stored(telegramtype="GroupValueWrite", raw_data=None)) is None
+
+
+# ── Export → re-import round trip ────────────────────────────────────────────
+
+
+def _round_trip(stored: StoredTelegram):
+    record = te.stored_to_record(stored)
+    assert record is not None
+    xml = (
+        '<CommunicationLog xmlns="http://knx.org/xml/telegrams/01">\n'
+        + format_telegram_element(record, connection_name="Spectrum KNX Export")
+        + "</CommunicationLog>\n"
+    )
+    parsed = list(iter_communication_log(io.BytesIO(xml.encode())))
+    assert len(parsed) == 1
+    return decode_cemi(parsed[0].raw_data)
+
+
+def test_round_trip_preserves_addresses_type_and_payload():
+    telegram = _round_trip(_stored(source="1.0.18", destination="2/4/61", dpt_main=5, raw_data="00c8"))
+    assert str(telegram.source_address) == "1.0.18"
+    assert str(telegram.destination_address) == "2/4/61"
+    assert type(telegram.payload).__name__ == "GroupValueWrite"
+    assert telegram.payload.value.value == (0x00, 0xC8)
+
+
+def test_round_trip_group_value_read():
+    telegram = _round_trip(_stored(telegramtype="GroupValueRead", raw_data=None))
+    assert type(telegram.payload).__name__ == "GroupValueRead"
+    assert str(telegram.destination_address) == "1/2/3"

--- a/backend/tests/test_telegram_import.py
+++ b/backend/tests/test_telegram_import.py
@@ -1,0 +1,243 @@
+"""Tests for the telegram log importer (see DESIGN_IMPORT_EXPORT.md).
+
+Covers the protocol-specific logic that lives in the app: the TP1 busmonitor
+frame adapter (incl. checksum), cEMI decoding, de-duplication (window +
+idempotency) and the background import job's counters and lifecycle.
+"""
+
+import os
+import tempfile
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+
+import knx_daemon
+import telegram_import as ti
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
+from knx_telegram_store.formats import RawTelegramRecord
+
+
+@pytest.fixture(autouse=True)
+def _clean_daemon_globals():
+    """Isolate from other tests that patch knx_daemon globals to mocks — the
+    importer decodes via the real parser pipeline and needs a clean daemon."""
+    saved_xknx = knx_daemon.xknx_instance
+    saved_map = knx_daemon.project_name_map
+    knx_daemon.xknx_instance = None
+    knx_daemon.project_name_map = {"ga": {}, "ia": {}}
+    try:
+        yield
+    finally:
+        knx_daemon.xknx_instance = saved_xknx
+        knx_daemon.project_name_map = saved_map
+
+# Real frames sampled from a Gira data logger (see the library format fixtures).
+BUSMON_LDATA = bytes.fromhex("2B090301030604BAD64193BC1012143DE3008000C8C3")  # 1.0.18 → 2/4/61 write
+BUSMON_ACK = bytes.fromhex("2B090301040604BAD6A0ACCC")  # single-byte link-layer ACK
+ETS_LDATA = bytes.fromhex("2900BCE010180504010081")  # ETS6 export, decodes directly
+
+
+# ── Busmonitor (TP1) → cEMI conversion ───────────────────────────────────────
+
+
+def test_busmon_standard_ldata_frame():
+    cemi, kind = ti.busmon_to_ldata(BUSMON_LDATA)
+    assert kind == "data"
+    # Reconstructed as a plain cEMI L_Data.ind (29 00 ...); checksum byte dropped.
+    assert cemi is not None
+    assert cemi[:2] == bytes([0x29, 0x00])
+    assert cemi == bytes.fromhex("2900bce01012143d03008000c8")
+
+
+def test_busmon_single_byte_is_ack():
+    assert ti.busmon_to_ldata(BUSMON_ACK) == (None, "ack")
+
+
+def test_busmon_checksum_mismatch_is_corrupt():
+    corrupt = BUSMON_LDATA[:-1] + bytes([BUSMON_LDATA[-1] ^ 0xFF])
+    assert ti.busmon_to_ldata(corrupt) == (None, "corrupt")
+
+
+def test_busmon_non_ldata_control_is_other():
+    # ctrl=0x00 → (ctrl & 0xD3) matches neither the standard nor extended mask.
+    body = bytes([0x00, 0x11, 0x22])
+    checksum = 0xFF
+    for byte in body:
+        checksum ^= byte
+    frame = bytes([0x2B, 0x00]) + body + bytes([checksum])
+    assert ti.busmon_to_ldata(frame) == (None, "other")
+
+
+def test_busmon_wrong_message_code_is_other():
+    # Not a cEMI L_Busmon.ind (first byte ≠ 0x2B).
+    assert ti.busmon_to_ldata(bytes([0x11, 0x00])) == (None, "other")
+
+
+def test_record_to_cemi_dispatches_on_service():
+    busmon = RawTelegramRecord(datetime.now(UTC), "L_Busmon.ind", BUSMON_LDATA)
+    cemi, kind = ti.record_to_cemi(busmon)
+    assert kind == "data"
+    assert cemi == bytes.fromhex("2900bce01012143d03008000c8")
+
+    # L_Data.ind passes through untouched.
+    ldata = RawTelegramRecord(datetime.now(UTC), "L_Data.ind", ETS_LDATA)
+    assert ti.record_to_cemi(ldata) == (ETS_LDATA, "data")
+
+
+# ── Decoding ─────────────────────────────────────────────────────────────────
+
+
+def test_decode_cemi_valid_frame():
+    telegram = ti.decode_cemi(ETS_LDATA)
+    assert telegram is not None
+    assert str(telegram.source_address) == "1.0.24"
+    assert str(telegram.destination_address) == "0/5/4"
+
+
+def test_decode_cemi_garbage_returns_none():
+    assert ti.decode_cemi(b"\x00\x01\x02") is None
+
+
+# ── De-dup key normalization ─────────────────────────────────────────────────
+
+
+def _stored(**kw) -> StoredTelegram:
+    base = dict(
+        source="1.1.1",
+        destination="1/2/3",
+        telegramtype="GroupValueWrite",
+        direction="Incoming",
+        dpt_main=1,
+        dpt_sub=1,
+        payload=None,
+        value=1.0,
+        raw_data="01",
+    )
+    base.update(kw)
+    return StoredTelegram(**base)
+
+
+def test_dedup_key_normalizes_aware_and_naive_timestamps():
+    aware = _stored(timestamp=datetime(2026, 3, 5, 1, 0, 0, tzinfo=timezone(timedelta(hours=1))))
+    naive_utc = _stored(timestamp=datetime(2026, 3, 5, 0, 0, 0))  # same instant, naive UTC
+    assert ti._dedup_key(aware) == ti._dedup_key(naive_utc)
+
+
+# ── Source grouping ──────────────────────────────────────────────────────────
+
+
+def test_group_sources_buckets_by_first_timestamp_date():
+    def _src(name, xml):
+        import io
+
+        return ti.ImportSource(name=name, open_stream=lambda x=xml: io.BytesIO(x.encode()))
+
+    day1 = '<CommunicationLog xmlns="http://knx.org/xml/telegrams/01"><Telegram Timestamp="2026-03-05T00:00:40.000Z" Service="L_Data.ind" RawData="2900BCE010180504010081" /></CommunicationLog>'
+    day2 = '<CommunicationLog xmlns="http://knx.org/xml/telegrams/01"><Telegram Timestamp="2026-03-06T00:00:40.000Z" Service="L_Data.ind" RawData="2900BCE010180504010081" /></CommunicationLog>'
+    groups = ti._group_sources([_src("lan.xml", day1), _src("tp1.xml", day2), _src("lan2.xml", day1)])
+    # Two dates → two groups; the two day-1 files land together.
+    assert len(groups) == 2
+    assert {len(g) for g in groups} == {1, 2}
+
+
+# ── Job lifecycle ────────────────────────────────────────────────────────────
+
+
+def test_import_job_to_dict_shape():
+    job = ti.ImportJob(filename="x.xml")
+    d = job.to_dict()
+    assert d["state"] == "running"
+    assert d["filename"] == "x.xml"
+    assert set(d) >= {
+        "id",
+        "telegrams_parsed",
+        "telegrams_imported",
+        "duplicates_skipped",
+        "acks_skipped",
+        "non_group_skipped",
+        "errors",
+        "finished_at",
+    }
+
+
+def test_cancel_import_returns_false_when_idle():
+    ti.current_job = None
+    assert ti.cancel_import() is False
+
+
+# ── Full import flow (window + idempotency de-dup, counters) ──────────────────
+
+# Two near-simultaneous busmon copies of the same telegram (window duplicate),
+# one distinct ETS L_Data telegram, one link-layer ACK (skipped).
+_IMPORT_XML = """<CommunicationLog xmlns="http://knx.org/xml/telegrams/01">
+  <Telegram Timestamp="2026-03-05T00:00:38.994Z" Service="L_Busmon.ind" RawData="2B090301030604BAD64193BC1012143DE3008000C8C3" />
+  <Telegram Timestamp="2026-03-05T00:00:39.000Z" Service="L_Busmon.ind" RawData="2B090301030604BAD64193BC1012143DE3008000C8C3" />
+  <Telegram Timestamp="2026-03-05T00:00:40.000Z" Service="L_Data.ind" RawData="2900BCE010180504010081" />
+  <Telegram Timestamp="2026-03-05T00:00:41.000Z" Service="L_Busmon.ind" RawData="2B090301040604BAD6A0ACCC" />
+</CommunicationLog>
+"""
+
+
+class _FakeStore:
+    """Minimal async store: accumulates saved telegrams, queries return them all."""
+
+    def __init__(self):
+        self.saved: list[StoredTelegram] = []
+
+    async def query(self, query, **kwargs):
+        return TelegramQueryResult(telegrams=list(self.saved), total_count=len(self.saved), limit_reached=False)
+
+    async def store_many(self, batch):
+        self.saved.extend(batch)
+
+
+def _write_temp_xml() -> str:
+    fd, path = tempfile.mkstemp(suffix=".xml")
+    os.write(fd, _IMPORT_XML.encode())
+    os.close(fd)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_run_import_counts_and_dedups():
+    store = _FakeStore()
+    job = ti.ImportJob(filename="log.xml")
+    await ti._run_import(store, _write_temp_xml(), "log.xml", job)
+
+    assert job.state == "done"
+    assert job.telegrams_parsed == 4
+    assert job.telegrams_imported == 2  # window-dup pair collapsed, ACK dropped
+    assert job.duplicates_skipped == 1  # the second busmon copy
+    assert job.acks_skipped == 1
+    assert job.errors == 0
+    assert len(store.saved) == 2
+    assert job.finished_at is not None
+
+    # Re-importing the same file is idempotent (layer-2 de-dup against the store).
+    job2 = ti.ImportJob(filename="log.xml")
+    await ti._run_import(store, _write_temp_xml(), "log.xml", job2)
+    assert job2.telegrams_imported == 0
+    assert job2.duplicates_skipped == 3
+    assert len(store.saved) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_import_cleans_up_temp_file():
+    store = _FakeStore()
+    path = _write_temp_xml()
+    await ti._run_import(store, path, "log.xml", ti.ImportJob(filename="log.xml"))
+    assert not os.path.exists(path)
+
+
+@pytest.mark.asyncio
+async def test_start_import_rejects_concurrent_job():
+    # A job in the "running" state blocks a second start (409 upstream).
+    ti.current_job = ti.ImportJob(filename="running.xml")
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            ti.start_import(_FakeStore(), "/tmp/does-not-matter.xml", "log2.xml")
+        # cancel flips the flag so a later start is allowed.
+        assert ti.cancel_import() is True
+        assert ti.current_job.cancel_requested is True
+    finally:
+        ti.current_job = None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,13 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useWebSocket, type Telegram } from './hooks/useWebSocket';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigCookie, writeSortConfigCookie } from './utils/sortConfig';
-import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor } from 'lucide-react';
+import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor, FolderInput } from 'lucide-react';
 import { getCookie, setCookie } from './utils/cookies';
 import { useTheme } from './hooks/useTheme';
 import { apiUrl, wsUrl } from './utils/basePath';
 import { HistoryLoader } from './components/HistoryLoader';
 import { HistorySearch } from './components/HistorySearch';
+import { ImportExportView } from './components/ImportExportView';
 import { Visualizer } from './components/Visualizer';
 import { FilterPanel } from './components/FilterPanel';
 import { ProjectUploadWizard } from './components/ProjectUploadWizard';
@@ -46,6 +47,7 @@ const NavDropdown = ({ activeTab, isSettingsOpen, onChange }: { activeTab: strin
   const items = [
     { id: 'live', label: 'Group Monitor', icon: LayoutDashboard },
     { id: 'history', label: 'History Search', icon: History },
+    { id: 'import', label: 'Import / Export', icon: FolderInput },
     { id: 'settings', label: 'Settings', icon: Settings }
   ];
 
@@ -120,7 +122,7 @@ const NavDropdown = ({ activeTab, isSettingsOpen, onChange }: { activeTab: strin
 
 function App() {
   const [theme, setTheme] = useTheme();
-  const [activeTab, setActiveTab] = useState<'live' | 'history'>('live');
+  const [activeTab, setActiveTab] = useState<'live' | 'history' | 'import'>('live');
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(true);
   const [isVisualizerOpen, setIsVisualizerOpen] = useState(false);
@@ -466,10 +468,10 @@ function App() {
               onChange={(id) => {
                 if (id === 'settings') {
                   setIsSettingsOpen(true);
-                  if (activeTab === 'history') setActiveTab('live');
+                  if (activeTab !== 'live') setActiveTab('live');
                 } else {
                   setIsSettingsOpen(false);
-                  setActiveTab(id as 'live' | 'history');
+                  setActiveTab(id as 'live' | 'history' | 'import');
                 }
               }}
             />
@@ -840,6 +842,8 @@ function App() {
               </div>
             </div>
           </div>
+        ) : activeTab === 'import' ? (
+          <ImportExportView />
         ) : (
           <HistorySearch
             visibleColumns={visibleColumns}

--- a/frontend/src/components/ImportExportView.tsx
+++ b/frontend/src/components/ImportExportView.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  FolderInput, Upload, Download, AlertTriangle, Loader2, CheckCircle2,
+  XCircle, Ban, FileArchive,
+} from 'lucide-react';
+import { apiUrl } from '../utils/basePath';
+
+// Mirrors ImportJob.to_dict() in backend/telegram_import.py plus the read_only flag.
+interface ImportStatus {
+  state: 'idle' | 'running' | 'done' | 'failed' | 'cancelled';
+  filename?: string;
+  files_total?: number;
+  files_done?: number;
+  current_file?: string;
+  telegrams_parsed?: number;
+  telegrams_imported?: number;
+  duplicates_skipped?: number;
+  acks_skipped?: number;
+  non_group_skipped?: number;
+  errors?: number;
+  error?: string | null;
+  read_only?: boolean;
+}
+
+const POLL_INTERVAL_MS = 500;
+
+const cardStyle: React.CSSProperties = {
+  padding: '1.5rem', borderRadius: '12px', border: '1px solid var(--border-color)',
+  background: 'var(--bg-subtle)', display: 'flex', flexDirection: 'column', gap: '1rem',
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '0.85rem', fontWeight: 600, color: 'var(--text-main)',
+  display: 'flex', alignItems: 'center', gap: '0.5rem',
+};
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+};
+
+export function ImportExportView() {
+  const [file, setFile] = useState<File | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [status, setStatus] = useState<ImportStatus>({ state: 'idle' });
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const pollRef = useRef<number | null>(null);
+
+  // Export filter state
+  const [startTime, setStartTime] = useState('');
+  const [endTime, setEndTime] = useState('');
+  const [sourceAddress, setSourceAddress] = useState('');
+  const [targetAddress, setTargetAddress] = useState('');
+  const [telegramType, setTelegramType] = useState('');
+
+  const readOnly = status.read_only === true;
+  const isRunning = status.state === 'running';
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch(apiUrl('/api/import/status'));
+      if (res.ok) setStatus(await res.json());
+    } catch {
+      // transient; next poll retries
+    }
+  }, []);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(() => {
+    if (pollRef.current !== null) return;
+    pollRef.current = window.setInterval(fetchStatus, POLL_INTERVAL_MS);
+  }, [fetchStatus]);
+
+  // Pick up any already-running job on mount (page-reload safe) and read the mode.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchStatus();
+    return stopPolling;
+  }, [fetchStatus, stopPolling]);
+
+  // Poll only while a job is running.
+  useEffect(() => {
+    if (isRunning) startPolling();
+    else stopPolling();
+  }, [isRunning, startPolling, stopPolling]);
+
+  const handleStart = async () => {
+    if (!file) return;
+    setError(null);
+    setStarting(true);
+    const form = new FormData();
+    form.append('file', file);
+    try {
+      const res = await fetch(apiUrl('/api/import'), { method: 'POST', body: form });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(typeof data.detail === 'string' ? data.detail : 'Import failed to start');
+      }
+      setStatus(data);
+      setFile(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed to start');
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    try {
+      await fetch(apiUrl('/api/import/cancel'), { method: 'POST' });
+      fetchStatus();
+    } catch {
+      // ignore; job will finish or the next poll reflects state
+    }
+  };
+
+  const handleFilePick = (picked: File | null) => {
+    setError(null);
+    if (picked && !/\.(xml|zip)$/i.test(picked.name)) {
+      setError('File must be a .xml or .zip telegram log.');
+      setFile(null);
+      return;
+    }
+    setFile(picked);
+  };
+
+  const handleExport = () => {
+    const params = new URLSearchParams();
+    if (startTime) params.set('start_time', new Date(startTime).toISOString());
+    if (endTime) params.set('end_time', new Date(endTime).toISOString());
+    if (sourceAddress.trim()) params.set('source_address', sourceAddress.trim());
+    if (targetAddress.trim()) params.set('target_address', targetAddress.trim());
+    if (telegramType.trim()) params.set('telegram_type', telegramType.trim());
+    const qs = params.toString();
+    window.location.href = apiUrl(`/api/export${qs ? `?${qs}` : ''}`);
+  };
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Header */}
+      <div style={{
+        padding: '0 1.25rem', height: '3.5rem', borderBottom: '1px solid var(--border-color)',
+        display: 'flex', alignItems: 'center', gap: '0.75rem', flexShrink: 0,
+      }}>
+        <FolderInput size={18} className="accent-primary" />
+        <span style={{ fontWeight: 600 }}>Import / Export</span>
+        <span style={{ fontSize: '0.8rem', color: 'var(--text-dim)' }}>
+          Offline analysis of ETS6 / Gira telegram logs
+        </span>
+      </div>
+
+      {/* Body */}
+      <div style={{ flex: 1, overflow: 'auto', padding: '1.5rem' }}>
+        <div style={{ maxWidth: 720, margin: '0 auto', display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+
+          {/* ── Import card ── */}
+          <div style={cardStyle}>
+            <div style={labelStyle}><Upload size={16} /> Import telegram log</div>
+            <p style={{ color: 'var(--text-dim)', fontSize: '0.85rem', margin: 0, lineHeight: 1.5 }}>
+              Upload an ETS6 group-monitor export (<code>.xml</code>) or a Gira data-logger
+              dump (<code>.zip</code> of daily XML files). Telegrams are decoded, de-duplicated
+              and added to the store, where every history and analysis feature works on them.
+            </p>
+
+            {readOnly ? (
+              <div style={{
+                display: 'flex', alignItems: 'flex-start', gap: '0.6rem', padding: '0.85rem 1rem',
+                background: 'rgba(234,179,8,0.08)', border: '1px solid rgba(234,179,8,0.3)',
+                borderRadius: '8px', color: '#eab308', fontSize: '0.85rem',
+              }}>
+                <AlertTriangle size={16} style={{ flexShrink: 0, marginTop: '1px' }} />
+                <span>Import is unavailable in read-only companion mode.</span>
+              </div>
+            ) : (
+              <>
+                <label
+                  onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}
+                  onDragLeave={() => setIsDragging(false)}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    setIsDragging(false);
+                    handleFilePick(e.dataTransfer.files?.[0] || null);
+                  }}
+                  style={{
+                    display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '0.5rem',
+                    padding: '1.75rem', borderRadius: '10px', cursor: isRunning ? 'not-allowed' : 'pointer',
+                    border: `1.5px dashed ${isDragging ? 'var(--accent-primary)' : 'var(--border-color)'}`,
+                    background: isDragging ? 'rgba(99,102,241,0.08)' : 'rgba(0,0,0,0.15)',
+                    transition: 'all 0.15s ease', opacity: isRunning ? 0.5 : 1,
+                  }}
+                >
+                  <FileArchive size={26} style={{ color: 'var(--text-dim)' }} />
+                  <span style={{ fontSize: '0.9rem', color: 'var(--text-main)', fontWeight: 500 }}>
+                    {file ? file.name : 'Drop a file here, or click to browse'}
+                  </span>
+                  <span style={{ fontSize: '0.78rem', color: 'var(--text-dim)' }}>
+                    {file ? formatBytes(file.size) : '.xml or .zip'}
+                  </span>
+                  <input
+                    type="file" accept=".xml,.zip" hidden disabled={isRunning}
+                    onChange={(e) => handleFilePick(e.target.files?.[0] || null)}
+                  />
+                </label>
+
+                <button
+                  onClick={handleStart}
+                  disabled={!file || isRunning || starting}
+                  style={{
+                    padding: '0.75rem', borderRadius: '8px', border: 'none',
+                    background: !file || isRunning || starting ? 'rgba(99,102,241,0.5)' : 'var(--accent-primary)',
+                    color: 'white', fontWeight: 600, fontSize: '0.95rem',
+                    cursor: !file || isRunning || starting ? 'not-allowed' : 'pointer',
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem',
+                  }}
+                >
+                  {starting
+                    ? <><Loader2 size={17} style={{ animation: 'spin 1s linear infinite' }} /> Starting…</>
+                    : <>Start import</>}
+                </button>
+              </>
+            )}
+
+            {error && (
+              <div style={{
+                display: 'flex', alignItems: 'flex-start', gap: '0.6rem', padding: '0.75rem 1rem',
+                background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)',
+                borderRadius: '8px', color: '#fca5a5', fontSize: '0.85rem',
+              }}>
+                <AlertTriangle size={16} style={{ flexShrink: 0, marginTop: '1px' }} />
+                <span>{error}</span>
+              </div>
+            )}
+          </div>
+
+          {/* ── Progress / result card ── */}
+          {status.state !== 'idle' && (
+            <div style={cardStyle}>
+              <div style={{ ...labelStyle, justifyContent: 'space-between' }}>
+                <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                  {isRunning && <Loader2 size={16} style={{ animation: 'spin 1s linear infinite' }} className="accent-primary" />}
+                  {status.state === 'done' && <CheckCircle2 size={16} style={{ color: 'var(--success, #22c55e)' }} />}
+                  {status.state === 'failed' && <XCircle size={16} style={{ color: '#ef4444' }} />}
+                  {status.state === 'cancelled' && <Ban size={16} style={{ color: 'var(--text-dim)' }} />}
+                  {isRunning ? 'Importing' : `Import ${status.state}`}
+                  {status.filename ? ` — ${status.filename}` : ''}
+                </span>
+                {isRunning && (
+                  <button
+                    onClick={handleCancel}
+                    style={{
+                      padding: '0.35rem 0.8rem', borderRadius: '6px', fontSize: '0.8rem',
+                      border: '1px solid var(--border-color)', background: 'transparent',
+                      color: 'var(--text-dim)', cursor: 'pointer', fontWeight: 500,
+                    }}
+                  >
+                    Cancel
+                  </button>
+                )}
+              </div>
+
+              {isRunning && (status.files_total ?? 0) > 0 && (
+                <div>
+                  <div style={{ fontSize: '0.78rem', color: 'var(--text-dim)', marginBottom: '0.35rem' }}>
+                    {status.current_file || `File ${status.files_done ?? 0} / ${status.files_total}`}
+                  </div>
+                  <div style={{ height: 6, borderRadius: 999, background: 'rgba(0,0,0,0.25)', overflow: 'hidden' }}>
+                    <div style={{
+                      height: '100%', borderRadius: 999, background: 'var(--accent-primary)',
+                      width: `${Math.round(((status.files_done ?? 0) / (status.files_total || 1)) * 100)}%`,
+                      transition: 'width 0.3s ease',
+                    }} />
+                  </div>
+                </div>
+              )}
+
+              <div style={{
+                display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: '0.75rem',
+              }}>
+                <Stat label="Imported" value={status.telegrams_imported} accent />
+                <Stat label="Parsed" value={status.telegrams_parsed} />
+                <Stat label="Duplicates" value={status.duplicates_skipped} />
+                <Stat label="ACKs skipped" value={status.acks_skipped} />
+                <Stat label="Non-group" value={status.non_group_skipped} />
+                <Stat label="Errors" value={status.errors} danger={(status.errors ?? 0) > 0} />
+              </div>
+
+              {status.state === 'failed' && status.error && (
+                <div style={{ fontSize: '0.82rem', color: '#fca5a5' }}>{status.error}</div>
+              )}
+            </div>
+          )}
+
+          {/* ── Export card ── */}
+          <div style={cardStyle}>
+            <div style={labelStyle}><Download size={16} /> Export to ETS6 XML</div>
+            <p style={{ color: 'var(--text-dim)', fontSize: '0.85rem', margin: 0, lineHeight: 1.5 }}>
+              Download stored telegrams as an ETS6-compatible <code>CommunicationLog</code>.
+              Leave filters blank to export everything.
+            </p>
+
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+              <Field label="Start time">
+                <input type="datetime-local" value={startTime} onChange={(e) => setStartTime(e.target.value)}
+                  className="glass-input" style={{ padding: '0.5rem', width: '100%' }} />
+              </Field>
+              <Field label="End time">
+                <input type="datetime-local" value={endTime} onChange={(e) => setEndTime(e.target.value)}
+                  className="glass-input" style={{ padding: '0.5rem', width: '100%' }} />
+              </Field>
+              <Field label="Source (PA)">
+                <input value={sourceAddress} onChange={(e) => setSourceAddress(e.target.value)}
+                  placeholder="e.g. 1.1.1" className="glass-input" style={{ padding: '0.5rem', width: '100%' }} />
+              </Field>
+              <Field label="Destination (GA)">
+                <input value={targetAddress} onChange={(e) => setTargetAddress(e.target.value)}
+                  placeholder="e.g. 1/2/3" className="glass-input" style={{ padding: '0.5rem', width: '100%' }} />
+              </Field>
+              <Field label="Type">
+                <input value={telegramType} onChange={(e) => setTelegramType(e.target.value)}
+                  placeholder="Write, Read, Response" className="glass-input" style={{ padding: '0.5rem', width: '100%' }} />
+              </Field>
+            </div>
+
+            <button
+              onClick={handleExport}
+              style={{
+                padding: '0.75rem', borderRadius: '8px', border: '1px solid var(--border-color)',
+                background: 'var(--bg-tag)', color: 'var(--text-main)', fontWeight: 600, fontSize: '0.95rem',
+                cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.5rem',
+              }}
+            >
+              <Download size={17} /> Download ETS6 XML
+            </button>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, accent, danger }: { label: string; value?: number; accent?: boolean; danger?: boolean }) {
+  return (
+    <div style={{
+      padding: '0.65rem 0.85rem', borderRadius: '8px', background: 'rgba(0,0,0,0.18)',
+      border: '1px solid var(--border-color)',
+    }}>
+      <div style={{
+        fontSize: '1.15rem', fontWeight: 700,
+        color: danger ? '#ef4444' : accent ? 'var(--accent-primary)' : 'var(--text-main)',
+      }}>
+        {(value ?? 0).toLocaleString()}
+      </div>
+      <div style={{ fontSize: '0.72rem', color: 'var(--text-dim)' }}>{label}</div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+      <label style={{ fontSize: '0.75rem', fontWeight: 600, color: 'var(--text-dim)' }}>{label}</label>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Implements #99: import historical KNX bus recordings (ETS6 group-monitor exports, Gira IP-Router data-logger dumps) into the telegram store for offline analysis, plus export of a telegram selection back to ETS6 XML. Full design in `DESIGN_IMPORT_EXPORT.md`.

## What's included

**Backend**
- `telegram_import.py` — TP1 busmonitor→cEMI adapter (incl. checksum), cEMI decode + enrichment through the shared parser pipeline, two-layer de-duplication (cross-media 200 ms window + idempotency against the store) and a cancellable background import job with progress counters.
- `telegram_export.py` — re-encodes stored telegrams to cEMI `L_Data.ind` via xknx (APCI reconstruction with DPT heuristics).
- `api.py` — `POST /api/import`, `GET /api/import/status`, `POST /api/import/cancel`, `GET /api/export` (streaming ETS6 XML). READ_ONLY-gated consistent with project upload.

**Frontend**
- New "Import / Export" view (`ImportExportView.tsx`) + `NavDropdown` entry: drag-drop upload, live progress polling (500 ms, page-reload-safe), read-only gating, and ETS6 export with time-range/source/destination/type filters.

**Tests**
- Importer (adapter/checksum/de-dup/job flow), exporter (APCI rebuild + export→re-import round trip), and the four API endpoints.
- Hardened `test_database_info`/`test_database_optimize` to pin `store.capabilities` so they no longer depend on the ambient DB backend — they were failing against Postgres, which correctly reports `supports_optimize=False` since the 0.7.1 "Reclaim space"/VACUUM fix (#143).

## Dependency

Requires **`knx-telegram-store==0.8.0`** (already published to PyPI), which adds the `formats.ets_xml` `CommunicationLog` container reader/writer this feature builds on. `requirements.txt` is bumped accordingly.

## Verification

- Backend suite green under **both** the default Postgres env and CI's sqlite env (101 passed).
- Frontend `tsc`, `eslint`, `vite build`, and `vitest` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)