### PR TITLE
feat: show DPT name in building structure view (#160)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -437,12 +437,18 @@ def _build_ko(co: dict, gas: dict) -> dict:
     group_addresses = [
         {"address": ga, "name": gas.get(ga, {}).get("name", "")} for ga in co.get("group_address_links") or []
     ]
+    # Resolve each DPT's descriptive name (e.g. "5.001 - Percent") so the building
+    # view can show it like the group monitor does, not just the raw numbers.
+    dpts = [
+        {"main": d.get("main"), "sub": d.get("sub"), "name": format_dpt_name(d.get("main"), d.get("sub"))[0]}
+        for d in co.get("dpts") or []
+    ]
     return {
         "number": co.get("number"),
         "name": co.get("name", ""),
         "text": co.get("text", ""),
         "function_text": co.get("function_text", ""),
-        "dpts": co.get("dpts") or [],
+        "dpts": dpts,
         "flags": co.get("flags") or {},
         "group_addresses": group_addresses,
     }

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -113,7 +113,13 @@ def test_get_building_with_project():
             },
         },
         "communication_objects": {
-            "O-1": {"number": 1, "name": "Switch", "text": "On/Off", "group_address_links": ["1/2/3"]},
+            "O-1": {
+                "number": 1,
+                "name": "Switch",
+                "text": "On/Off",
+                "dpts": [{"main": 1, "sub": 1}],
+                "group_address_links": ["1/2/3"],
+            },
             # No GA links → must be omitted.
             "O-2": {"number": 2, "name": "Unused", "text": "", "group_address_links": []},
             # Linked but not in any channel → unassigned KO list.
@@ -143,6 +149,8 @@ def test_get_building_with_project():
     assert device["channels"][0]["name"] == "Channel A"
     assert device["channels"][0]["kos"][0]["number"] == 1
     assert device["channels"][0]["kos"][0]["group_addresses"][0] == {"address": "1/2/3", "name": "Light On/Off"}
+    # DPTs carry a resolved descriptive name for the building view (#160).
+    assert device["channels"][0]["kos"][0]["dpts"] == [{"main": 1, "sub": 1, "name": "1.001 - Switch"}]
     assert len(device["kos"]) == 1
     assert device["kos"][0]["number"] == 3
 

--- a/frontend/src/components/BuildingOverlay.tsx
+++ b/frontend/src/components/BuildingOverlay.tsx
@@ -17,7 +17,7 @@ interface Ko {
   name: string;
   text: string;
   function_text: string;
-  dpts: { main: number; sub: number | null }[];
+  dpts: { main: number; sub: number | null; name?: string | null }[];
   group_addresses: GaRef[];
 }
 
@@ -109,10 +109,20 @@ const spaceMatches = (s: SpaceNode, q: string): boolean =>
   s.spaces.some(sub => spaceMatches(sub, q)) ||
   s.devices.some(d => deviceMatches(d, q));
 
-const formatDpt = (dpts: { main: number; sub: number | null }[]): string | null => {
+const formatDpt = (
+  dpts: { main: number; sub: number | null; name?: string | null }[]
+): { label: string; name: string | null } | null => {
   if (!dpts || dpts.length === 0) return null;
   const d = dpts[0];
-  return d.sub != null ? `DPT ${d.main}.${String(d.sub).padStart(3, '0')}` : `DPT ${d.main}`;
+  const label = d.sub != null ? `DPT ${d.main}.${String(d.sub).padStart(3, '0')}` : `DPT ${d.main}`;
+  // Backend names read like "5.001 - Percent"; keep only the descriptive part
+  // since the numeric label is already shown alongside it.
+  let name: string | null = null;
+  if (d.name) {
+    const sep = d.name.indexOf(' - ');
+    name = sep >= 0 ? d.name.slice(sep + 3) : null;
+  }
+  return { label, name };
 };
 
 // ── Row primitives ──────────────────────────────────────────────────────────────
@@ -143,7 +153,7 @@ const KoRow: React.FC<{
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
 }> = ({ ko, depth, onFilterGAs, onLastSeen }) => {
-  const dptLabel = formatDpt(ko.dpts);
+  const dpt = formatDpt(ko.dpts);
   const gaAddresses = ko.group_addresses.map(g => g.address);
   const nameText = ko.text || ko.name;
   const label = (nameText && ko.function_text && nameText !== ko.function_text)
@@ -180,10 +190,26 @@ const KoRow: React.FC<{
           ))}
         </div>
       </div>
-      {dptLabel && (
-        <span style={{ fontSize: '0.65rem', color: 'var(--text-dim)', flexShrink: 0, whiteSpace: 'nowrap' }}>
-          {dptLabel}
-        </span>
+      {dpt && (
+        <div
+          title={dpt.name ? `${dpt.label} – ${dpt.name}` : dpt.label}
+          style={{
+            display: 'flex', flexDirection: 'column', alignItems: 'flex-end',
+            flexShrink: 0, minWidth: 0, maxWidth: '45%',
+          }}
+        >
+          <span style={{ fontSize: '0.65rem', color: 'var(--text-dim)', whiteSpace: 'nowrap' }}>
+            {dpt.label}
+          </span>
+          {dpt.name && (
+            <span style={{
+              fontSize: '0.6rem', color: 'var(--text-dim)', opacity: 0.75,
+              whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: '100%',
+            }}>
+              {dpt.name}
+            </span>
+          )}
+        </div>
       )}
       {gaAddresses.length > 0 && (
         <>


### PR DESCRIPTION
## Summary

Closes #160. In the building structure view, communication objects (KOs) only showed the raw DPT number (e.g. `DPT 5.001`). This adds the descriptive DPT name — the same one shown in the group monitor — so KOs are easier to read at a glance.

## Changes

- **`api.py` (`_build_ko`)**: resolve each KO DPT to its descriptive name via the existing `format_dpt_name` (e.g. `5.001 - Percent`), returned as a `name` field on each DPT entry in the `/api/building` response.
- **`BuildingOverlay.tsx`**: show the descriptive part of the name on a second line beneath the DPT number, and expose the full `DPT 5.001 – Percent` as a hover tooltip (the issue suggested either — this does both). The line truncates with an ellipsis so long names don't break the row layout.

Unknown/unmapped DPTs keep showing just the number, unchanged.

## Testing

- Backend `pytest tests/test_api.py` — 33 passed (extended the building test to assert the resolved DPT name `1.001 - Switch`), `ruff` clean.
- Frontend `tsc --noEmit` clean, `lint` 0 errors, `vitest` 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)