### PR TITLE
fix: stop pinning pydantic-core to end unresolvable Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,18 +14,14 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      pydantic:
-        patterns:
-          - "pydantic"
-          - "pydantic_core"
-          - "pydantic-core"
       dependencies:
         patterns:
           - "*"
-        exclude-patterns:
-          - "pydantic"
-          - "pydantic_core"
-          - "pydantic-core"
+    # pydantic-core is not pinned in requirements.txt (pydantic pins it
+    # exactly itself); ignore it in case it ever shows up transitively.
+    ignore:
+      - dependency-name: "pydantic-core"
+      - dependency-name: "pydantic_core"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,8 +18,9 @@ packaging==26.2
 pluggy==1.6.0
 pycparser==3.0
 pycryptodomex==3.23.0
+# pydantic-core is deliberately unpinned: pydantic requires an exact core
+# version itself, so pinning it here only creates unresolvable Dependabot PRs.
 pydantic==2.13.4
-pydantic_core==2.46.4
 Pygments==2.20.0
 pytest==9.1.1
 python-dotenv==1.2.2


### PR DESCRIPTION
## Problem

Dependabot PRs bumping `pydantic_core` (like #168) are **structurally unresolvable**: pydantic pins its core dependency exactly (`pydantic==2.13.4` → `pydantic-core==2.46.4`), so a solo core bump always conflicts. The existing "pydantic" Dependabot group didn't help because it only bundles packages when both have pending updates — and pydantic-core routinely releases between pydantic releases. This will re-break on every such release.

## Fix

- Drop the `pydantic_core` pin from `backend/requirements.txt`. Its version is fully determined by the pydantic pin, so reproducibility is unchanged — pip installs the exact core version pydantic requires.
- Remove the now-pointless pydantic group from `.github/dependabot.yml`; add an `ignore` for pydantic-core as belt and braces.

Future pydantic updates arrive as normal single bumps that bring the matching core along automatically.

Verified: `pip install --dry-run -r requirements.txt` resolves cleanly (pydantic 2.13.4 / core 2.46.4).

Supersedes #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)