### PR TITLE
fix: store telegrams sent to the KNX bus (#161)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -59,6 +59,7 @@ def _build_telegram_response(telegrams: list) -> list:
             "timestamp": t.timestamp,
             "source_address": t.source,
             "target_address": t.destination,
+            "direction": t.direction,
             "telegram_type": t.telegramtype,
             "dpt_main": t.dpt_main,
             "dpt_sub": t.dpt_sub,

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -8,6 +8,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBase, DPTBinary
 from xknx.io import ConnectionConfig, ConnectionType, SecureConfig
 from xknx.telegram import Telegram as XknxTelegram
+from xknx.telegram import TelegramDirection
 from xknx.telegram.address import GroupAddress, IndividualAddress
 from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
 
@@ -108,7 +109,8 @@ async def _reconnect_knx():
         }
         xknx_instance.group_address_dpt.set(dpt_dict)
 
-    xknx_instance.telegram_queue.register_telegram_received_cb(telegram_received_cb)
+    # match_for_outgoing=True so telegrams we send to the bus are stored/broadcast too (#161).
+    xknx_instance.telegram_queue.register_telegram_received_cb(telegram_received_cb, match_for_outgoing=True)
     try:
         await xknx_instance.start()
         logger.info("KNX Daemon reconnected to bus successfully.")
@@ -164,6 +166,7 @@ async def process_telegram_async(telegram: XknxTelegram):
         source_addr = str(telegram.source_address)
         target_addr = str(telegram.destination_address) if telegram.destination_address else "0/0/0"
         telegram_type_name = type(telegram.payload).__name__
+        direction = "Outgoing" if telegram.direction == TelegramDirection.OUTGOING else "Incoming"
 
         value_numeric, value_json, raw_data, dpt_str, dpt_main, dpt_sub, unit, value_formatted, raw_hex = (
             parse_telegram_payload(telegram, xknx_instance)
@@ -180,7 +183,7 @@ async def process_telegram_async(telegram: XknxTelegram):
                 source=source_addr,
                 destination=target_addr,
                 telegramtype=telegram_type_name,
-                direction="Incoming",  # Default for daemon received telegrams
+                direction=direction,
                 dpt_main=dpt_main,
                 dpt_sub=dpt_sub,
                 payload=value_json,
@@ -199,6 +202,7 @@ async def process_telegram_async(telegram: XknxTelegram):
             "source_name": source_name,
             "target_address": target_addr,
             "target_name": target_name,
+            "direction": direction,
             "telegram_type": telegram_type_name,
             "simplified_type": get_simplified_type(telegram_type_name),
             "dpt": dpt_str,
@@ -476,7 +480,8 @@ async def knx_startup():
         }
         xknx_instance.group_address_dpt.set(dpt_dict)
 
-    xknx_instance.telegram_queue.register_telegram_received_cb(telegram_received_cb)
+    # match_for_outgoing=True so telegrams we send to the bus are stored/broadcast too (#161).
+    xknx_instance.telegram_queue.register_telegram_received_cb(telegram_received_cb, match_for_outgoing=True)
     try:
         await xknx_instance.start()
         logger.info("KNX Daemon connected to bus and listening.")

--- a/backend/tests/test_knx_daemon.py
+++ b/backend/tests/test_knx_daemon.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from xknx.dpt import DPTBinary
 from xknx.telegram import Telegram as XknxTelegram
+from xknx.telegram import TelegramDirection
 from xknx.telegram.address import GroupAddress, IndividualAddress
 
 from knx_daemon import process_telegram_async, telegram_received_cb
@@ -19,9 +20,12 @@ async def test_process_telegram_async(mock_parse, mock_broadcast, mock_store):
     # value_numeric, value_json, raw_data, dpt_str, dpt_main, dpt_sub, unit, value_formatted, raw_hex
     mock_parse.return_value = (1.0, True, b"\x01", "1.001", 1, 1, "on/off", "On", "01")
 
-    # Create a dummy xknx telegram
+    # Create a dummy xknx telegram received from the bus
     telegram = XknxTelegram(
-        source_address=IndividualAddress("1.1.1"), destination_address=GroupAddress("1/1/1"), payload=DPTBinary(1)
+        source_address=IndividualAddress("1.1.1"),
+        destination_address=GroupAddress("1/1/1"),
+        payload=DPTBinary(1),
+        direction=TelegramDirection.INCOMING,
     )
 
     # Run the function
@@ -43,6 +47,35 @@ async def test_process_telegram_async(mock_parse, mock_broadcast, mock_store):
     assert broadcast_data["target_address"] == "1/1/1"
     assert broadcast_data["value_numeric"] == 1.0
     assert broadcast_data["value_formatted"] == "On"
+    # Incoming is the default direction for telegrams received from the bus.
+    assert stored_telegram.direction == "Incoming"
+    assert broadcast_data["direction"] == "Incoming"
+
+
+@pytest.mark.asyncio
+@patch("knx_daemon.store.store", new_callable=AsyncMock)
+@patch("knx_daemon.manager.broadcast", new_callable=AsyncMock)
+@patch("knx_daemon.parse_telegram_payload")
+async def test_process_telegram_async_outgoing_is_stored(mock_parse, mock_broadcast, mock_store):
+    """Telegrams we send to the bus (#161) are stored and broadcast as Outgoing."""
+    mock_parse.return_value = (1.0, True, b"\x01", "1.001", 1, 1, "on/off", "On", "01")
+
+    telegram = XknxTelegram(
+        source_address=IndividualAddress("1.1.1"),
+        destination_address=GroupAddress("1/1/1"),
+        payload=DPTBinary(1),
+        direction=TelegramDirection.OUTGOING,
+    )
+
+    await process_telegram_async(telegram)
+
+    assert mock_store.called
+    stored_telegram = mock_store.call_args[0][0]
+    assert stored_telegram.direction == "Outgoing"
+
+    assert mock_broadcast.called
+    broadcast_data = mock_broadcast.call_args[0][0]
+    assert broadcast_data["direction"] == "Outgoing"
 
 
 @patch("knx_daemon.asyncio.get_running_loop")
@@ -85,6 +118,10 @@ async def test_knx_startup_success(
     mock_store_init.assert_called_once()
     mock_store_start.assert_called_once()
     mock_xknx_instance.start.assert_called_once()
+    # The received callback must also fire for outgoing telegrams so sent
+    # telegrams are stored/broadcast (#161).
+    _, kwargs = mock_xknx_instance.telegram_queue.register_telegram_received_cb.call_args
+    assert kwargs.get("match_for_outgoing") is True
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/TelegramLog.tsx
+++ b/frontend/src/components/TelegramLog.tsx
@@ -235,7 +235,7 @@ export const TelegramLog: React.FC<TelegramLogProps> = ({ telegrams, isConnected
                     <div style={{ color: getTypeColor(t.simplified_type), fontWeight: 600, fontSize: '0.75rem', textTransform: 'uppercase' }}>
                       {t.simplified_type || t.telegram_type}
                     </div>
-                    <div style={{ fontSize: '0.65rem', color: '#10b981', marginTop: '0.1rem', opacity: 0.8 }}>Incoming</div>
+                    <div style={{ fontSize: '0.65rem', color: t.direction === 'Outgoing' ? '#f59e0b' : '#10b981', marginTop: '0.1rem', opacity: 0.8 }}>{t.direction === 'Outgoing' ? 'Outgoing' : 'Incoming'}</div>
                   </td>
                 )}
 

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -317,7 +317,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                 <X className="cancel-icon" size={12} />
               </button>
             </div>
-            <div style={{ fontSize: '0.65rem', color: '#10b981', marginTop: '0.1rem', opacity: 0.8 }}>Incoming</div>
+            <div style={{ fontSize: '0.65rem', color: t.direction === 'Outgoing' ? '#f59e0b' : '#10b981', marginTop: '0.1rem', opacity: 0.8 }}>{t.direction === 'Outgoing' ? 'Outgoing' : 'Incoming'}</div>
           </div>
         );
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -6,6 +6,7 @@ export interface Telegram {
   source_name?: string | null;
   target_address: string;
   target_name?: string | null;
+  direction?: string | null;
   telegram_type: string;
   simplified_type?: string | null;
   dpt: string | null;


### PR DESCRIPTION
## Summary

Fixes #161. Telegrams sent from the Group Monitor via the "send to bus" feature were only queued for transmission and never persisted or shown, so the telegram log was incomplete — sent messages often trigger further bus traffic, which then looked unexplained.

## Changes

- **`knx_daemon.py`**: register the received callback with `match_for_outgoing=True`, so xknx invokes our storing/broadcasting handler for outgoing telegrams (both `send` and `read`) as well as incoming ones. The stored/broadcast `direction` is now derived from the telegram's actual `TelegramDirection` instead of being hardcoded to `"Incoming"`.
- **`api.py`**: include `direction` in the history serializer so stored sent telegrams report the right direction.
- **Frontend**: add `direction` to the `Telegram` type and label each row by its real direction (Outgoing shown in amber) instead of always "Incoming", in both the live log and the history table.

## Testing

- `pytest` backend suite — 123 passed (added coverage for outgoing telegrams being stored/broadcast as `Outgoing`, and that startup registers the callback with `match_for_outgoing=True`).
- Frontend `tsc --noEmit`, `lint` (0 errors), and `vitest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)