### PR TITLE
feat: delayed and cyclic send-to-bus like the ETS group monitor

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -8,11 +8,12 @@ from typing import Any
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
 from fastapi.responses import StreamingResponse
 from knx_telegram_store.formats import COMMUNICATION_LOG_FOOTER, COMMUNICATION_LOG_HEADER, format_telegram_element
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import text
 from xknx.exceptions import ConversionError, CouldNotParseAddress
-from xknx.telegram.address import IndividualAddress
+from xknx.telegram.address import GroupAddress, IndividualAddress
 
+import cyclic_send
 import knx_daemon  # import global config
 import telegram_export
 import telegram_import
@@ -387,6 +388,58 @@ async def knx_read(request: KnxReadRequest):
     except (CouldNotParseAddress, ValueError) as err:
         raise HTTPException(status_code=400, detail=str(err)) from err
     return {"status": "sent"}
+
+
+class KnxScheduledSendRequest(BaseModel):
+    address: str
+    payload: Any
+    dpt: str | None = None
+    response: bool = False
+    # One-shot delay before the (first) send.
+    delay_seconds: float = Field(0, ge=0, le=86400)
+    # Repeat interval; 1s floor keeps a runaway job from flooding the bus.
+    interval_seconds: float | None = Field(None, ge=1.0, le=86400)
+
+
+@router.post("/api/knx/send/scheduled")
+async def knx_send_scheduled(request: KnxScheduledSendRequest):
+    """Start a delayed and/or cyclic send job (#167). One job at a time."""
+    _require_bus_write()
+    if request.delay_seconds == 0 and request.interval_seconds is None:
+        raise HTTPException(status_code=400, detail="Set a delay or interval; use /api/knx/send for immediate sends")
+    # Validate address and payload up front so the background job can't fail on bad input
+    try:
+        GroupAddress(request.address)
+        knx_daemon._encode_payload(request.payload, request.dpt)
+    except (ConversionError, CouldNotParseAddress, ValueError) as err:
+        raise HTTPException(status_code=400, detail=str(err)) from err
+    try:
+        job = cyclic_send.start_send(
+            request.address,
+            request.payload,
+            request.dpt,
+            request.response,
+            request.delay_seconds,
+            request.interval_seconds,
+        )
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+    return job.to_dict()
+
+
+@router.get("/api/knx/send/scheduled/status")
+async def get_scheduled_send_status():
+    """Returns the state of the current/last scheduled send job."""
+    job = cyclic_send.current_job
+    return job.to_dict() if job else {"state": "idle"}
+
+
+@router.post("/api/knx/send/scheduled/cancel")
+async def cancel_scheduled_send():
+    """Cancels the active scheduled send job."""
+    if not cyclic_send.cancel_send():
+        raise HTTPException(status_code=404, detail="No scheduled send is active")
+    return {"status": "ok"}
 
 
 @router.post("/api/database/purge")

--- a/backend/cyclic_send.py
+++ b/backend/cyclic_send.py
@@ -1,0 +1,135 @@
+"""Delayed and cyclic send-to-bus jobs (#167).
+
+A single job at a time (mirroring telegram_import): an optional one-shot
+delay before the first send, then optionally repeating at a fixed interval
+until cancelled. Jobs live in memory only and do not survive restarts.
+"""
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import knx_daemon
+
+logger = logging.getLogger("cyclic_send")
+
+
+@dataclass
+class SendJob:
+    id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    state: str = "waiting"  # waiting | running | done | cancelled | failed
+    address: str = ""
+    payload: Any = None
+    dpt: str | None = None
+    response: bool = False
+    delay_seconds: float = 0.0
+    interval_seconds: float | None = None
+    sends_done: int = 0
+    sends_skipped: int = 0
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    next_send_at: datetime | None = None
+    finished_at: datetime | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "state": self.state,
+            "address": self.address,
+            "payload": self.payload,
+            "dpt": self.dpt,
+            "response": self.response,
+            "delay_seconds": self.delay_seconds,
+            "interval_seconds": self.interval_seconds,
+            "sends_done": self.sends_done,
+            "sends_skipped": self.sends_skipped,
+            "started_at": self.started_at.isoformat(),
+            "next_send_at": self.next_send_at.isoformat() if self.next_send_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "error": self.error,
+        }
+
+
+current_job: SendJob | None = None
+_job_task: asyncio.Task | None = None
+
+
+async def _attempt_send(job: SendJob) -> None:
+    """Send one telegram; skip (but keep the job alive) while the bus is unavailable."""
+    if not knx_daemon.write_enabled():
+        job.sends_skipped += 1
+        logger.warning(f"Skipping scheduled send to {job.address}: bus not writable")
+        return
+    await knx_daemon.send_group_value(job.address, job.payload, job.dpt, job.response)
+    job.sends_done += 1
+
+
+async def _run_job(job: SendJob) -> None:
+    try:
+        if job.delay_seconds > 0:
+            job.next_send_at = datetime.now(UTC) + timedelta(seconds=job.delay_seconds)
+            await asyncio.sleep(job.delay_seconds)
+        job.state = "running"
+        while True:
+            job.next_send_at = None
+            await _attempt_send(job)
+            if job.interval_seconds is None:
+                job.state = "done"
+                return
+            job.next_send_at = datetime.now(UTC) + timedelta(seconds=job.interval_seconds)
+            await asyncio.sleep(job.interval_seconds)
+    except asyncio.CancelledError:
+        job.state = "cancelled"
+        raise
+    except Exception as e:
+        logger.error(f"Scheduled send to {job.address} failed: {e}")
+        job.state = "failed"
+        job.error = str(e)
+    finally:
+        job.finished_at = datetime.now(UTC)
+        job.next_send_at = None
+
+
+def start_send(
+    address: str,
+    payload: Any,
+    dpt: str | None,
+    response: bool,
+    delay_seconds: float,
+    interval_seconds: float | None,
+) -> SendJob:
+    """Starts a background delayed/cyclic send. Raises if one is active."""
+    global current_job, _job_task
+    if current_job is not None and current_job.state in ("waiting", "running"):
+        raise RuntimeError("A scheduled send is already active")
+    current_job = SendJob(
+        address=address,
+        payload=payload,
+        dpt=dpt,
+        response=response,
+        delay_seconds=delay_seconds,
+        interval_seconds=interval_seconds,
+    )
+    _job_task = asyncio.get_running_loop().create_task(_run_job(current_job))
+    return current_job
+
+
+def cancel_send() -> bool:
+    """Cancels the active scheduled send. Returns False if none is active."""
+    if current_job is None or current_job.state not in ("waiting", "running"):
+        return False
+    if _job_task is not None:
+        _job_task.cancel()
+    return True
+
+
+async def shutdown() -> None:
+    """Cancels and awaits the job task on application shutdown."""
+    if _job_task is not None and not _job_task.done():
+        _job_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await _job_task

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware  # noqa: E402
 from fastapi.responses import FileResponse  # noqa: E402
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 
+import cyclic_send  # noqa: E402
 from api import get_backend_version  # noqa: E402
 from api import router as api_router  # noqa: E402
 from database import READ_ONLY, engine  # noqa: E402
@@ -38,6 +39,7 @@ async def lifespan(app: FastAPI):
     if READ_ONLY:
         await companion_shutdown()
     else:
+        await cyclic_send.shutdown()
         await knx_shutdown()
     await engine.dispose()
 

--- a/backend/tests/test_api_knx_control.py
+++ b/backend/tests/test_api_knx_control.py
@@ -3,7 +3,9 @@ from unittest.mock import AsyncMock, patch
 from fastapi.testclient import TestClient
 from xknx.exceptions import ConversionError, CouldNotParseAddress
 
+import cyclic_send
 import knx_daemon
+from cyclic_send import SendJob
 from main import app
 
 client = TestClient(app)
@@ -69,3 +71,106 @@ def test_read_invalid_address_returns_400():
     ):
         response = client.post("/api/knx/read", json={"address": "nope"})
     assert response.status_code == 400
+
+
+def test_scheduled_send_starts_job():
+    with (
+        patch.object(knx_daemon, "ALLOW_WRITE", True),
+        patch.object(knx_daemon, "is_connected", return_value=True),
+        patch.object(cyclic_send, "start_send", return_value=SendJob(address="1/2/3")) as start,
+    ):
+        response = client.post(
+            "/api/knx/send/scheduled",
+            json={"address": "1/2/3", "payload": 50, "dpt": "5.001", "delay_seconds": 2, "interval_seconds": 5},
+        )
+    assert response.status_code == 200
+    assert response.json()["state"] == "waiting"
+    start.assert_called_once_with("1/2/3", 50, "5.001", False, 2.0, 5.0)
+
+
+def test_scheduled_send_rejected_when_job_active():
+    with (
+        patch.object(knx_daemon, "ALLOW_WRITE", True),
+        patch.object(knx_daemon, "is_connected", return_value=True),
+        patch.object(cyclic_send, "start_send", side_effect=RuntimeError("A scheduled send is already active")),
+    ):
+        response = client.post(
+            "/api/knx/send/scheduled",
+            json={"address": "1/2/3", "payload": True, "dpt": "1.001", "interval_seconds": 5},
+        )
+    assert response.status_code == 409
+
+
+def test_scheduled_send_without_delay_or_interval_returns_400():
+    with (
+        patch.object(knx_daemon, "ALLOW_WRITE", True),
+        patch.object(knx_daemon, "is_connected", return_value=True),
+    ):
+        response = client.post("/api/knx/send/scheduled", json={"address": "1/2/3", "payload": True, "dpt": "1.001"})
+    assert response.status_code == 400
+
+
+def test_scheduled_send_invalid_payload_returns_400():
+    with (
+        patch.object(knx_daemon, "ALLOW_WRITE", True),
+        patch.object(knx_daemon, "is_connected", return_value=True),
+    ):
+        response = client.post(
+            "/api/knx/send/scheduled",
+            json={"address": "1/2/3", "payload": "not-a-number", "dpt": "9.001", "interval_seconds": 5},
+        )
+    assert response.status_code == 400
+
+
+def test_scheduled_send_interval_below_floor_returns_422():
+    with (
+        patch.object(knx_daemon, "ALLOW_WRITE", True),
+        patch.object(knx_daemon, "is_connected", return_value=True),
+    ):
+        response = client.post(
+            "/api/knx/send/scheduled",
+            json={"address": "1/2/3", "payload": True, "dpt": "1.001", "interval_seconds": 0.5},
+        )
+    assert response.status_code == 422
+
+
+def test_scheduled_send_rejected_when_write_disabled():
+    with patch.object(knx_daemon, "ALLOW_WRITE", False):
+        response = client.post(
+            "/api/knx/send/scheduled",
+            json={"address": "1/2/3", "payload": True, "dpt": "1.001", "interval_seconds": 5},
+        )
+    assert response.status_code == 403
+
+
+def test_scheduled_send_status_idle():
+    with patch.object(cyclic_send, "current_job", None):
+        response = client.get("/api/knx/send/scheduled/status")
+    assert response.status_code == 200
+    assert response.json() == {"state": "idle"}
+
+
+def test_scheduled_send_status_reports_job():
+    job = SendJob(address="1/2/3", interval_seconds=5.0)
+    job.state = "running"
+    job.sends_done = 3
+    with patch.object(cyclic_send, "current_job", job):
+        response = client.get("/api/knx/send/scheduled/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["state"] == "running"
+    assert data["address"] == "1/2/3"
+    assert data["sends_done"] == 3
+
+
+def test_scheduled_send_cancel():
+    with patch.object(cyclic_send, "cancel_send", return_value=True):
+        response = client.post("/api/knx/send/scheduled/cancel")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_scheduled_send_cancel_when_idle_returns_404():
+    with patch.object(cyclic_send, "cancel_send", return_value=False):
+        response = client.post("/api/knx/send/scheduled/cancel")
+    assert response.status_code == 404

--- a/backend/tests/test_cyclic_send.py
+++ b/backend/tests/test_cyclic_send.py
@@ -1,0 +1,114 @@
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+import cyclic_send
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_job_state():
+    yield
+    if cyclic_send._job_task is not None and not cyclic_send._job_task.done():
+        cyclic_send._job_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cyclic_send._job_task
+    cyclic_send.current_job = None
+    cyclic_send._job_task = None
+
+
+@pytest.mark.asyncio
+async def test_one_shot_delayed_send():
+    with (
+        patch.object(cyclic_send.knx_daemon, "write_enabled", return_value=True),
+        patch.object(cyclic_send.knx_daemon, "send_group_value", new=AsyncMock()) as send,
+    ):
+        job = cyclic_send.start_send("1/2/3", 50, "5.001", False, delay_seconds=0.01, interval_seconds=None)
+        assert job.state == "waiting"
+        await cyclic_send._job_task
+
+    assert job.state == "done"
+    assert job.sends_done == 1
+    assert job.finished_at is not None
+    send.assert_awaited_once_with("1/2/3", 50, "5.001", False)
+
+
+@pytest.mark.asyncio
+async def test_cyclic_send_ticks_until_cancelled():
+    with (
+        patch.object(cyclic_send.knx_daemon, "write_enabled", return_value=True),
+        patch.object(cyclic_send.knx_daemon, "send_group_value", new=AsyncMock()) as send,
+    ):
+        job = cyclic_send.start_send("1/2/3", True, "1.001", False, delay_seconds=0, interval_seconds=0.01)
+        await asyncio.sleep(0.05)
+        assert job.state == "running"
+        assert cyclic_send.cancel_send() is True
+        with contextlib.suppress(asyncio.CancelledError):
+            await cyclic_send._job_task
+
+    assert job.state == "cancelled"
+    assert job.sends_done >= 2
+    assert job.finished_at is not None
+    assert job.next_send_at is None
+    assert send.await_count == job.sends_done
+
+
+@pytest.mark.asyncio
+async def test_second_job_rejected_while_active():
+    with (
+        patch.object(cyclic_send.knx_daemon, "write_enabled", return_value=True),
+        patch.object(cyclic_send.knx_daemon, "send_group_value", new=AsyncMock()),
+    ):
+        cyclic_send.start_send("1/2/3", True, "1.001", False, delay_seconds=0, interval_seconds=1.0)
+        await asyncio.sleep(0)
+        with pytest.raises(RuntimeError, match="already active"):
+            cyclic_send.start_send("4/5/6", False, "1.001", False, delay_seconds=0, interval_seconds=1.0)
+
+
+@pytest.mark.asyncio
+async def test_sends_skipped_while_disconnected():
+    with (
+        patch.object(cyclic_send.knx_daemon, "write_enabled", return_value=False),
+        patch.object(cyclic_send.knx_daemon, "send_group_value", new=AsyncMock()) as send,
+    ):
+        job = cyclic_send.start_send("1/2/3", True, "1.001", False, delay_seconds=0, interval_seconds=0.01)
+        await asyncio.sleep(0.05)
+
+        # The job survives the outage and counts the skipped attempts
+        assert job.state == "running"
+        assert job.sends_done == 0
+        assert job.sends_skipped >= 2
+        send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_failure_marks_job_failed():
+    with (
+        patch.object(cyclic_send.knx_daemon, "write_enabled", return_value=True),
+        patch.object(cyclic_send.knx_daemon, "send_group_value", new=AsyncMock(side_effect=RuntimeError("boom"))),
+    ):
+        job = cyclic_send.start_send("1/2/3", True, "1.001", False, delay_seconds=0, interval_seconds=None)
+        await cyclic_send._job_task
+
+    assert job.state == "failed"
+    assert job.error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_cancel_when_idle_returns_false():
+    assert cyclic_send.cancel_send() is False
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cancels_active_job():
+    with (
+        patch.object(cyclic_send.knx_daemon, "write_enabled", return_value=True),
+        patch.object(cyclic_send.knx_daemon, "send_group_value", new=AsyncMock()),
+    ):
+        job = cyclic_send.start_send("1/2/3", True, "1.001", False, delay_seconds=0, interval_seconds=60.0)
+        await asyncio.sleep(0)
+        await cyclic_send.shutdown()
+
+    assert job.state == "cancelled"

--- a/frontend/src/components/SendTelegramBar.test.tsx
+++ b/frontend/src/components/SendTelegramBar.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { SendTelegramBar } from './SendTelegramBar';
+
+const IDLE = { state: 'idle' };
+const RUNNING_JOB = {
+  state: 'running',
+  id: 'abc',
+  address: '1/2/3',
+  interval_seconds: 5,
+  sends_done: 3,
+  sends_skipped: 0,
+};
+
+function mockFetch(routes: Record<string, unknown>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    for (const [path, body] of Object.entries(routes)) {
+      if (url.includes(path)) {
+        return { ok: true, json: async () => body } as Response;
+      }
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/knx/send/scheduled/status': IDLE }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test('sends immediately when no delay or interval is set', async () => {
+  const fetchMock = mockFetch({
+    '/api/knx/send/scheduled/status': IDLE,
+    '/api/knx/send': { status: 'sent' },
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  render(<SendTelegramBar targets={[]} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  fireEvent.change(screen.getByPlaceholderText(/Value/), { target: { value: '50' } });
+  fireEvent.click(screen.getByText('Write'));
+
+  await waitFor(() => expect(screen.getByText(/Sent 50 to 1\/2\/3/)).toBeInTheDocument());
+  const sendCall = fetchMock.mock.calls.find(([u]) => String(u).includes('/api/knx/send') && !String(u).includes('scheduled'));
+  expect(sendCall).toBeTruthy();
+});
+
+test('starts a scheduled job when an interval is set and shows the cancel row', async () => {
+  const fetchMock = mockFetch({
+    '/api/knx/send/scheduled/status': IDLE,
+    '/api/knx/send/scheduled': RUNNING_JOB,
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  render(<SendTelegramBar targets={[]} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  fireEvent.change(screen.getByPlaceholderText(/Value/), { target: { value: '50' } });
+  fireEvent.change(screen.getByPlaceholderText('Every s'), { target: { value: '5' } });
+  fireEvent.click(screen.getByText('Write'));
+
+  await waitFor(() => expect(screen.getByText(/Cyclic send to 1\/2\/3 every 5s — 3 sent/)).toBeInTheDocument());
+  expect(screen.getByText('Cancel')).toBeInTheDocument();
+
+  const scheduledCall = fetchMock.mock.calls.find(([u]) => String(u).endsWith('/api/knx/send/scheduled'));
+  expect(scheduledCall).toBeTruthy();
+  const body = JSON.parse((scheduledCall![1] as RequestInit).body as string);
+  expect(body.interval_seconds).toBe(5);
+  expect(body.delay_seconds).toBe(0);
+});
+
+test('picks up an already-running job on mount', async () => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/knx/send/scheduled/status': RUNNING_JOB }));
+
+  render(<SendTelegramBar targets={[]} onClose={() => {}} />);
+  await waitFor(() => expect(screen.getByText(/Cyclic send to 1\/2\/3/)).toBeInTheDocument());
+});

--- a/frontend/src/components/SendTelegramBar.tsx
+++ b/frontend/src/components/SendTelegramBar.tsx
@@ -1,8 +1,17 @@
-import { useMemo, useState } from 'react';
-import { Send, Radio, X, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Send, Radio, X, AlertTriangle, CheckCircle2, Timer } from 'lucide-react';
 
 import type { FilterOption } from '../types/filters';
-import { coerceValue, formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
+import {
+  coerceValue,
+  formatDpt,
+  readTelegram,
+  sendTelegram,
+  startScheduledSend,
+  getScheduledSendStatus,
+  cancelScheduledSend,
+  type ScheduledSendStatus,
+} from '../utils/knxSend';
 import { GaCombobox } from './GaCombobox';
 
 interface Props {
@@ -13,17 +22,25 @@ interface Props {
 
 const GA_RE = /^\d{1,2}\/\d{1,2}\/\d{1,3}$|^\d{1,2}\/\d{1,4}$|^\d{1,5}$/;
 
+const POLL_INTERVAL_MS = 1000;
+
 /**
  * Group-monitor send bar: write a value to a group address or trigger a
- * GroupValueRead. Shown above the telegram table in live mode only, and only
- * when the backend reports the bus is writable.
+ * GroupValueRead. Optionally delays the send or repeats it cyclically (#167).
+ * Shown above the telegram table in live mode only, and only when the backend
+ * reports the bus is writable.
  */
 export function SendTelegramBar({ targets, onClose }: Props) {
   const [address, setAddress] = useState('');
   const [dpt, setDpt] = useState('');
   const [value, setValue] = useState('');
+  const [delay, setDelay] = useState('');
+  const [every, setEvery] = useState('');
   const [busy, setBusy] = useState(false);
   const [feedback, setFeedback] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [job, setJob] = useState<ScheduledSendStatus | null>(null);
+  const pollRef = useRef<number | null>(null);
+  const watchingRef = useRef(false);
 
   const byAddress = useMemo(() => {
     const m = new Map<string, FilterOption>();
@@ -34,6 +51,19 @@ export function SendTelegramBar({ targets, onClose }: Props) {
   const known = byAddress.get(address.trim());
   const dptMain = known?.main ?? undefined;
   const addressValid = GA_RE.test(address.trim());
+
+  const delaySeconds = parseFloat(delay) || 0;
+  const intervalSeconds = parseFloat(every) || 0;
+  const isScheduled = delaySeconds > 0 || intervalSeconds > 0;
+  const jobActive = job != null && (job.state === 'waiting' || job.state === 'running');
+  const sendDisabled = busy || jobActive || !addressValid;
+
+  // Pick up an already-active job (e.g. after a page reload) and clean up the poller.
+  useEffect(() => {
+    void refreshJob();
+    return stopPolling;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const onAddressChange = (next: string, option?: FilterOption) => {
     setAddress(next);
@@ -50,6 +80,8 @@ export function SendTelegramBar({ targets, onClose }: Props) {
       if (action === 'read') {
         await readTelegram(address.trim());
         setFeedback({ ok: true, msg: `Read request sent to ${address.trim()}` });
+      } else if (isScheduled) {
+        await startScheduled(coerceValue(value));
       } else {
         await sendTelegram(address.trim(), coerceValue(value), dpt.trim() || undefined);
         setFeedback({ ok: true, msg: `Sent ${value || '(raw)'} to ${address.trim()}` });
@@ -93,8 +125,8 @@ export function SendTelegramBar({ targets, onClose }: Props) {
 
         {dptMain === 1 ? (
           <div style={{ display: 'flex', gap: '0.3rem' }}>
-            <button disabled={busy || !addressValid} onClick={() => void sendBoolean(true)} style={boolBtn(busy || !addressValid)}>On</button>
-            <button disabled={busy || !addressValid} onClick={() => void sendBoolean(false)} style={boolBtn(busy || !addressValid)}>Off</button>
+            <button disabled={sendDisabled} onClick={() => void sendBoolean(true)} style={boolBtn(sendDisabled)}>On</button>
+            <button disabled={sendDisabled} onClick={() => void sendBoolean(false)} style={boolBtn(sendDisabled)}>Off</button>
           </div>
         ) : (
           <input
@@ -106,11 +138,29 @@ export function SendTelegramBar({ targets, onClose }: Props) {
           />
         )}
 
+        <input
+          className="glass-input"
+          placeholder="Delay s"
+          value={delay}
+          onChange={e => { setDelay(e.target.value); setFeedback(null); }}
+          title="Wait this many seconds before sending"
+          style={{ width: 70 }}
+        />
+
+        <input
+          className="glass-input"
+          placeholder="Every s"
+          value={every}
+          onChange={e => { setEvery(e.target.value); setFeedback(null); }}
+          title="Repeat the send at this interval in seconds (min 1) until cancelled"
+          style={{ width: 70 }}
+        />
+
         {dptMain !== 1 && (
           <button
             onClick={() => run('send')}
-            disabled={busy || !addressValid || value.trim() === ''}
-            style={primaryBtn(busy || !addressValid || value.trim() === '')}
+            disabled={sendDisabled || value.trim() === ''}
+            style={primaryBtn(sendDisabled || value.trim() === '')}
           >
             <Send size={14} /> Write
           </button>
@@ -130,6 +180,16 @@ export function SendTelegramBar({ targets, onClose }: Props) {
         </button>
       </div>
 
+      {jobActive && job && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.72rem', color: 'var(--accent-primary)' }}>
+          <Timer size={13} />
+          <span>{describeJob(job)}</span>
+          <button onClick={() => void cancelJob()} style={secondaryBtn(false)}>
+            Cancel
+          </button>
+        </div>
+      )}
+
       {(label || feedback) && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.72rem', minHeight: '1rem' }}>
           {label && <span style={{ color: 'var(--text-dim)' }}>{address.trim()} — {label}</span>}
@@ -147,14 +207,92 @@ export function SendTelegramBar({ targets, onClose }: Props) {
     setBusy(true);
     setFeedback(null);
     try {
-      await sendTelegram(address.trim(), on, dpt.trim() || undefined);
-      setFeedback({ ok: true, msg: `Sent ${on ? 'on' : 'off'} to ${address.trim()}` });
+      if (isScheduled) {
+        await startScheduled(on);
+      } else {
+        await sendTelegram(address.trim(), on, dpt.trim() || undefined);
+        setFeedback({ ok: true, msg: `Sent ${on ? 'on' : 'off'} to ${address.trim()}` });
+      }
     } catch (err) {
       setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Request failed' });
     } finally {
       setBusy(false);
     }
   }
+
+  async function startScheduled(payload: unknown) {
+    if (intervalSeconds > 0 && intervalSeconds < 1) {
+      setFeedback({ ok: false, msg: 'Interval must be at least 1 second' });
+      return;
+    }
+    const status = await startScheduledSend(address.trim(), payload, dpt.trim() || undefined, {
+      delaySeconds: delaySeconds > 0 ? delaySeconds : undefined,
+      intervalSeconds: intervalSeconds > 0 ? intervalSeconds : undefined,
+    });
+    watchingRef.current = true;
+    setJob(status);
+    startPolling();
+  }
+
+  async function refreshJob() {
+    let status: ScheduledSendStatus;
+    try {
+      status = await getScheduledSendStatus();
+    } catch {
+      return; // transient fetch error — keep polling
+    }
+    if (status.state === 'waiting' || status.state === 'running') {
+      watchingRef.current = true;
+      setJob(status);
+      if (pollRef.current == null) startPolling();
+      return;
+    }
+    stopPolling();
+    setJob(null);
+    if (watchingRef.current) {
+      watchingRef.current = false;
+      if (status.state === 'done') {
+        setFeedback({ ok: true, msg: `Sent to ${status.address}` });
+      } else if (status.state === 'cancelled') {
+        setFeedback({ ok: true, msg: `Scheduled send to ${status.address} cancelled after ${status.sends_done ?? 0} send(s)` });
+      } else if (status.state === 'failed') {
+        setFeedback({ ok: false, msg: status.error || 'Scheduled send failed' });
+      }
+    }
+  }
+
+  async function cancelJob() {
+    try {
+      await cancelScheduledSend();
+    } catch (err) {
+      setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Cancel failed' });
+    }
+    await refreshJob();
+  }
+
+  function startPolling() {
+    stopPolling();
+    pollRef.current = window.setInterval(() => void refreshJob(), POLL_INTERVAL_MS);
+  }
+
+  function stopPolling() {
+    if (pollRef.current != null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }
+}
+
+function describeJob(job: ScheduledSendStatus): string {
+  if (job.state === 'waiting') {
+    const at = job.next_send_at ? ` at ${new Date(job.next_send_at).toLocaleTimeString()}` : '';
+    return `Delayed send to ${job.address} — first send${at}`;
+  }
+  if (job.interval_seconds) {
+    const skipped = job.sends_skipped ? ` (${job.sends_skipped} skipped)` : '';
+    return `Cyclic send to ${job.address} every ${job.interval_seconds}s — ${job.sends_done ?? 0} sent${skipped}`;
+  }
+  return `Sending to ${job.address}…`;
 }
 
 function boolBtn(disabled: boolean): React.CSSProperties {

--- a/frontend/src/utils/knxSend.ts
+++ b/frontend/src/utils/knxSend.ts
@@ -18,28 +18,69 @@ export function formatDpt(main?: number | null, sub?: number | null): string {
   return sub == null ? String(main) : `${main}.${String(sub).padStart(3, '0')}`;
 }
 
-async function post(endpoint: string, body: unknown): Promise<void> {
+async function post<T = unknown>(endpoint: string, body?: unknown): Promise<T> {
   const res = await fetch(apiUrl(endpoint), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
+    body: body === undefined ? undefined : JSON.stringify(body),
   });
   if (!res.ok) {
     let detail = `Request failed (${res.status})`;
     try {
       const data = await res.json();
-      if (data?.detail) detail = data.detail;
+      if (typeof data?.detail === 'string') detail = data.detail;
     } catch {
       // non-JSON error body — keep the generic message
     }
     throw new Error(detail);
   }
+  return res.json() as Promise<T>;
 }
 
-export function sendTelegram(address: string, payload: unknown, dpt?: string, response = false): Promise<void> {
+export function sendTelegram(address: string, payload: unknown, dpt?: string, response = false): Promise<unknown> {
   return post('/api/knx/send', { address, payload, dpt: dpt || null, response });
 }
 
-export function readTelegram(address: string): Promise<void> {
+export function readTelegram(address: string): Promise<unknown> {
   return post('/api/knx/read', { address });
+}
+
+/** Status of the (single) delayed/cyclic send job, as returned by the backend. */
+export interface ScheduledSendStatus {
+  state: 'idle' | 'waiting' | 'running' | 'done' | 'cancelled' | 'failed';
+  id?: string;
+  address?: string;
+  delay_seconds?: number;
+  interval_seconds?: number | null;
+  sends_done?: number;
+  sends_skipped?: number;
+  next_send_at?: string | null;
+  finished_at?: string | null;
+  error?: string | null;
+}
+
+export function startScheduledSend(
+  address: string,
+  payload: unknown,
+  dpt: string | undefined,
+  opts: { delaySeconds?: number; intervalSeconds?: number },
+): Promise<ScheduledSendStatus> {
+  return post<ScheduledSendStatus>('/api/knx/send/scheduled', {
+    address,
+    payload,
+    dpt: dpt || null,
+    response: false,
+    delay_seconds: opts.delaySeconds ?? 0,
+    interval_seconds: opts.intervalSeconds ?? null,
+  });
+}
+
+export async function getScheduledSendStatus(): Promise<ScheduledSendStatus> {
+  const res = await fetch(apiUrl('/api/knx/send/scheduled/status'));
+  if (!res.ok) throw new Error(`Request failed (${res.status})`);
+  return res.json() as Promise<ScheduledSendStatus>;
+}
+
+export function cancelScheduledSend(): Promise<unknown> {
+  return post('/api/knx/send/scheduled/cancel');
 }


### PR DESCRIPTION
Fixes #167

## What

Extends "Send to bus" with an optional send delay and cyclic sending at a configurable interval, like the ETS group monitor.

## Design

- **Single active job** at a time, mirroring the `telegram_import` job pattern: `backend/cyclic_send.py` with a `SendJob` dataclass, module-level `current_job`/`_job_task`, cooperative cancel. Jobs live in memory only and do not survive restarts.
- **Semantics:** `delay_seconds` (0–86400) waits once before the first send; `interval_seconds` (1–86400, optional) repeats send-then-sleep until cancelled. One-shot = no interval.
- **1s interval floor** (pydantic validation) so a runaway job cannot flood the bus (single job, TP1 ≈ 30–50 tps).
- **Disconnect mid-cycle:** attempts are skipped and counted (`sends_skipped`) instead of failing the job — combined with #166 the connection self-heals and the cycle resumes.
- Endpoints: `POST /api/knx/send/scheduled` (400 for immediate sends — use `/api/knx/send`; 409 while a job is active; address/payload validated up front), `GET /api/knx/send/scheduled/status`, `POST /api/knx/send/scheduled/cancel`. Same write guards as the existing send endpoints.
- Lifespan shutdown cancels an active job (`main.py`, before `knx_shutdown`).

## UI

- Compact "Delay s" / "Every s" fields in the send bar; Write/On/Off route through the scheduled endpoint when either is set.
- Live indicator row with a Timer icon — "Cyclic send to 1/2/3 every 5s — 12 sent (2 skipped)" — and a Cancel button; send buttons are disabled while a job is active.
- Status polling (1s) starts with the job and re-attaches to a running job after a page reload.

## Tests

- Backend: job lifecycle (delayed one-shot, cyclic ticks + cancel, second job rejected, skips while disconnected, failure state, shutdown cancel) and API tests (200/400/409/422/403 paths, status, cancel). 153 passed.
- Frontend: send bar tests for immediate vs scheduled path and reload pickup; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)