### PR TITLE
feat: device-centric live status view for all KOs of a device

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -95,6 +95,14 @@ User preferences are persisted locally using cookies:
 - Selected Bus Rate unit (s/m/h)
 - Column visibility toggles (e.g., hiding Raw Data or DPT columns)
 
+### 2.8 Building Structure & Device Status
+Device-centric browsing and diagnostics derived from the ETS project (`/api/building`).
+- **Building Tree:** Mirrors the ETS building view — nested spaces → devices → channels → communication objects (KOs), each KO listing its linked group addresses, DPT names and flags. Rows offer quick actions: filter by device (source), filter connected GAs (targets), and open the last-seen view.
+- **Device Status View (Live KOs):** A per-device panel showing **all** communication objects with the current value of each linked group address — regardless of which device wrote it (KNX-Lens style diagnostics, #153).
+  - Initial values come from `GET /api/telegrams/last`, which returns the most recent telegram **per group address** (`store.get_last_unique_telegrams()`), so quiet addresses are included instead of falling off a recency-limited list. An optional `target_address` param (comma-separated) narrows the result.
+  - Values then update live from the existing telegram websocket feed — no polling.
+  - Each row shows KO number, object text/function, DPT, group address, formatted value with unit, age of the value, and the source device that last wrote it.
+
 ---
 
 ## 3. Implementation Plan (Development State)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Spectrum KNX is a dedicated tool to record, store, search, and visualize KNX bus
 - **Historical Analysis:** Search millions of past telegrams instantly with powerful backend query engines.
 - **Time-Delta Context:** Automatically capture the events "before and after" a filtered event to debug logic faults.
 - **Data Rendering:** Dynamically graph numerical readouts over time, grouped by physical unit types.
+- **Device Status View:** Browse the ETS building structure and open any device to see all its communication objects with live values — KNX-Lens-style diagnostics in the browser.
 - **Zero Loss:** Pause the live feed without dropping packets—everything queues silently in the background buffer until you resume.
 - **Database Maintenance:** Inspect database size, telegram count and covered time range; purge old telegrams with a dry-run preview and reclaim the freed disk space—right from the UI.
 - **Home Assistant Companion Mode:** Run the analyzer directly on Home Assistant's own KNX telegram history—no second bus connection, no separate database.

--- a/backend/api.py
+++ b/backend/api.py
@@ -156,6 +156,21 @@ async def get_telegrams(
     }
 
 
+@router.get("/api/telegrams/last")
+async def get_last_telegrams(target_address: str | None = None):
+    """Returns the most recent telegram per group address (#153).
+
+    Unlike /api/telegrams this is an aggregation: one entry per destination GA,
+    so quiet addresses are included instead of falling off a recency-limited
+    list. Optionally filtered to a comma-separated set of group addresses.
+    """
+    telegrams = await store.get_last_unique_telegrams()
+    if target_address:
+        wanted = {t.strip() for t in target_address.split(",") if t.strip()}
+        telegrams = [t for t in telegrams if t.destination in wanted]
+    return {"telegrams": _build_telegram_response(telegrams)}
+
+
 @router.get("/api/filter-options")
 async def get_filter_options():
     """

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -243,6 +243,47 @@ def test_get_telegrams(mock_query):
     assert data["telegrams"][0]["raw_data"] == "01"
 
 
+def _stored_telegram(destination: str, value: float) -> StoredTelegram:
+    return StoredTelegram(
+        timestamp=datetime(2023, 1, 1),
+        source="1.1.1",
+        destination=destination,
+        telegramtype="GroupValueWrite",
+        direction="Incoming",
+        dpt_main=5,
+        dpt_sub=1,
+        payload=None,
+        value=value,
+        raw_data="7f",
+        source_name="Test Source",
+        destination_name="Test GA",
+    )
+
+
+@patch("database.store.get_last_unique_telegrams", new_callable=AsyncMock)
+def test_get_last_telegrams(mock_last):
+    mock_last.return_value = [_stored_telegram("1/2/3", 50.0), _stored_telegram("4/5/6", 25.0)]
+
+    response = client.get("/api/telegrams/last")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["telegrams"]) == 2
+    assert data["telegrams"][0]["target_address"] == "1/2/3"
+    # Serialized like /api/telegrams (DPT names, formatted values, ...)
+    assert data["telegrams"][0]["value_formatted"] is not None
+    assert data["telegrams"][0]["dpt_name"] is not None
+
+
+@patch("database.store.get_last_unique_telegrams", new_callable=AsyncMock)
+def test_get_last_telegrams_filtered(mock_last):
+    mock_last.return_value = [_stored_telegram("1/2/3", 50.0), _stored_telegram("4/5/6", 25.0)]
+
+    response = client.get("/api/telegrams/last?target_address=4/5/6,7/8/9")
+    assert response.status_code == 200
+    data = response.json()
+    assert [t["target_address"] for t in data["telegrams"]] == ["4/5/6"]
+
+
 @patch("database.store.query", new_callable=AsyncMock)
 def test_get_telegrams_string_value_formatted(mock_query):
     """Strings stored as plain payload (new format) should display without JSON wrapping."""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useWebSocket, type Telegram, type ConnectionStateEvent } from './hooks/useWebSocket';
+import { DeviceStatusOverlay } from './components/DeviceStatusOverlay';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigCookie, writeSortConfigCookie } from './utils/sortConfig';
 import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor, FolderInput, Send, Sparkles } from 'lucide-react';
@@ -15,7 +16,7 @@ import { ProjectUploadWizard } from './components/ProjectUploadWizard';
 import { KeysUploadWizard } from './components/KeysUploadWizard';
 import { LastSeenOverlay } from './components/LastSeenOverlay';
 import { StatisticsOverlay } from './components/StatisticsOverlay';
-import { BuildingOverlay } from './components/BuildingOverlay';
+import { BuildingOverlay, type DeviceNode } from './components/BuildingOverlay';
 import { DatabaseOverlay } from './components/DatabaseOverlay';
 import { SendTelegramBar } from './components/SendTelegramBar';
 import { UpdateNotification } from './components/UpdateNotification';
@@ -138,6 +139,8 @@ function App() {
   const [lastSeenMode, setLastSeenMode] = useState<'ga' | 'pa'>('ga');
   const [isStatisticsOpen, setIsStatisticsOpen] = useState(false);
   const [isBuildingOpen, setIsBuildingOpen] = useState(false);
+  const [statusDevice, setStatusDevice] = useState<DeviceNode | null>(null);
+  const [latestTelegram, setLatestTelegram] = useState<Telegram | null>(null);
   const [isDatabaseOpen, setIsDatabaseOpen] = useState(false);
   const [isSendOpen, setIsSendOpen] = useState(false);
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
@@ -286,6 +289,9 @@ function App() {
 
   // ── WebSocket ───────────────────────────────────────────────────────────────
   const handleTelegram = useCallback((t: Telegram) => {
+    // Track the newest telegram even while paused — the device status view (#153)
+    // stays live independently of the table.
+    setLatestTelegram(t);
     const now = Date.now();
     arrivalTimesRef.current.push(now);
     const oneHourAgo = now - 3_600_000;
@@ -604,7 +610,7 @@ function App() {
                 </button>
                 <button
                   className="icon-button"
-                  onClick={() => { setIsBuildingOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsDatabaseOpen(false); }}
+                  onClick={() => { setIsBuildingOpen(v => !v); setStatusDevice(null); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsDatabaseOpen(false); }}
                   title="Building structure"
                   style={{ color: isBuildingOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
                 >
@@ -908,12 +914,19 @@ function App() {
                     filterOptions={filterOptions}
                     onClose={() => setIsStatisticsOpen(false)}
                   />
+                ) : isBuildingOpen && statusDevice ? (
+                  <DeviceStatusOverlay
+                    device={statusDevice}
+                    latestTelegram={latestTelegram}
+                    onClose={() => setStatusDevice(null)}
+                  />
                 ) : isBuildingOpen ? (
                   <BuildingOverlay
                     onClose={() => setIsBuildingOpen(false)}
                     onFilterDevice={(pa) => handleQuickFilter('sources', pa)}
                     onFilterGAs={handleFilterGAs}
                     onLastSeen={handleQuickLastSeen}
+                    onDeviceStatus={setStatusDevice}
                   />
                 ) : isDatabaseOpen ? (
                   <DatabaseOverlay onClose={() => setIsDatabaseOpen(false)} />

--- a/frontend/src/components/BuildingOverlay.tsx
+++ b/frontend/src/components/BuildingOverlay.tsx
@@ -1,18 +1,18 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import {
-  X, RefreshCw, Building2, ChevronDown, ChevronRight, Cpu, Layers, Filter, ListFilter, Clock,
+  X, RefreshCw, Building2, ChevronDown, ChevronRight, Cpu, Layers, Filter, ListFilter, Clock, Activity,
 } from 'lucide-react';
 import { apiUrl } from '../utils/basePath';
 import { useExpanded } from '../utils/buildingExpansion';
 
 // ── Types (mirror /api/building response) ──────────────────────────────────────
 
-interface GaRef {
+export interface GaRef {
   address: string;
   name: string;
 }
 
-interface Ko {
+export interface Ko {
   number: number | null;
   name: string;
   text: string;
@@ -21,13 +21,13 @@ interface Ko {
   group_addresses: GaRef[];
 }
 
-interface Channel {
+export interface Channel {
   id: string;
   name: string;
   kos: Ko[];
 }
 
-interface DeviceNode {
+export interface DeviceNode {
   address: string;
   name: string;
   manufacturer: string;
@@ -58,6 +58,8 @@ interface BuildingOverlayProps {
   onFilterGAs: (addresses: string[]) => void;
   /** Open the last-seen overlay for one or more addresses. */
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  /** Open the live KO status view for a device (#153). */
+  onDeviceStatus: (device: DeviceNode) => void;
 }
 
 // ── Group-address collection helpers ─────────────────────────────────────────────
@@ -246,7 +248,8 @@ const DeviceRow: React.FC<{
   onFilterDevice: (pa: string) => void;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
-}> = ({ device, depth, query, onFilterDevice, onFilterGAs, onLastSeen }) => {
+  onDeviceStatus: (device: DeviceNode) => void;
+}> = ({ device, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus }) => {
   const [open, toggle] = useExpanded(`dev:${device.address}`, false);
   const koCount = device.channels.reduce((s, c) => s + c.kos.length, 0) + device.kos.length;
   const hasChildren = koCount > 0;
@@ -305,6 +308,17 @@ const DeviceRow: React.FC<{
         >
           <Clock size={12} />
         </button>
+        {hasChildren && (
+          <button
+            style={iconBtnStyle}
+            title="Live status of all communication objects"
+            onClick={e => { e.stopPropagation(); onDeviceStatus(device); }}
+            onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+            onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+          >
+            <Activity size={12} />
+          </button>
+        )}
       </div>
       {effectiveOpen && hasChildren && (
         <div>
@@ -384,7 +398,8 @@ const SpaceRow: React.FC<{
   onFilterDevice: (pa: string) => void;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
-}> = ({ space, path, depth, query, onFilterDevice, onFilterGAs, onLastSeen }) => {
+  onDeviceStatus: (device: DeviceNode) => void;
+}> = ({ space, path, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus }) => {
   const [open, toggle] = useExpanded(`space:${path}`, depth < 2);
   if (query && !spaceMatches(space, query)) return null;
   const effectiveOpen = open || !!query;
@@ -415,13 +430,13 @@ const SpaceRow: React.FC<{
           {sortSpaces(space.spaces).map((sub, i) => (
             <SpaceRow
               key={`${sub.name}-${i}`} space={sub} path={`${path}/${sub.type}:${sub.name}#${i}`} depth={depth + 1} query={query}
-              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
             />
           ))}
           {visibleDevices.map(device => (
             <DeviceRow
               key={device.address} device={device} depth={depth + 1} query={query}
-              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
             />
           ))}
         </div>
@@ -433,7 +448,7 @@ const SpaceRow: React.FC<{
 // ── Main overlay ────────────────────────────────────────────────────────────────
 
 export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
-  onClose, onFilterDevice, onFilterGAs, onLastSeen,
+  onClose, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus,
 }) => {
   const [data, setData] = useState<BuildingData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -507,7 +522,7 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
           {sortSpaces(data.tree).map((space, i) => (
             <SpaceRow
               key={`${space.name}-${i}`} space={space} path={`${space.type}:${space.name}#${i}`} depth={0} query={query}
-              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
             />
           ))}
 
@@ -519,7 +534,7 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
               {visibleUnassigned.map(device => (
                 <DeviceRow
                   key={device.address} device={device} depth={1} query={query}
-                  onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+                  onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
                 />
               ))}
             </div>

--- a/frontend/src/components/DeviceStatusOverlay.test.tsx
+++ b/frontend/src/components/DeviceStatusOverlay.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { DeviceStatusOverlay } from './DeviceStatusOverlay';
+import type { DeviceNode } from './BuildingOverlay';
+import type { Telegram } from '../hooks/useWebSocket';
+
+const DEVICE: DeviceNode = {
+  address: '1.1.5',
+  name: 'Switch Actuator',
+  manufacturer: 'ACME',
+  hardware: 'SA/S 4.16',
+  channels: [
+    {
+      id: 'ch1',
+      name: 'Channel A',
+      kos: [
+        {
+          number: 10,
+          name: 'Switch',
+          text: 'Switch',
+          function_text: 'On/Off',
+          dpts: [{ main: 1, sub: 1, name: '1.001 - Switch' }],
+          group_addresses: [{ address: '1/2/3', name: 'Kitchen Light' }],
+        },
+      ],
+    },
+  ],
+  kos: [
+    {
+      number: 11,
+      name: 'Status',
+      text: 'Status',
+      function_text: '',
+      dpts: [{ main: 1, sub: 11, name: '1.011 - State' }],
+      group_addresses: [{ address: '1/2/4', name: 'Kitchen Light Status' }],
+    },
+  ],
+};
+
+function telegram(target: string, value: string): Telegram {
+  return {
+    timestamp: new Date().toISOString(),
+    source_address: '1.1.9',
+    source_name: 'Push Button',
+    target_address: target,
+    telegram_type: 'GroupValueWrite',
+    dpt: '1.001',
+    dpt_main: 1,
+    dpt_sub: 1,
+    dpt_name: '1.001 - Switch',
+    value_numeric: 1,
+    value_json: null,
+    value_formatted: value,
+    raw_data: '01',
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test('loads latest values per GA and renders one row per KO group address', async () => {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    expect(url).toContain('/api/telegrams/last');
+    expect(decodeURIComponent(url)).toContain('1/2/3,1/2/4');
+    return { ok: true, json: async () => ({ telegrams: [telegram('1/2/3', 'On')] }) } as Response;
+  }));
+
+  render(<DeviceStatusOverlay device={DEVICE} latestTelegram={null} onClose={() => {}} />);
+
+  await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
+  // KO 11's GA has no stored telegram yet
+  expect(screen.getByText('never seen')).toBeInTheDocument();
+  expect(screen.getByText('Channel A')).toBeInTheDocument();
+  expect(screen.getByText('1/2/4')).toBeInTheDocument();
+});
+
+test('updates a value live from the websocket feed', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => (
+    { ok: true, json: async () => ({ telegrams: [telegram('1/2/3', 'On')] }) } as Response
+  )));
+
+  const { rerender } = render(
+    <DeviceStatusOverlay device={DEVICE} latestTelegram={null} onClose={() => {}} />
+  );
+  await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
+
+  rerender(
+    <DeviceStatusOverlay device={DEVICE} latestTelegram={telegram('1/2/4', 'Off')} onClose={() => {}} />
+  );
+  await waitFor(() => expect(screen.getByText('Off')).toBeInTheDocument());
+  expect(screen.queryByText('never seen')).not.toBeInTheDocument();
+
+  // Telegrams for unrelated GAs are ignored
+  rerender(
+    <DeviceStatusOverlay device={DEVICE} latestTelegram={telegram('9/9/9', 'Ignored')} onClose={() => {}} />
+  );
+  expect(screen.queryByText('Ignored')).not.toBeInTheDocument();
+});

--- a/frontend/src/components/DeviceStatusOverlay.tsx
+++ b/frontend/src/components/DeviceStatusOverlay.tsx
@@ -1,0 +1,224 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { X, RefreshCw, Activity, Layers } from 'lucide-react';
+import { apiUrl } from '../utils/basePath';
+import type { Telegram } from '../hooks/useWebSocket';
+import type { DeviceNode, Ko } from './BuildingOverlay';
+
+interface DeviceStatusOverlayProps {
+  device: DeviceNode;
+  /** Newest telegram from the live websocket feed; used to update values in place. */
+  latestTelegram: Telegram | null;
+  onClose: () => void;
+}
+
+const thStyle: React.CSSProperties = {
+  padding: '0.5rem 0.75rem',
+  textAlign: 'left',
+  fontWeight: 600,
+  fontSize: '0.7rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  color: 'var(--text-dim)',
+  whiteSpace: 'nowrap',
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: '0.45rem 0.75rem',
+  verticalAlign: 'middle',
+};
+
+const mono: React.CSSProperties = { fontFamily: "'JetBrains Mono', monospace" };
+
+function ageOf(timestamp: string): string {
+  const diffMs = Date.now() - new Date(timestamp).getTime();
+  if (diffMs < 60_000) return `${Math.max(0, Math.round(diffMs / 1000))}s ago`;
+  if (diffMs < 3_600_000) return `${Math.round(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.round(diffMs / 3_600_000)}h ago`;
+  return `${Math.round(diffMs / 86_400_000)}d ago`;
+}
+
+/**
+ * Device-centric live status view (#153): every communication object of a
+ * device with the current value of its linked group address(es), regardless
+ * of which device wrote it. Values load from /api/telegrams/last (latest
+ * telegram per GA) and update live from the websocket feed.
+ */
+export const DeviceStatusOverlay: React.FC<DeviceStatusOverlayProps> = ({
+  device, latestTelegram, onClose,
+}) => {
+  const [valuesByGA, setValuesByGA] = useState<Record<string, Telegram>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [fetchedAt, setFetchedAt] = useState<Date | null>(null);
+
+  const allGAs = useMemo(() => {
+    const set = new Set<string>();
+    for (const ch of device.channels) for (const ko of ch.kos) for (const ga of ko.group_addresses) set.add(ga.address);
+    for (const ko of device.kos) for (const ga of ko.group_addresses) set.add(ga.address);
+    return set;
+  }, [device]);
+
+  const fetchValues = useCallback(async () => {
+    if (allGAs.size === 0) return;
+    setIsLoading(true);
+    try {
+      const res = await fetch(
+        apiUrl(`/api/telegrams/last?target_address=${encodeURIComponent([...allGAs].join(','))}`)
+      );
+      const json = await res.json();
+      const map: Record<string, Telegram> = {};
+      for (const t of (json.telegrams ?? []) as Telegram[]) map[t.target_address] = t;
+      setValuesByGA(map);
+      setFetchedAt(new Date());
+    } catch {
+      // network errors are non-fatal; the view just stays empty/stale
+    } finally {
+      setIsLoading(false);
+    }
+  }, [allGAs]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchValues();
+  }, [fetchValues]);
+
+  // Keep values current from the live feed without re-fetching.
+  useEffect(() => {
+    if (!latestTelegram || !allGAs.has(latestTelegram.target_address)) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setValuesByGA(prev => ({ ...prev, [latestTelegram.target_address]: latestTelegram }));
+  }, [latestTelegram, allGAs]);
+
+  const koCount = device.channels.reduce((s, c) => s + c.kos.length, 0) + device.kos.length;
+
+  const renderKoRows = (kos: Ko[]) =>
+    kos.flatMap((ko, koIdx) =>
+      ko.group_addresses.map((ga, gaIdx) => {
+        const t = valuesByGA[ga.address];
+        const first = gaIdx === 0;
+        return (
+          <tr key={`${ko.number}-${koIdx}-${ga.address}`} style={{ borderTop: first ? '1px solid var(--border-color)' : 'none' }}>
+            <td style={{ ...tdStyle, ...mono, fontSize: '0.75rem', color: 'var(--text-dim)' }}>
+              {first && ko.number != null ? ko.number : ''}
+            </td>
+            <td style={{ ...tdStyle, fontSize: '0.78rem', maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                title={first ? `${ko.text}${ko.function_text ? ` — ${ko.function_text}` : ''}` : undefined}>
+              {first && (
+                <>
+                  {ko.text || ko.name || '—'}
+                  {ko.function_text && <span style={{ color: 'var(--text-dim)' }}> — {ko.function_text}</span>}
+                </>
+              )}
+            </td>
+            <td style={{ ...tdStyle, fontSize: '0.73rem', color: 'var(--text-dim)', whiteSpace: 'nowrap' }}>
+              {first ? (ko.dpts.map(d => d.name || `DPT ${d.main}`).join(', ') || '—') : ''}
+            </td>
+            <td style={{ ...tdStyle, whiteSpace: 'nowrap' }}>
+              <span style={{ ...mono, fontSize: '0.75rem' }}>{ga.address}</span>
+              {ga.name && <span style={{ fontSize: '0.7rem', color: 'var(--text-dim)' }}> {ga.name}</span>}
+            </td>
+            <td style={{ ...tdStyle, fontSize: '0.8rem', fontWeight: 600, whiteSpace: 'nowrap' }}>
+              {t ? (
+                <>
+                  {t.value_formatted ?? t.value_numeric ?? '—'}
+                  {t.unit && <span style={{ fontWeight: 400, color: 'var(--text-dim)' }}> {t.unit}</span>}
+                </>
+              ) : (
+                <span style={{ color: 'var(--text-dim)', fontWeight: 400 }}>never seen</span>
+              )}
+            </td>
+            <td style={{ ...tdStyle, fontSize: '0.73rem', color: 'var(--text-dim)', whiteSpace: 'nowrap' }}
+                title={t ? new Date(t.timestamp).toLocaleString() : undefined}>
+              {t ? ageOf(t.timestamp) : '—'}
+            </td>
+            <td style={{ ...tdStyle, whiteSpace: 'nowrap' }}>
+              {t ? (
+                <>
+                  <span style={{ ...mono, fontSize: '0.73rem' }}>{t.source_address}</span>
+                  {t.source_name && <span style={{ fontSize: '0.7rem', color: 'var(--text-dim)' }}> {t.source_name}</span>}
+                </>
+              ) : '—'}
+            </td>
+          </tr>
+        );
+      })
+    );
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Header */}
+      <div style={{
+        padding: '0.65rem 1rem', borderBottom: '1px solid var(--border-color)',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        flexShrink: 0, gap: '1rem',
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.65rem', minWidth: 0 }}>
+          <Activity size={15} style={{ color: 'var(--accent-primary)', flexShrink: 0 }} />
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontWeight: 600, fontSize: '0.875rem' }}>
+              Device Status — <span style={mono}>{device.address}</span> {device.name}
+            </div>
+            <div style={{ fontSize: '0.73rem', color: 'var(--text-dim)', marginTop: '0.1rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {[device.manufacturer, device.hardware].filter(Boolean).join(' · ')}
+              {' '}— {koCount} communication object{koCount !== 1 ? 's' : ''}, live values per group address
+            </div>
+          </div>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexShrink: 0 }}>
+          {fetchedAt && (
+            <span style={{ fontSize: '0.68rem', color: 'var(--text-dim)' }}>
+              loaded {fetchedAt.toLocaleTimeString()} · live
+            </span>
+          )}
+          <button className="icon-button" title="Reload values" onClick={() => void fetchValues()}>
+            <RefreshCw size={14} style={isLoading ? { animation: 'spin 1s linear infinite' } : undefined} />
+          </button>
+          <button className="icon-button" title="Back to building view" onClick={onClose}>
+            <X size={15} />
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {koCount === 0 ? (
+          <div style={{ padding: '2rem', textAlign: 'center', fontSize: '0.8rem', color: 'var(--text-dim)' }}>
+            This device has no communication objects linked to group addresses.
+          </div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.8rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid var(--border-color)' }}>
+                <th style={thStyle}>KO</th>
+                <th style={thStyle}>Object</th>
+                <th style={thStyle}>DPT</th>
+                <th style={thStyle}>Group Address</th>
+                <th style={thStyle}>Value</th>
+                <th style={thStyle}>Updated</th>
+                <th style={thStyle}>Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              {device.channels.map(ch => (
+                <React.Fragment key={ch.id}>
+                  <tr>
+                    <td colSpan={7} style={{
+                      ...tdStyle, paddingTop: '0.7rem', fontSize: '0.7rem', fontWeight: 600,
+                      textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--text-dim)',
+                    }}>
+                      <Layers size={11} style={{ verticalAlign: '-1px', marginRight: '0.35rem' }} />
+                      {ch.name || ch.id}
+                    </td>
+                  </tr>
+                  {renderKoRows(ch.kos)}
+                </React.Fragment>
+              ))}
+              {renderKoRows(device.kos)}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};


### PR DESCRIPTION
Fixes #153

## What

A device-centric live view, KNX-Lens style: open any device from the building tree and see **all of its communication objects** with the current value of each linked group address — regardless of which device wrote it. Requested on the KNX-User-Forum (posts #56/#71).

## Gap this closes

The building view (#160/#164) already covered structure browsing (spaces → devices → channels → KOs), and per-KO "last seen" jumps existed. What was missing:
- The device-level "last seen" filtered by *source* address — telegrams *sent by* the device, not the status of its KOs (which other devices write).
- No aggregated per-device view; each KO had to be clicked individually.
- `/api/telegrams` returns the N most recent telegrams, so quiet GAs fall off the list — unusable as a status table.

## Changes

**Backend**
- New `GET /api/telegrams/last`: exposes the store's existing `get_last_unique_telegrams()` (latest telegram **per destination GA**, window query; the buffered wrapper flushes first so values are current). Optional `target_address` comma-list filter. Same serialization as `/api/telegrams` (DPT names, formatted values).

**Frontend**
- New `DeviceStatusOverlay`: table of all KOs (grouped by channel) with KO number, object text/function, DPT, group address, formatted value + unit, value age, and the source device that last wrote it. Opened via a new Activity button on device rows in the building tree; closing returns to the tree.
- Initial values load from `/api/telegrams/last`; afterwards the view updates **live** from the existing websocket feed (App threads the newest telegram down — works even while the main table is paused). No polling.

**Docs**
- New DESIGN.md section 2.8 (Building Structure & Device Status) and a README feature bullet.

## Tests

- Backend: `/api/telegrams/last` unfiltered + filtered serialization tests (160 passed total).
- Frontend: DeviceStatusOverlay — initial fetch renders one row per KO/GA incl. "never seen", live update via websocket telegram, unrelated telegrams ignored (17 passed total). Lint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)