### PR TITLE
feat: make the web listen port configurable (#147)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -65,6 +65,12 @@ POSTGRES_PORT=5432
 # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
 
+# Address and port the web interface listens on. Change BIND_PORT if 8000
+# clashes with another service on the same host. With docker-compose the
+# published host port follows BIND_PORT automatically.
+# BIND_HOST=0.0.0.0
+# BIND_PORT=8000
+
 # Full image name for the application (Docker/GHCR)
 # Used by docker-compose.yml
 APP_IMAGE=ghcr.io/martinhoefling/spectrumknx:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,9 @@ EXPOSE 8000
 
 # Environment variables
 ENV LOG_LEVEL=INFO
+ENV BIND_HOST=0.0.0.0
+ENV BIND_PORT=8000
 
-# Command to run the application
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Command to run the application. `exec` keeps uvicorn as PID 1 so it receives
+# signals for graceful shutdown; the shell form lets BIND_HOST/BIND_PORT expand.
+CMD ["sh", "-c", "exec uvicorn main:app --host \"$BIND_HOST\" --port \"$BIND_PORT\""]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The easiest way to run Spectrum KNX is with Docker Compose. This automatically p
 
 4. Access the web interface at `http://localhost:8000` (or `http://localhost:5173` in Dev mode).
 
+   > The listen port defaults to `8000`. Set `BIND_PORT` (and optionally
+   > `BIND_HOST`) in your `.env` if it clashes with another service.
+
 ## 📦 Debian Package & Windows
 
 No Docker needed — both packages run Spectrum KNX with a local SQLite database

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,4 +7,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+ENV BIND_HOST=0.0.0.0
+ENV BIND_PORT=8000
+
+# `exec` keeps uvicorn as PID 1 so it receives signals for graceful shutdown;
+# the shell form lets BIND_HOST/BIND_PORT expand.
+CMD ["sh", "-c", "exec uvicorn main:app --host \"$BIND_HOST\" --port \"$BIND_PORT\""]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,12 +22,14 @@ services:
       - POSTGRES_HOST=${POSTGRES_HOST:-db}
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - BIND_HOST=${BIND_HOST:-0.0.0.0}
+      - BIND_PORT=${BIND_PORT:-8000}
     env_file:
       - .env
     volumes:
       - knx_project_data:/project
     ports:
-      - "8000:8000"
+      - "${BIND_PORT:-8000}:${BIND_PORT:-8000}"
     depends_on:
       - db
     restart: unless-stopped


### PR DESCRIPTION
## Summary
Makes the web interface listen port configurable instead of hardcoded to `8000`, so it no longer clashes with other services on the same host.

The Docker deployment hardcoded uvicorn's `--port 8000`. This unifies on the `BIND_HOST`/`BIND_PORT` convention already used by the Debian service and Windows launcher, so every deployment method shares one knob.

## Changes
- **`Dockerfile` / `backend/Dockerfile`** — CMD expands `BIND_HOST`/`BIND_PORT` (defaults `0.0.0.0:8000`). Uses `sh -c "exec …"` so uvicorn stays PID 1 and keeps receiving signals for graceful shutdown.
- **`docker-compose.yml`** — passes `BIND_HOST`/`BIND_PORT` into the container and lets the published host port follow `BIND_PORT`.
- **`.env_example` / `README.md`** — document `BIND_HOST`/`BIND_PORT`.

The HA add-on port stays fixed at `8000` by design (internal to Ingress).

## Testing
`BIND_PORT=9100 docker compose config` confirms the container target, published port, and env var all resolve to `9100`; default remains `8000`.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)