### PR TITLE
fix: prevent header brand overlapping toolbar metrics on narrow windows

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -461,9 +461,9 @@ function App() {
       <main style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', flex: 1, borderRadius: '12px' }} className="glass">
 
         {/* === GLOBAL HEADER === */}
-        <div style={{ padding: '1rem 1.25rem', borderBottom: '1px solid var(--border-color)', display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexShrink: 0, background: 'rgba(0,0,0,0.2)' }}>
+        <div style={{ padding: '1rem 1.25rem', borderBottom: '1px solid var(--border-color)', display: 'flex', alignItems: 'center', flexShrink: 0, background: 'rgba(0,0,0,0.2)' }}>
           {/* Left: App Section Dropdown */}
-          <div style={{ display: 'flex', alignItems: 'center', zIndex: 50 }}>
+          <div style={{ display: 'flex', alignItems: 'center', flexShrink: 0, zIndex: 50 }}>
             <NavDropdown
               activeTab={activeTab}
               isSettingsOpen={isSettingsOpen}
@@ -479,14 +479,16 @@ function App() {
             />
           </div>
 
-          {/* Center: Brand */}
-          <div style={{ display: 'flex', alignItems: 'center', gap: '0.65rem', position: 'absolute', left: '50%', transform: 'translateX(-50%)' }}>
-            <img src={`${import.meta.env.BASE_URL}logo.svg`} alt="Spectrum KNX" style={{ width: 22, height: 22 }} />
-            <h1 style={{ fontSize: '1.25rem', fontWeight: 700, margin: 0, letterSpacing: '-0.02em' }}>Spectrum KNX</h1>
+          {/* Center: Brand — flexible middle column, clips gracefully instead of overlapping the actions */}
+          <div style={{ flex: '1 1 0', minWidth: 0, display: 'flex', justifyContent: 'center', alignItems: 'center', overflow: 'hidden', padding: '0 0.75rem', pointerEvents: 'none' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.65rem', flexShrink: 0 }}>
+              <img src={`${import.meta.env.BASE_URL}logo.svg`} alt="Spectrum KNX" style={{ width: 22, height: 22 }} />
+              <h1 style={{ fontSize: '1.25rem', fontWeight: 700, margin: 0, letterSpacing: '-0.02em', whiteSpace: 'nowrap' }}>Spectrum KNX</h1>
+            </div>
           </div>
 
           {/* Right: Actions */}
-          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+          <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexShrink: 0 }}>
             {activeTab === 'live' && !isSettingsOpen && (
               <>
                 {/* Embedded Stats */}


### PR DESCRIPTION
## Problem

On narrow windows the **Spectrum KNX** brand in the global header collided with the metrics block (Rate / Buffer / WS), looking broken.

The brand was **absolutely centered** (`position: absolute; left: 50%; transform: translateX(-50%)`), so it reserved zero layout width. The right-hand toolbar (stats + ~9 action icons, ~800px wide) is much wider than the left dropdown, so as the window narrowed it slid leftward under the centered brand and overlapped it.

## Fix

Convert the header to a proper three-column flex layout:

- **Left** (nav dropdown) and **right** (actions) → `flexShrink: 0`, keep their intrinsic size.
- **Brand** → in-flow flexible middle column (`flex: 1 1 0; minWidth: 0; overflow: hidden; justifyContent: center`). It stays centered within the gap between the two sides and **clips cleanly** at very narrow widths instead of overlapping the metrics.
- `pointerEvents: none` on the brand so it can never intercept toolbar clicks.
- Dropped the now-redundant `justifyContent: space-between` on the header.

## Testing

- `npx tsc --noEmit` passes.
- Verified in the running app by dragging the window narrow — brand no longer overlaps the metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)