### PR TITLE
fix: retry KNX connection until the bus interface is reachable

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -794,6 +794,17 @@ async def export_telegrams(
 @router.websocket("/ws/telegrams")
 async def websocket_endpoint(websocket: WebSocket):
     await manager.connect(websocket)
+    if not READ_ONLY:
+        # Initial state so (re)connecting clients don't have to wait for a change
+        connected = knx_daemon.is_connected()
+        await websocket.send_json(
+            {
+                "type": "connection_state",
+                "connected": connected,
+                "state": "connected" if connected else "disconnected",
+                "timestamp": datetime.now(UTC).isoformat(),
+            }
+        )
     try:
         while True:
             # Client sends filters over WS as JSON

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -1,10 +1,12 @@
 import asyncio
+import contextlib
 import logging
 import os
 from datetime import UTC, datetime
 from typing import Any
 
 from xknx import XKNX
+from xknx.core import XknxConnectionState
 from xknx.dpt import DPTArray, DPTBase, DPTBinary
 from xknx.io import ConnectionConfig, ConnectionType, SecureConfig
 from xknx.telegram import Telegram as XknxTelegram
@@ -29,6 +31,8 @@ ALLOW_WRITE = os.getenv("KNX_ALLOW_WRITE", "true").lower() == "true"
 xknx_instance: XKNX | None = None
 global_knx_project: Any | None = None
 project_name_map: dict[str, dict[str, str | None]] = {"ga": {}, "ia": {}}
+_connect_task: asyncio.Task | None = None
+_watch_task: asyncio.Task | None = None
 
 
 async def _load_project_data() -> bool:
@@ -90,9 +94,84 @@ async def _load_project_data() -> bool:
         return False
 
 
+def _register_connection_state_cb(instance: XKNX) -> None:
+    """Log connection state changes and push them to websocket clients."""
+
+    def _on_state_change(state: XknxConnectionState) -> None:
+        if xknx_instance is not instance:
+            return  # event from a replaced instance
+        logger.info(f"KNX connection state changed: {state.name}")
+        asyncio.get_running_loop().create_task(
+            manager.broadcast_event(
+                {
+                    "type": "connection_state",
+                    "connected": state == XknxConnectionState.CONNECTED,
+                    "state": state.name.lower(),
+                    "timestamp": datetime.now(UTC),
+                }
+            )
+        )
+
+    instance.connection_manager.register_connection_state_changed_cb(_on_state_change)
+
+
+def _create_xknx_instance() -> XKNX:
+    """Create a configured XKNX instance with telegram and state callbacks registered."""
+    connection_config = _build_connection_config()
+    logger.info(
+        f"Connecting to KNX bus: type={connection_config.connection_type.name}, "
+        f"gateway={connection_config.gateway_ip if connection_config.gateway_ip else 'AUTO'}, "
+        f"port={connection_config.gateway_port}, "
+        f"local_ip={connection_config.local_ip if connection_config.local_ip else 'default'}, "
+        f"route_back={connection_config.route_back}, "
+        f"secure={'yes' if connection_config.secure_config else 'no'}"
+    )
+    instance = XKNX(connection_config=connection_config)
+
+    if global_knx_project:
+        dpt_dict = {
+            ga: data["dpt"] for ga, data in global_knx_project["group_addresses"].items() if data["dpt"] is not None
+        }
+        instance.group_address_dpt.set(dpt_dict)
+
+    # match_for_outgoing=True so telegrams we send to the bus are stored/broadcast too (#161).
+    instance.telegram_queue.register_telegram_received_cb(telegram_received_cb, match_for_outgoing=True)
+    _register_connection_state_cb(instance)
+    return instance
+
+
+async def _start_with_retry():
+    """Connect to the bus, retrying with backoff until it succeeds (#166).
+
+    Only the initial connect needs this: once connected, xknx's built-in
+    auto_reconnect recovers dropped tunnels on its own.
+    """
+    global xknx_instance
+    backoff = 1.0
+    while True:
+        try:
+            await xknx_instance.start()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.warning(f"Could not connect to KNX bus: {e} - retrying in {backoff:.0f}s")
+            with contextlib.suppress(Exception):
+                await xknx_instance.stop()
+            xknx_instance = _create_xknx_instance()
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+        else:
+            logger.info("KNX Daemon connected to bus and listening.")
+            return
+
+
 async def _reconnect_knx():
     """Reconnect to KNX bus with rebuilt configuration (e.g. after knxkeys change)."""
-    global xknx_instance
+    global xknx_instance, _connect_task
+    if _connect_task and not _connect_task.done():
+        _connect_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await _connect_task
     if xknx_instance:
         logger.info("Reconnecting to KNX bus with updated configuration...")
         try:
@@ -100,22 +179,8 @@ async def _reconnect_knx():
         except Exception as e:
             logger.warning(f"Error stopping previous connection: {e}")
 
-    connection_config = _build_connection_config()
-    xknx_instance = XKNX(connection_config=connection_config)
-
-    if global_knx_project:
-        dpt_dict = {
-            ga: data["dpt"] for ga, data in global_knx_project["group_addresses"].items() if data["dpt"] is not None
-        }
-        xknx_instance.group_address_dpt.set(dpt_dict)
-
-    # match_for_outgoing=True so telegrams we send to the bus are stored/broadcast too (#161).
-    xknx_instance.telegram_queue.register_telegram_received_cb(telegram_received_cb, match_for_outgoing=True)
-    try:
-        await xknx_instance.start()
-        logger.info("KNX Daemon reconnected to bus successfully.")
-    except Exception as e:
-        logger.error(f"Failed to reconnect to KNX bus: {e}")
+    xknx_instance = _create_xknx_instance()
+    _connect_task = asyncio.create_task(_start_with_retry())
 
 
 async def _watch_files():
@@ -442,7 +507,7 @@ def get_server_config() -> dict:
 
 
 async def knx_startup():
-    global xknx_instance, global_knx_project, project_name_map
+    global xknx_instance, global_knx_project, project_name_map, _connect_task, _watch_task
     logger.info("Starting KNX Daemon...")
 
     # Check the database connection first
@@ -459,40 +524,23 @@ async def knx_startup():
     await store.initialize()
     store.start()
 
-    connection_config = _build_connection_config()
-
-    logger.info(
-        f"Connecting to KNX bus: type={connection_config.connection_type.name}, "
-        f"gateway={connection_config.gateway_ip if connection_config.gateway_ip else 'AUTO'}, "
-        f"port={connection_config.gateway_port}, "
-        f"local_ip={connection_config.local_ip if connection_config.local_ip else 'default'}, "
-        f"route_back={connection_config.route_back}, "
-        f"secure={'yes' if connection_config.secure_config else 'no'}"
-    )
-
     await _load_project_data()
 
-    xknx_instance = XKNX(connection_config=connection_config)
-
-    if global_knx_project:
-        dpt_dict = {
-            ga: data["dpt"] for ga, data in global_knx_project["group_addresses"].items() if data["dpt"] is not None
-        }
-        xknx_instance.group_address_dpt.set(dpt_dict)
-
-    # match_for_outgoing=True so telegrams we send to the bus are stored/broadcast too (#161).
-    xknx_instance.telegram_queue.register_telegram_received_cb(telegram_received_cb, match_for_outgoing=True)
-    try:
-        await xknx_instance.start()
-        logger.info("KNX Daemon connected to bus and listening.")
-        # Start background file watcher (project + knxkeys)
-        asyncio.create_task(_watch_files())
-    except Exception as e:
-        logger.error(f"Failed to connect to KNX bus: {e}")
+    xknx_instance = _create_xknx_instance()
+    _connect_task = asyncio.create_task(_start_with_retry())
+    # Start background file watcher (project + knxkeys) even while disconnected
+    _watch_task = asyncio.create_task(_watch_files())
 
 
 async def knx_shutdown():
-    global xknx_instance
+    global xknx_instance, _connect_task, _watch_task
+    for task in (_connect_task, _watch_task):
+        if task and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+    _connect_task = None
+    _watch_task = None
     if xknx_instance:
         logger.info("Stopping KNX Daemon...")
         await xknx_instance.stop()

--- a/backend/tests/test_knx_daemon.py
+++ b/backend/tests/test_knx_daemon.py
@@ -1,12 +1,29 @@
+import asyncio
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from xknx.core import XknxConnectionState
 from xknx.dpt import DPTBinary
+from xknx.exceptions import CommunicationError
 from xknx.telegram import Telegram as XknxTelegram
 from xknx.telegram import TelegramDirection
 from xknx.telegram.address import GroupAddress, IndividualAddress
 
 from knx_daemon import process_telegram_async, telegram_received_cb
+
+
+async def _cleanup_daemon_tasks():
+    """Cancel and clear the background tasks knx_startup leaves running."""
+    import knx_daemon
+
+    for task in (knx_daemon._connect_task, knx_daemon._watch_task):
+        if task and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+    knx_daemon._connect_task = None
+    knx_daemon._watch_task = None
 
 
 @pytest.mark.asyncio
@@ -100,11 +117,13 @@ def test_telegram_received_cb(mock_process, mock_get_loop):
 @patch("knx_daemon.store.start")
 @patch("knx_daemon._load_project_data")
 @patch("knx_daemon.XKNX")
-@patch("knx_daemon._watch_files")
+@patch("knx_daemon._watch_files", new_callable=AsyncMock)
 async def test_knx_startup_success(
     mock_watch_files, mock_xknx, mock_load_project, mock_store_start, mock_store_init, mock_check_conn
 ):
     from knx_telegram_store.connection import ConnectionCheckResult
+
+    import knx_daemon
 
     mock_check_conn.return_value = ConnectionCheckResult.success()
     mock_xknx_instance = MagicMock()
@@ -113,17 +132,145 @@ async def test_knx_startup_success(
 
     from knx_daemon import knx_startup
 
-    with patch("knx_daemon.global_knx_project", None):
-        await knx_startup()
+    try:
+        with patch("knx_daemon.global_knx_project", None):
+            await knx_startup()
+            await knx_daemon._connect_task
 
-    mock_check_conn.assert_called_once()
-    mock_store_init.assert_called_once()
-    mock_store_start.assert_called_once()
-    mock_xknx_instance.start.assert_called_once()
-    # The received callback must also fire for outgoing telegrams so sent
-    # telegrams are stored/broadcast (#161).
-    _, kwargs = mock_xknx_instance.telegram_queue.register_telegram_received_cb.call_args
-    assert kwargs.get("match_for_outgoing") is True
+        mock_check_conn.assert_called_once()
+        mock_store_init.assert_called_once()
+        mock_store_start.assert_called_once()
+        mock_xknx_instance.start.assert_called_once()
+        # The received callback must also fire for outgoing telegrams so sent
+        # telegrams are stored/broadcast (#161).
+        _, kwargs = mock_xknx_instance.telegram_queue.register_telegram_received_cb.call_args
+        assert kwargs.get("match_for_outgoing") is True
+        # Connection state changes are observed for the websocket status push (#166)
+        assert mock_xknx_instance.connection_manager.register_connection_state_changed_cb.called
+        mock_watch_files.assert_called_once()
+    finally:
+        await _cleanup_daemon_tasks()
+
+
+@pytest.mark.asyncio
+@patch("knx_daemon.store.check_connection")
+@patch("knx_daemon.store.initialize")
+@patch("knx_daemon.store.start")
+@patch("knx_daemon._load_project_data")
+@patch("knx_daemon.XKNX")
+@patch("knx_daemon._watch_files", new_callable=AsyncMock)
+@patch("knx_daemon.asyncio.sleep", new_callable=AsyncMock)
+async def test_knx_startup_retries_until_connected(
+    mock_sleep, mock_watch_files, mock_xknx, mock_load_project, mock_store_start, mock_store_init, mock_check_conn
+):
+    """A failed initial connect is retried with a fresh instance until it succeeds (#166)."""
+    from knx_telegram_store.connection import ConnectionCheckResult
+
+    import knx_daemon
+
+    mock_check_conn.return_value = ConnectionCheckResult.success()
+    failing_instance = MagicMock()
+    failing_instance.start = AsyncMock(side_effect=CommunicationError("gateway unreachable"))
+    failing_instance.stop = AsyncMock()
+    ok_instance = MagicMock()
+    ok_instance.start = AsyncMock()
+    mock_xknx.side_effect = [failing_instance, ok_instance]
+
+    from knx_daemon import knx_startup
+
+    try:
+        with patch("knx_daemon.global_knx_project", None):
+            await knx_startup()
+            await knx_daemon._connect_task
+
+        failing_instance.start.assert_called_once()
+        failing_instance.stop.assert_called_once()
+        ok_instance.start.assert_called_once()
+        assert knx_daemon.xknx_instance is ok_instance
+    finally:
+        await _cleanup_daemon_tasks()
+
+
+@pytest.mark.asyncio
+@patch("knx_daemon.store.check_connection")
+@patch("knx_daemon.store.initialize")
+@patch("knx_daemon.store.start")
+@patch("knx_daemon._load_project_data")
+@patch("knx_daemon.XKNX")
+@patch("knx_daemon._watch_files", new_callable=AsyncMock)
+async def test_knx_startup_watcher_runs_while_disconnected(
+    mock_watch_files, mock_xknx, mock_load_project, mock_store_start, mock_store_init, mock_check_conn
+):
+    """The file watcher starts even when the bus cannot be reached (#166)."""
+    from knx_telegram_store.connection import ConnectionCheckResult
+
+    mock_check_conn.return_value = ConnectionCheckResult.success()
+    mock_xknx_instance = MagicMock()
+    mock_xknx.return_value = mock_xknx_instance
+    mock_xknx_instance.start = AsyncMock(side_effect=CommunicationError("gateway unreachable"))
+    mock_xknx_instance.stop = AsyncMock()
+
+    from knx_daemon import knx_startup
+
+    try:
+        with patch("knx_daemon.global_knx_project", None):
+            await knx_startup()
+            await asyncio.sleep(0)
+
+        mock_watch_files.assert_called_once()
+    finally:
+        await _cleanup_daemon_tasks()
+
+
+@pytest.mark.asyncio
+@patch("knx_daemon.store.stop", new_callable=AsyncMock)
+async def test_knx_shutdown_cancels_background_tasks(mock_store_stop):
+    import knx_daemon
+    from knx_daemon import knx_shutdown
+
+    connect_task = asyncio.create_task(asyncio.sleep(3600))
+    watch_task = asyncio.create_task(asyncio.sleep(3600))
+    mock_instance = MagicMock()
+    mock_instance.stop = AsyncMock()
+
+    knx_daemon._connect_task = connect_task
+    knx_daemon._watch_task = watch_task
+    with patch("knx_daemon.xknx_instance", mock_instance):
+        await knx_shutdown()
+
+    assert connect_task.cancelled()
+    assert watch_task.cancelled()
+    assert knx_daemon._connect_task is None
+    assert knx_daemon._watch_task is None
+    mock_instance.stop.assert_called_once()
+    mock_store_stop.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("knx_daemon.manager.broadcast_event", new_callable=AsyncMock)
+async def test_connection_state_cb_broadcasts(mock_broadcast_event):
+    import knx_daemon
+
+    instance = MagicMock()
+    knx_daemon._register_connection_state_cb(instance)
+    state_cb = instance.connection_manager.register_connection_state_changed_cb.call_args[0][0]
+
+    with patch("knx_daemon.xknx_instance", instance):
+        state_cb(XknxConnectionState.DISCONNECTED)
+        await asyncio.sleep(0)
+
+    mock_broadcast_event.assert_called_once()
+    event = mock_broadcast_event.call_args[0][0]
+    assert event["type"] == "connection_state"
+    assert event["connected"] is False
+    assert event["state"] == "disconnected"
+
+    # Events from a replaced instance are ignored
+    with patch("knx_daemon.xknx_instance", MagicMock()):
+        state_cb(XknxConnectionState.CONNECTED)
+        await asyncio.sleep(0)
+
+    assert mock_broadcast_event.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ws_manager.py
+++ b/backend/tests/test_ws_manager.py
@@ -63,3 +63,37 @@ async def test_websocket_manager():
 
     manager.disconnect(ws1)
     assert ws1 not in manager.active_connections
+
+
+@pytest.mark.asyncio
+async def test_broadcast_event_bypasses_filters():
+    """connection_state events reach every client, even with non-matching filters (#166)."""
+    manager = ConnectionManager()
+
+    class MockWebsocket:
+        def __init__(self):
+            self.sent_data = []
+
+        async def accept(self):
+            pass
+
+        async def send_json(self, data):
+            if data.get("raise_error"):
+                raise Exception("Simulated connection error")
+            self.sent_data.append(data)
+
+    ws = MockWebsocket()
+    await manager.connect(ws)
+    await manager.update_filters(ws, {"target_address": "1/1/1"})
+
+    ts = datetime(2023, 1, 1, tzinfo=UTC)
+    await manager.broadcast_event({"type": "connection_state", "connected": False, "timestamp": ts})
+    assert len(ws.sent_data) == 1
+    assert ws.sent_data[0]["type"] == "connection_state"
+    assert ws.sent_data[0]["timestamp"] == ts.isoformat()
+
+    # Dead connections are dropped
+    dead = MockWebsocket()
+    await manager.connect(dead)
+    await manager.broadcast_event({"type": "connection_state", "raise_error": True})
+    assert dead not in manager.active_connections

--- a/backend/ws_manager.py
+++ b/backend/ws_manager.py
@@ -18,6 +18,17 @@ class ConnectionManager:
         """Update the server-side filters for this specific connection."""
         self.active_connections[websocket] = filters
 
+    async def broadcast_event(self, event: dict):
+        """Broadcast a non-telegram event (e.g. connection state) to all clients, bypassing filters."""
+        if "timestamp" in event and isinstance(event["timestamp"], datetime):
+            event["timestamp"] = event["timestamp"].isoformat()
+
+        for connection in list(self.active_connections):
+            try:
+                await connection.send_json(event)
+            except Exception:
+                self.disconnect(connection)
+
     async def broadcast(self, telegram: dict):
         """Broadcasts telegrams to connected clients, applying server-side filters."""
         if "timestamp" in telegram and isinstance(telegram["timestamp"], datetime):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
-import { useWebSocket, type Telegram } from './hooks/useWebSocket';
+import { useWebSocket, type Telegram, type ConnectionStateEvent } from './hooks/useWebSocket';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigCookie, writeSortConfigCookie } from './utils/sortConfig';
 import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor, FolderInput, Send, Sparkles } from 'lucide-react';
@@ -218,6 +218,13 @@ function App() {
     });
   }, []);
 
+  const refreshServerConfig = useCallback(() => {
+    fetch(apiUrl('/api/server/config'))
+      .then(r => r.json())
+      .then(data => setServerConfig(data))
+      .catch(err => console.error("Failed to load server config", err));
+  }, []);
+
   // Load filter options from backend on mount
   useEffect(() => {
     fetch(apiUrl('/api/filter-options'))
@@ -259,11 +266,8 @@ function App() {
       .catch(err => console.error("Failed to check knxkeys status", err));
 
     // Load server config
-    fetch(apiUrl('/api/server/config'))
-      .then(r => r.json())
-      .then(data => setServerConfig(data))
-      .catch(err => console.error("Failed to load server config", err));
-  }, []);
+    refreshServerConfig();
+  }, [refreshServerConfig]);
 
   // A new release the user hasn't been shown yet (seenUpdateVersion is frozen
   // at mount, so it stays true for the session once detected). Auto-shows once;
@@ -300,8 +304,24 @@ function App() {
     }
   }, [isPaused, loadLimit]);
 
+  const handleConnectionState = useCallback((e: ConnectionStateEvent) => {
+    // Flip the badge immediately, then refetch for authoritative state
+    // (write_enabled depends on the connection and is recomputed server-side).
+    setServerConfig((prev: any) => prev
+      ? {
+          ...prev,
+          status: {
+            ...prev.status,
+            connected: e.connected,
+            write_enabled: prev.status?.write_enabled && e.connected,
+          },
+        }
+      : prev);
+    refreshServerConfig();
+  }, [refreshServerConfig]);
+
   const wsEndpoint = wsUrl('/ws/telegrams');
-  const { isConnected } = useWebSocket(wsEndpoint, handleTelegram);
+  const { isConnected } = useWebSocket(wsEndpoint, handleTelegram, handleConnectionState);
 
   // ── Persist settings to cookies ─────────────────────────────────────────────
   useEffect(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -307,7 +307,7 @@ function App() {
   const handleConnectionState = useCallback((e: ConnectionStateEvent) => {
     // Flip the badge immediately, then refetch for authoritative state
     // (write_enabled depends on the connection and is recomputed server-side).
-    setServerConfig((prev: any) => prev
+    setServerConfig((prev: { status?: { connected?: boolean; write_enabled?: boolean } } | null) => prev
       ? {
           ...prev,
           status: {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -21,7 +21,18 @@ export interface Telegram {
   raw_hex?: string | null;
 }
 
-export function useWebSocket(url: string, onTelegram?: (t: Telegram) => void) {
+export interface ConnectionStateEvent {
+  type: 'connection_state';
+  connected: boolean;
+  state: string;
+  timestamp: string;
+}
+
+export function useWebSocket(
+  url: string,
+  onTelegram?: (t: Telegram) => void,
+  onEvent?: (e: ConnectionStateEvent) => void,
+) {
   const [isConnected, setIsConnected] = useState(false);
   const ws = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<number | null>(null);
@@ -31,6 +42,11 @@ export function useWebSocket(url: string, onTelegram?: (t: Telegram) => void) {
   useEffect(() => {
     onTelegramRef.current = onTelegram;
   }, [onTelegram]);
+
+  const onEventRef = useRef(onEvent);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
 
   const connect = useCallback(() => {
     if (ws.current?.readyState === WebSocket.OPEN) return;
@@ -44,9 +60,13 @@ export function useWebSocket(url: string, onTelegram?: (t: Telegram) => void) {
 
     socket.onmessage = (event) => {
       try {
-        const data = JSON.parse(event.data) as Telegram;
+        const data = JSON.parse(event.data) as Telegram | ConnectionStateEvent;
+        if ('type' in data && data.type === 'connection_state') {
+          onEventRef.current?.(data);
+          return;
+        }
         if (onTelegramRef.current) {
-          onTelegramRef.current(data);
+          onTelegramRef.current(data as Telegram);
         }
       } catch (err) {
         console.error('Error parsing WS message:', err);


### PR DESCRIPTION
Fixes #166

## Problem

When the app starts while the KNX IP interface is unreachable, `knx_startup()` logs the failure and gives up — the app stays "disconnected" until restarted. xknx's built-in `auto_reconnect` only recovers tunnels that connected successfully at least once, so the initial connect was never retried. The frontend badge also only reflected the state at page load.

## Changes

**Backend**
- The initial connect now runs in a background task that retries with exponential backoff (1s → ×2 → cap 30s), rebuilding a fresh `XKNX` instance per attempt. Once connected the task exits; mid-run tunnel drops remain covered by xknx's own `auto_reconnect` (verified: its reconnect loop never gives up), so there is no competing reconnect logic.
- The project/knxkeys file watcher starts regardless of connection state (previously skipped on connect failure).
- `_reconnect_knx()` (knxkeys changes) uses the same retry loop instead of failing silently.
- `knx_shutdown()` cancels and awaits both background tasks.
- Connection state changes are pushed to websocket clients as `connection_state` events via a new filter-bypassing `ConnectionManager.broadcast_event()`; each client also receives the current state on connect.

**Frontend**
- `useWebSocket` routes `connection_state` events to a new optional callback; `App.tsx` flips the Connected/Disconnected badge immediately and refetches `/api/server/config` for authoritative state (keeps `write_enabled` gating consistent).

## Tests

- Startup retries until connected (fresh instance per attempt), watcher runs while disconnected, shutdown cancels the retry task, state callback broadcasts the right payload and ignores stale instances, `broadcast_event` bypasses per-connection filters.
- Backend: 141 passed. Frontend: tests pass, build clean.

## Notes / limitations

- With connection type AUTOMATIC, xknx keeps retrying the gateway it discovered; if the gateway IP changes mid-run, a restart or knxkeys re-upload is needed (pre-existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)