### PR TITLE
fix: actionable error + docs for large zip imports failing on temp storage

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -76,6 +76,11 @@ LOG_LEVEL=INFO
 # false to keep SpectrumKNX strictly read-only.
 # KNX_ALLOW_WRITE=true
 
+# Directory for temporary upload files during telegram-log import. Defaults to
+# /tmp. Uploads are buffered here (~2x the compressed .zip); if /tmp is small in
+# your container, point this at a larger mounted volume for big imports.
+# TMPDIR=/project/tmp
+
 # Full image name for the application (Docker/GHCR)
 # Used by docker-compose.yml
 APP_IMAGE=ghcr.io/martinhoefling/spectrumknx:latest

--- a/DESIGN_IMPORT_EXPORT.md
+++ b/DESIGN_IMPORT_EXPORT.md
@@ -78,6 +78,26 @@ upload (.xml | .zip)
 * Zip entries are processed via `zipfile` streams — a multi-GB upload is decompressed
   incrementally, bounded by one day-group of telegrams in memory (≈100 k telegrams).
 
+### Temporary storage for uploads
+
+The **compressed** upload is written to disk twice before parsing begins: once by
+Starlette (spooled `UploadFile`, spills past 1 MB) and once by our own
+`NamedTemporaryFile` (`api.py`). Both land in the system temp dir — `$TMPDIR` if
+set, otherwise `/tmp`. The *uncompressed* size never hits disk (entries are
+streamed), so only the `.zip` matters: the temp filesystem needs roughly **2× the
+compressed archive size** free.
+
+In Docker/HA, `/tmp` is the container's writable layer (or a size-limited tmpfs if
+configured). If it runs out of space, the upload is truncated and parsing fails
+with a corrupt-archive error (e.g. `unpack requires a buffer of N bytes`). To give
+large imports more room, mount a bigger volume and point `TMPDIR` at it, e.g.:
+
+```yaml
+# docker-compose.yml (backend service)
+environment:
+  - TMPDIR=/project/tmp   # on the persisted knx_project_data volume
+```
+
 ### De-duplication (two layers)
 
 1. **Cross-media window de-dup** (within the import): key `(src, dst, apdu-bytes)` inside a

--- a/backend/telegram_import.py
+++ b/backend/telegram_import.py
@@ -13,6 +13,7 @@ import asyncio
 import heapq
 import logging
 import os
+import struct
 import uuid
 import zipfile
 from collections.abc import Callable, Iterator
@@ -148,9 +149,21 @@ class ImportSource:
 
 def _list_sources(path: str, filename: str) -> list[ImportSource]:
     if zipfile.is_zipfile(path):
-        archive = zipfile.ZipFile(path)
+        try:
+            archive = zipfile.ZipFile(path)
+            infos = archive.infolist()
+        except (zipfile.BadZipFile, struct.error, EOFError, OSError) as e:
+            # A struct/EOF error here usually means the archive is corrupt or was
+            # written only partially — commonly because the upload was truncated
+            # when the container's temp storage ran out of space. See the import
+            # docs for how to enlarge it (TMPDIR).
+            raise ValueError(
+                f"Could not read the zip archive ({e}). It may be corrupt or the upload "
+                f"was truncated — ensure the container has enough temp storage for large "
+                f"uploads (see the import docs)."
+            ) from e
         sources = []
-        for info in archive.infolist():
+        for info in infos:
             base = os.path.basename(info.filename)
             if info.is_dir() or not base.lower().endswith(".xml") or base.startswith("."):
                 continue

--- a/backend/tests/test_telegram_import.py
+++ b/backend/tests/test_telegram_import.py
@@ -10,11 +10,11 @@ import tempfile
 from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
+from knx_telegram_store.formats import RawTelegramRecord
 
 import knx_daemon
 import telegram_import as ti
 from knx_telegram_store import StoredTelegram, TelegramQueryResult
-from knx_telegram_store.formats import RawTelegramRecord
 
 
 @pytest.fixture(autouse=True)
@@ -241,3 +241,36 @@ async def test_start_import_rejects_concurrent_job():
         assert ti.current_job.cancel_requested is True
     finally:
         ti.current_job = None
+
+
+def test_list_sources_corrupt_zip_raises_actionable_error(monkeypatch, tmp_path):
+    """A zip that passes is_zipfile but fails to parse (e.g. truncated central
+    directory) surfaces a clear message instead of a raw struct.error."""
+    import struct
+    import zipfile
+
+    fake = tmp_path / "corrupt.zip"
+    fake.write_bytes(b"PK\x03\x04corrupt")
+
+    monkeypatch.setattr(ti.zipfile, "is_zipfile", lambda _p: True)
+
+    def _boom(*_a, **_k):
+        raise struct.error("unpack requires a buffer of 4 bytes")
+
+    monkeypatch.setattr(ti.zipfile, "ZipFile", _boom)
+
+    with pytest.raises(ValueError, match="Could not read the zip archive"):
+        ti._list_sources(str(fake), "corrupt.zip")
+
+    # sanity: real BadZipFile is also wrapped
+    monkeypatch.setattr(ti.zipfile, "ZipFile", lambda *_a, **_k: (_ for _ in ()).throw(zipfile.BadZipFile("bad")))
+    with pytest.raises(ValueError, match="Could not read the zip archive"):
+        ti._list_sources(str(fake), "corrupt.zip")
+
+
+def test_list_sources_single_xml_passthrough(tmp_path):
+    xml = tmp_path / "log.xml"
+    xml.write_bytes(b"<CommunicationLog/>")
+    sources = ti._list_sources(str(xml), "log.xml")
+    assert len(sources) == 1
+    assert sources[0].name == "log.xml"


### PR DESCRIPTION
## Summary
Large telegram-log **zip** imports could fail with a cryptic `unpack requires a buffer of N bytes` (a `struct` error from Python's `zipfile`). Investigation showed the archive itself is a valid multi-GB / many-entry ZIP64 — Python reads those fine. The real cause is the **compressed upload being truncated when the container's temp storage runs out of space**.

### Where uploads are written
The compressed `.zip` is buffered to disk **twice** before parsing, both in the system temp dir (`$TMPDIR`, else `/tmp`):
1. Starlette's spooled `UploadFile` (spills past 1 MB), then
2. our `NamedTemporaryFile` (`api.py`).

The *uncompressed* size never hits disk (entries stream), so only the `.zip` matters — the temp filesystem needs roughly **2× the compressed archive**. In Docker/HA, `/tmp` is the container's writable layer (or a size-limited tmpfs), which is easy to exhaust with big uploads.

## Changes
- **`telegram_import._list_sources`**: wrap the zip `open`/`infolist` and turn `BadZipFile`/`struct.error`/`EOFError`/`OSError` into a clear, actionable message (corrupt archive or truncated upload → check temp storage) instead of the raw struct error.
- **Docs**: new "Temporary storage for uploads" section in `DESIGN_IMPORT_EXPORT.md` (where data goes, ~2× sizing, `TMPDIR` override onto a larger mounted volume); `TMPDIR` documented in `.env_example`.
- **Tests**: corrupt-zip → actionable `ValueError`; single-XML passthrough.

## Workaround for users hitting this
Point `TMPDIR` at a larger mounted volume, e.g. in `docker-compose.yml`:
```yaml
environment:
  - TMPDIR=/project/tmp   # on the persisted knx_project_data volume
```

## Testing
Full backend suite: 122 pass. Ruff clean.

Note: this makes the failure **diagnosable** and documents the fix; it does not itself enlarge the container's storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)