### PR TITLE
fix: enable ETS project upload in companion mode so filtering works (#159)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -807,6 +807,8 @@ function App() {
                     counts={filterCounts}
                     onQuickLastSeen={handleQuickLastSeen}
                     mode="live"
+                    projectLoaded={projectStatus?.project_loaded}
+                    onUploadProject={() => setIsSettingsOpen(true)}
                   />
                 </div>
               </div>
@@ -870,6 +872,7 @@ function App() {
             activeFilters={activeFilters}
             onFiltersChange={handleFiltersChange}
             onOpenSettings={() => setIsSettingsOpen(true)}
+            projectLoaded={projectStatus?.project_loaded}
             selectedVisualizationTargets={selectedVisualizationTargets}
             onVisualizationTargetsChange={setSelectedVisualizationTargets}
           />

--- a/frontend/src/components/FilterPanel.test.tsx
+++ b/frontend/src/components/FilterPanel.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { FilterPanel } from './FilterPanel';
+import { DEFAULT_FILTERS, type FilterOptions } from '../types/filters';
+
+const EMPTY_OPTIONS: FilterOptions = {
+  sources: [], targets: [], types: ['Write', 'Read', 'Response'], dpts: [],
+  ga_group_names: {}, pa_line_names: {},
+};
+
+test('shows the no-project notice and CTA when no project is loaded', () => {
+  const onUploadProject = vi.fn();
+  render(
+    <FilterPanel
+      options={EMPTY_OPTIONS}
+      activeFilters={DEFAULT_FILTERS}
+      onFiltersChange={() => {}}
+      mode="history"
+      projectLoaded={false}
+      onUploadProject={onUploadProject}
+    />
+  );
+
+  expect(screen.getByText(/No ETS project loaded/i)).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Upload ETS project/i }));
+  expect(onUploadProject).toHaveBeenCalledTimes(1);
+});
+
+test('hides the notice while project status is unknown', () => {
+  render(
+    <FilterPanel
+      options={EMPTY_OPTIONS}
+      activeFilters={DEFAULT_FILTERS}
+      onFiltersChange={() => {}}
+      mode="history"
+    />
+  );
+  expect(screen.queryByText(/No ETS project loaded/i)).not.toBeInTheDocument();
+});
+
+test('hides the notice when a project is loaded', () => {
+  render(
+    <FilterPanel
+      options={EMPTY_OPTIONS}
+      activeFilters={DEFAULT_FILTERS}
+      onFiltersChange={() => {}}
+      mode="live"
+      projectLoaded={true}
+    />
+  );
+  expect(screen.queryByText(/No ETS project loaded/i)).not.toBeInTheDocument();
+});

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Search, ChevronDown, ChevronRight, SlidersHorizontal, X, Clock } from 'lucide-react';
+import { Search, ChevronDown, ChevronRight, SlidersHorizontal, X, Clock, FolderInput, AlertTriangle } from 'lucide-react';
 import {
   type FilterOptions,
   type ActiveFilters,
@@ -19,6 +19,15 @@ interface FilterPanelProps {
   counts?: FilterCounts;
   mode: 'live' | 'history';
   onQuickLastSeen?: (address: string, mode: 'ga' | 'pa') => void;
+  /**
+   * Whether an ETS project is loaded. Source/target/DPT options are derived from
+   * the project, so when it's absent (e.g. Home Assistant companion mode without
+   * an uploaded project) filtering by them is unavailable. `undefined` means the
+   * status isn't known yet, in which case no notice is shown.
+   */
+  projectLoaded?: boolean;
+  /** Opens the project upload flow (Settings). Enables the notice's CTA button. */
+  onUploadProject?: () => void;
 }
 
 interface SectionProps {
@@ -147,8 +156,14 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   counts,
   mode,
   onQuickLastSeen,
+  projectLoaded,
+  onUploadProject,
 }) => {
   const [search, setSearch] = useState('');
+
+  // Source/target/DPT options come from the ETS project. Without one, those
+  // filters are empty and searching them turns up nothing — surface why.
+  const showNoProjectNotice = projectLoaded === false;
 
   const q = search.toLowerCase();
 
@@ -339,6 +354,42 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
 
       {/* Scrollable options */}
       <div style={{ flex: 1, overflowY: 'auto' }}>
+
+        {/* No-project notice — source/target/DPT filters need an ETS project */}
+        {showNoProjectNotice && (
+          <div style={{
+            margin: '0.75rem', padding: '0.85rem',
+            border: '1px solid var(--border-color)', borderRadius: '8px',
+            background: 'var(--bg-subtle)',
+          }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', marginBottom: '0.4rem' }}>
+              <AlertTriangle size={14} style={{ color: 'var(--warning, #f59e0b)', flexShrink: 0 }} />
+              <span style={{ fontSize: '0.8125rem', fontWeight: 700, color: 'var(--text-main)' }}>
+                No ETS project loaded
+              </span>
+            </div>
+            <div style={{ fontSize: '0.75rem', color: 'var(--text-dim)', lineHeight: 1.5, marginBottom: onUploadProject ? '0.7rem' : 0 }}>
+              Filtering by source, target and DPT needs the group and device names
+              from your ETS project. Upload a <code>.knxproj</code> file to enable it.
+            </div>
+            {onUploadProject && (
+              <button
+                onClick={onUploadProject}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: '0.4rem',
+                  width: '100%', justifyContent: 'center',
+                  padding: '0.5rem 0.65rem', borderRadius: '6px', cursor: 'pointer',
+                  border: '1px solid var(--accent-primary)',
+                  background: 'rgba(99,102,241,0.12)', color: 'var(--accent-primary)',
+                  fontSize: '0.78rem', fontWeight: 600, fontFamily: 'inherit',
+                }}
+              >
+                <FolderInput size={14} />
+                Upload ETS project
+              </button>
+            )}
+          </div>
+        )}
 
         {/* Source */}
         {filteredSources.length > 0 && (

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -27,13 +27,14 @@ interface HistorySearchProps {
   activeFilters: ActiveFilters;
   onFiltersChange: (f: ActiveFilters) => void;
   onOpenSettings: () => void;
+  projectLoaded?: boolean;
   selectedVisualizationTargets: string[];
   onVisualizationTargetsChange: (targets: string[] | ((prev: string[]) => string[])) => void;
 }
 
 export const HistorySearch: React.FC<HistorySearchProps> = ({
   visibleColumns, loadLimit, filterOptions, activeFilters, onFiltersChange, onOpenSettings,
-  selectedVisualizationTargets, onVisualizationTargetsChange
+  projectLoaded, selectedVisualizationTargets, onVisualizationTargetsChange
 }) => {
   const [telegrams, setTelegrams] = useState<Telegram[]>([]);
   const [isLoaderOpen, setIsLoaderOpen] = useState(false);
@@ -265,6 +266,8 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
               activeFilters={activeFilters}
               onFiltersChange={onFiltersChange}
               mode="history"
+              projectLoaded={projectLoaded}
+              onUploadProject={onOpenSettings}
             />
           </div>
         </div>

--- a/ha-addon/rootfs/etc/services.d/postgres/run
+++ b/ha-addon/rootfs/etc/services.d/postgres/run
@@ -10,15 +10,12 @@ fi
 
 # ── Persistent data directory ─────────────────────────────────────────────────
 # Home Assistant persists /data across container restarts and updates.
-# We store PostgreSQL data and KNX project files there.
+# We store PostgreSQL data there. The KNX project directory (/project) is set up
+# by the spectrum_knx service so it also exists in SQLite/companion modes.
 DATADIR="/data/postgres"
 mkdir -p "$DATADIR"
 chown -R postgres:postgres "$DATADIR"
 chmod 700 "$DATADIR"
-
-# Symlink /project → /data/project so the backend can use its default path
-mkdir -p /data/project
-ln -sfn /data/project /project
 
 if [ ! -s "$DATADIR/PG_VERSION" ]; then
     bashio::log.info "Initializing database..."

--- a/ha-addon/rootfs/etc/services.d/spectrum_knx/run
+++ b/ha-addon/rootfs/etc/services.d/spectrum_knx/run
@@ -51,6 +51,14 @@ if [ -z "$LOG_LEVEL" ]; then
     export LOG_LEVEL="INFO"
 fi
 
+# Persist uploaded ETS project files across restarts/updates. Home Assistant
+# keeps /data across the container lifecycle, so point the backend's default
+# project directory (/project) at it. This runs in every mode — including
+# companion mode, where it's the only writable place to store the project so
+# group/individual address names (and thus filtering) become available.
+mkdir -p /data/project
+ln -sfn /data/project /project
+
 # Ingress support path (provided by Home Assistant)
 if bashio::config.has_value 'ingress_port'; then
     # We serve directly on the port and Home Assistant handles the Ingress proxying


### PR DESCRIPTION
## Summary

Fixes #159. In Home Assistant companion mode the filter panel found nothing no matter what was typed. Per @martinhoefling's guidance on the issue, the fix is to make the ETS project uploadable in companion mode and to tell the user when filtering is disabled because no project is loaded.

## Root cause

The Source/Target/DPT filter options are derived from the loaded ETS project (`/api/filter-options` returns empty lists when no project is loaded). Companion mode never had a usable project, for two reasons:

1. **No writable place to store an uploaded project.** The addon symlinked the backend's default project directory (`/project` → persistent `/data/project`) only inside the **postgres** service. In SQLite/companion mode that service `exec sleep infinity` *before* reaching the symlink, so `/project` was never writable — `upload_writable` came back `false` and the Settings UI showed "Project file is not writable", with no way to upload.
2. **No feedback in the UI.** With no project, the filter panel simply rendered empty Source/Target/DPT sections, so it looked broken.

## Changes

- **`ha-addon/rootfs`**: move the `/project → /data/project` symlink setup from the `postgres` service into the `spectrum_knx` service, so it runs in **every** mode (postgres, sqlite, companion) before the backend starts. `/data` is persistent for HA addons, so uploaded projects now survive restarts and the upload path is writable in companion mode.
- **`FilterPanel`**: when `projectLoaded === false`, show a notice explaining that source/target/DPT filtering needs an ETS project, with an "Upload ETS project" button that opens the upload flow in Settings. Threaded through both the live Group Monitor (`App.tsx`) and History (`HistorySearch.tsx`). The status is `undefined` until known, so the notice never flashes on load.

After a successful upload the app already reloads, so the notice clears and filters populate.

## Testing

- Frontend `tsc --noEmit` clean, `lint` 0 errors, `vitest` 10 passed — added `FilterPanel.test.tsx` covering the notice/CTA behaviour (shown + clickable when no project, hidden when loaded or unknown).
- `bash -n` on both changed run scripts.

## Note

The companion addon needs no config change — `/data` is always mounted and persistent for HA addons. Left the addon `CHANGELOG.md`/version bumps to the maintainer's release flow (consistent with #162).

🤖 Generated with [Claude Code](https://claude.com/claude-code)