### PR TITLE
feat: shareable visualization URLs and embed mode

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -12,7 +12,7 @@ Use a throwaway sqlite DB to avoid needing Postgres:
 
 ```bash
 cd backend
-DATABASE_URL="sqlite+aiosqlite:////abs/path/to/test.db" venv/bin/uvicorn main:app --port 8321
+DATABASE_URL="sqlite+aiosqlite:////abs/path/to/test.db" .venv/bin/uvicorn main:app --port 8321
 ```
 
 Seed telegrams through the storage library (NOT `seed_data.py` — that targets the
@@ -32,10 +32,23 @@ VITE_BACKEND_URL=http://localhost:8321 npx vite --port 5199
 
 ## Driving the UI headlessly
 
-Playwright's bundled chromium is not installed and `--with-deps` needs sudo;
-system Chrome works: `npm i playwright` in a scratch dir, then
-`chromium.launch({ channel: 'chrome' })`. Toolbar overlays are reached via
-`button[title="..."]` (e.g. "Database maintenance", "Traffic statistics").
+`npm i playwright` in a scratch dir, then `npx playwright install chromium`
+(works without sudo; system deps are present). No system Chrome on this host.
+Toolbar overlays are reached via `button[title="..."]` (e.g. "Database
+maintenance", "Traffic statistics").
+
+With no `.knxproj` loaded, a blocking non-closable "Project Setup" wizard
+covers the app. Stub it at the network boundary:
+
+```js
+await ctx.route('**/api/project/status', route => route.fulfill({
+  json: { upload_feature_active: true, upload_writable: false, project_loaded: false, upload_required: false },
+}));
+```
+
+The venv is `backend/.venv` (not `venv`). Tab switching goes through the nav
+dropdown: click the current tab name (e.g. "Group Monitor"), then the entry
+(e.g. "History Search").
 
 ## Companion mode (STORE_MODE=external-readonly)
 
@@ -45,7 +58,7 @@ Run against any store sqlite file without a bus or HA:
 STORE_MODE=external-readonly \
 DATABASE_URL="sqlite+aiosqlite:////abs/path/to/ha.db" \
 LIVE_SOURCE=ha_websocket HA_WS_URL=ws://localhost:8765 HA_TOKEN=test-token \
-venv/bin/uvicorn main:app --port 8322
+.venv/bin/uvicorn main:app --port 8322
 ```
 
 A fake HA core websocket (auth_required/auth_ok + `knx/subscribe_telegrams`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -95,7 +95,14 @@ User preferences are persisted locally using cookies:
 - Selected Bus Rate unit (s/m/h)
 - Column visibility toggles (e.g., hiding Raw Data or DPT columns)
 
-### 2.8 Building Structure & Device Status
+### 2.8 Shareable Visualization URLs & Embed Mode
+A visualization (filters + plotted targets + time window) can be captured as a URL, bookmarked, and embedded (#150).
+- **URL scheme:** `/?view=viz&plot=1/2/3,1/2/4&rel=24h` plus optional filter params (`src`, `tgt`, `type`, `dpt`, `before`, `after`, `rel_st=OR`), an absolute window (`start`/`end`, datetime-local UTC) instead of `rel`, and `limit`. Parsing/serialization lives in `utils/viewUrl.ts`; defaults are omitted so URLs stay short.
+- **Restore:** opening a view URL lands on the History tab with filters applied, auto-loads the window server-side (via the fetch logic shared with the loader modal in `utils/historyLoad.ts`), and opens the visualizer.
+- **Share:** a "Copy link" button in the visualizer header serializes the currently loaded view. Links from relative windows always show the *current* trailing window; absolute links always show the same data.
+- **Embed mode:** `&embed=1` renders only the chart area (mounted instead of the full app, so no websocket table/polling/wizards) for iframes such as Home Assistant's Webpage card. Relative windows stay current via the live websocket feed plus a periodic re-fetch (`&refresh=<seconds>`, default 300); `&theme=dark|light` forces a theme. Note: the app has no auth of its own and HA ingress URLs are session-bound — embedding targets direct-port/reverse-proxy setups.
+
+### 2.9 Building Structure & Device Status
 Device-centric browsing and diagnostics derived from the ETS project (`/api/building`).
 - **Building Tree:** Mirrors the ETS building view — nested spaces → devices → channels → communication objects (KOs), each KO listing its linked group addresses, DPT names and flags. Rows offer quick actions: filter by device (source), filter connected GAs (targets), and open the last-seen view.
 - **Device Status View (Live KOs):** A per-device panel showing **all** communication objects with the current value of each linked group address — regardless of which device wrote it (KNX-Lens style diagnostics, #153).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Spectrum KNX is a dedicated tool to record, store, search, and visualize KNX bus
 - **Time-Delta Context:** Automatically capture the events "before and after" a filtered event to debug logic faults.
 - **Data Rendering:** Dynamically graph numerical readouts over time, grouped by physical unit types.
 - **Device Status View:** Browse the ETS building structure and open any device to see all its communication objects with live values — KNX-Lens-style diagnostics in the browser.
+- **Shareable Charts:** Copy a link to any visualization (filters, targets, time window) to bookmark it — or add `&embed=1` and drop it into a Home Assistant dashboard as a self-updating chart.
 - **Zero Loss:** Pause the live feed without dropping packets—everything queues silently in the background buffer until you resume.
 - **Database Maintenance:** Inspect database size, telegram count and covered time range; purge old telegrams with a dry-run preview and reclaim the freed disk space—right from the UI.
 - **Home Assistant Companion Mode:** Run the analyzer directly on Home Assistant's own KNX telegram history—no second bus connection, no separate database.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useWebSocket, type Telegram, type ConnectionStateEvent } from './hooks/useWebSocket';
+import { parseViewUrl } from './utils/viewUrl';
 import { DeviceStatusOverlay } from './components/DeviceStatusOverlay';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigCookie, writeSortConfigCookie } from './utils/sortConfig';
@@ -130,7 +131,9 @@ const NavDropdown = ({ activeTab, isSettingsOpen, onChange }: { activeTab: strin
 
 function App() {
   const [theme, setTheme] = useTheme();
-  const [activeTab, setActiveTab] = useState<'live' | 'history' | 'import'>('live');
+  // A view shared via URL (#150) starts on the History tab with its filters applied.
+  const [initialView] = useState(() => parseViewUrl(window.location.search));
+  const [activeTab, setActiveTab] = useState<'live' | 'history' | 'import'>(initialView ? 'history' : 'live');
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(true);
   const [isVisualizerOpen, setIsVisualizerOpen] = useState(false);
@@ -179,7 +182,7 @@ function App() {
   const [rateMode, setRateMode] = useState<'s' | 'm' | 'h'>((getCookie('rateMode') as 's' | 'm' | 'h') || 's');
 
   const [isHistoryLoaderOpen, setIsHistoryLoaderOpen] = useState(false);
-  const [selectedVisualizationTargets, setSelectedVisualizationTargets] = useState<string[]>([]);
+  const [selectedVisualizationTargets, setSelectedVisualizationTargets] = useState<string[]>(initialView?.plot ?? []);
 
   // ── Live State ──────────────────────────────────────────────────────────────
   const [liveTelegrams, setLiveTelegrams] = useState<Telegram[]>([]);
@@ -193,7 +196,7 @@ function App() {
 
   // ── Filter State ────────────────────────────────────────────────────────────
   const [filterOptions, setFilterOptions] = useState<FilterOptions>(EMPTY_FILTER_OPTIONS);
-  const [activeFilters, setActiveFilters] = useState<ActiveFilters>(DEFAULT_FILTERS);
+  const [activeFilters, setActiveFilters] = useState<ActiveFilters>(initialView?.filters ?? DEFAULT_FILTERS);
 
   const handleFiltersChange = useCallback((newFilters: ActiveFilters | ((prev: ActiveFilters) => ActiveFilters)) => {
     setActiveFilters((prevFilters) => {
@@ -958,6 +961,7 @@ function App() {
             projectLoaded={projectStatus?.project_loaded}
             selectedVisualizationTargets={selectedVisualizationTargets}
             onVisualizationTargetsChange={setSelectedVisualizationTargets}
+            initialView={initialView}
           />
         )}
       </main>

--- a/frontend/src/components/EmbedView.tsx
+++ b/frontend/src/components/EmbedView.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect, useLayoutEffect, useCallback } from 'react';
+import { Visualizer } from './Visualizer';
+import { useWebSocket, type Telegram } from '../hooks/useWebSocket';
+import { loadHistoryTelegrams } from '../utils/historyLoad';
+import { hasActiveFilters, matchesTelegram } from '../types/filters';
+import { wsUrl } from '../utils/basePath';
+import type { VizViewState } from '../utils/viewUrl';
+
+const DEFAULT_REFRESH_SECONDS = 300;
+const DEFAULT_LIMIT = 25000;
+
+/**
+ * Chart-only rendering of a shared view (#150) for iframes / dashboard cards
+ * (e.g. a Home Assistant Webpage card). Relative windows stay current via the
+ * live websocket feed plus a periodic window re-fetch; absolute windows are
+ * static.
+ */
+export function EmbedView({ view }: { view: VizViewState }) {
+  const [telegrams, setTelegrams] = useState<Telegram[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  // Force the requested theme (dashboards are commonly dark).
+  useLayoutEffect(() => {
+    if (view.theme) document.documentElement.setAttribute('data-theme', view.theme);
+  }, [view.theme]);
+
+  const limit = view.limit ?? DEFAULT_LIMIT;
+
+  const load = useCallback(() => {
+    loadHistoryTelegrams(view.range, limit, view.filters)
+      .then(({ telegrams: result }) => {
+        setTelegrams(result);
+        setError(null);
+      })
+      .catch(err => setError(err instanceof Error ? err.message : 'Load failed'))
+      .finally(() => setLoaded(true));
+  }, [view, limit]);
+
+  useEffect(() => {
+    load();
+    if (view.range.kind !== 'relative') return;
+    const interval = window.setInterval(load, (view.refresh ?? DEFAULT_REFRESH_SECONDS) * 1000);
+    return () => window.clearInterval(interval);
+  }, [load, view.range.kind, view.refresh]);
+
+  // Between re-fetches, append live telegrams that match the view's filters.
+  const handleTelegram = useCallback((t: Telegram) => {
+    if (view.range.kind !== 'relative') return;
+    if (hasActiveFilters(view.filters) && !matchesTelegram(t, view.filters)) return;
+    setTelegrams(prev => {
+      const next = [t, ...prev];
+      return next.length > limit ? next.slice(0, limit) : next;
+    });
+  }, [view, limit]);
+
+  useWebSocket(wsUrl('/ws/telegrams'), handleTelegram);
+
+  if (!loaded) {
+    return <div style={centered}>Loading…</div>;
+  }
+  if (error) {
+    return <div style={{ ...centered, color: 'var(--error)' }}>{error}</div>;
+  }
+  if (telegrams.length === 0) {
+    return <div style={centered}>No telegrams in the selected window.</div>;
+  }
+
+  return (
+    <div style={{ height: '100vh', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <Visualizer
+        telegrams={telegrams}
+        selectedTargets={view.plot}
+        onTargetsChange={() => {}}
+        onClose={() => {}}
+        embed
+      />
+    </div>
+  );
+}
+
+const centered: React.CSSProperties = {
+  height: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+  color: 'var(--text-dim)', fontSize: '0.875rem',
+};

--- a/frontend/src/components/HistoryLoader.tsx
+++ b/frontend/src/components/HistoryLoader.tsx
@@ -3,16 +3,11 @@ import { X, Clock, Database, AlertCircle, CheckCircle2, Calendar, Search } from 
 import type { Telegram } from '../hooks/useWebSocket';
 import type { ActiveFilters } from '../types/filters';
 import type { LoaderTimeRange } from './HistorySearch';
-import { apiUrl } from '../utils/basePath';
-
-interface Metadata {
-  total_count: number;
-  limit_reached: boolean;
-}
+import { loadHistoryTelegrams, type HistoryMetadata, type LoadedRange } from '../utils/historyLoad';
 
 interface HistoryLoaderProps {
   onClose: () => void;
-  onLoad: (telegrams: Telegram[], metadata?: Metadata) => void;
+  onLoad: (telegrams: Telegram[], metadata?: HistoryMetadata, range?: LoadedRange) => void;
   limit: number;
   /** 'monitor' = no date range pickers (Group Monitor); 'search' = full options (History Search) */
   mode?: 'monitor' | 'search';
@@ -32,25 +27,11 @@ const UNIT_TO_SECONDS: Record<Unit, number> = {
   days: 86400,
 };
 
-/** Appends active filter state as query params to a base URL string. */
-function applyFilterParams(url: string, filters?: ActiveFilters): string {
-  if (!filters) return url;
-  const params: string[] = [];
-  if (filters.sources.length > 0) params.push(`source_address=${encodeURIComponent(filters.sources.join(','))}`);
-  if (filters.targets.length > 0) params.push(`target_address=${encodeURIComponent(filters.targets.join(','))}`);
-  if (filters.types.length > 0) params.push(`telegram_type=${encodeURIComponent(filters.types.join(','))}`);
-  if (filters.dpts.length > 0) params.push(`dpt_main=${encodeURIComponent(filters.dpts.join(','))}`);
-  if (filters.deltaBeforeMs > 0) params.push(`delta_before_ms=${filters.deltaBeforeMs}`);
-  if (filters.deltaAfterMs > 0) params.push(`delta_after_ms=${filters.deltaAfterMs}`);
-  if (params.length === 0) return url;
-  return url + (url.includes('?') ? '&' : '?') + params.join('&');
-}
-
 export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, limit, mode = 'search', filters, timeRange, onTimeRangeChange }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<'idle' | 'loading' | 'success'>('idle');
-  const [resultMeta, setResultMeta] = useState<Metadata | null>(null);
+  const [resultMeta, setResultMeta] = useState<HistoryMetadata | null>(null);
 
   // Custom relative — initialised from persisted timeRange if provided
   const [relValue, setRelValue] = useState<number>(timeRange?.relValue ?? 1);
@@ -92,57 +73,16 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
     persistTimeRange({ endTime: clamped });
   };
 
-  const doFetch = useCallback(async (baseUrl: string) => {
+  const doFetch = useCallback(async (range: LoadedRange) => {
     setIsLoading(true);
     setError(null);
     setStatus('loading');
     setResultMeta(null);
     try {
-      const isOrMode = filters?.sourceTargetRelation === 'OR'
-        && (filters.sources.length > 0)
-        && (filters.targets.length > 0);
-
-      let telegrams: Telegram[];
-      let meta: Metadata;
-
-      if (isOrMode) {
-        // OR mode: two queries — one filtered by sources only, one by targets only.
-        // Results are merged and deduplicated by timestamp. The knx-telegram-store
-        // library only supports AND across source/destination filters, so we
-        // handle the OR logic here rather than in the library.
-        const srcFilters = { ...filters, targets: [], sourceTargetRelation: 'AND' as const };
-        const tgtFilters = { ...filters, sources: [], sourceTargetRelation: 'AND' as const };
-        const [srcRes, tgtRes] = await Promise.all([
-          fetch(applyFilterParams(baseUrl, srcFilters)),
-          fetch(applyFilterParams(baseUrl, tgtFilters)),
-        ]);
-        if (!srcRes.ok || !tgtRes.ok) throw new Error(`Server error: ${srcRes.ok ? tgtRes.status : srcRes.status}`);
-        const [srcData, tgtData] = await Promise.all([srcRes.json(), tgtRes.json()]);
-
-        const seen = new Set<string>();
-        const merged: Telegram[] = [];
-        for (const t of [...(srcData.telegrams || []), ...(tgtData.telegrams || [])]) {
-          if (!seen.has(t.timestamp)) {
-            seen.add(t.timestamp);
-            merged.push(t);
-          }
-        }
-        // Re-sort descending (both halves arrive sorted but interleaved)
-        merged.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-        const limitReached = (srcData.metadata?.limit_reached || tgtData.metadata?.limit_reached) ?? false;
-        meta = { total_count: merged.length, limit_reached: limitReached };
-        telegrams = merged;
-      } else {
-        const res = await fetch(applyFilterParams(baseUrl, filters));
-        if (!res.ok) throw new Error(`Server error: ${res.status}`);
-        const data = await res.json();
-        meta = data.metadata || { total_count: 0, limit_reached: false };
-        telegrams = data.telegrams || [];
-      }
-
-      setResultMeta(meta);
+      const { telegrams, metadata } = await loadHistoryTelegrams(range, limit, filters);
+      setResultMeta(metadata);
       setStatus('success');
-      onLoad(telegrams, meta);
+      onLoad(telegrams, metadata, range);
       setTimeout(onClose, 1500);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred';
@@ -151,13 +91,11 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
     } finally {
       setIsLoading(false);
     }
-  }, [filters, onLoad, onClose]);
+  }, [filters, limit, onLoad, onClose]);
 
   const handleLoadRelative = useCallback((seconds: number) => {
-    const start = new Date(Date.now() - seconds * 1000).toISOString();
-    const base = apiUrl(`/api/telegrams?limit=${limit}&start_time=${encodeURIComponent(start)}`);
-    doFetch(base);
-  }, [limit, doFetch]);
+    doFetch({ kind: 'relative', seconds });
+  }, [doFetch]);
 
   const handleLoadCustomRelative = useCallback(() => {
     if (!relValue || relValue <= 0) { setError('Enter a positive value.'); return; }
@@ -166,11 +104,8 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
 
   const handleLoadCustomAbsolute = useCallback(() => {
     if (!startTime && !endTime) { setError('Enter at least a start or end time.'); return; }
-    let url = apiUrl(`/api/telegrams?limit=${limit}`);
-    if (startTime) url += `&start_time=${encodeURIComponent(startTime + ':00Z')}`;
-    if (endTime) url += `&end_time=${encodeURIComponent(endTime + ':00Z')}`;
-    doFetch(url);
-  }, [limit, startTime, endTime, doFetch]);
+    doFetch({ kind: 'absolute', startTime, endTime });
+  }, [startTime, endTime, doFetch]);
 
   return (
     <div className="modal-overlay">

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { TelegramTable, type SortConfig, type SortKey } from './TelegramTable';
 import { readSortConfigCookie, writeSortConfigCookie } from '../utils/sortConfig';
 import type { Telegram } from '../hooks/useWebSocket';
@@ -6,6 +6,8 @@ import { History, Download, AlertTriangle, Trash2, SlidersHorizontal, LineChart,
 import { HistoryLoader } from './HistoryLoader';
 import { Visualizer } from './Visualizer';
 import { FilterPanel } from './FilterPanel';
+import { loadHistoryTelegrams, type LoadedRange } from '../utils/historyLoad';
+import { buildViewUrl, type VizViewState } from '../utils/viewUrl';
 import {
   hasActiveFilters,
   matchesTelegram,
@@ -30,11 +32,13 @@ interface HistorySearchProps {
   projectLoaded?: boolean;
   selectedVisualizationTargets: string[];
   onVisualizationTargetsChange: (targets: string[] | ((prev: string[]) => string[])) => void;
+  /** Shared-view state parsed from the URL — triggers an auto-load on mount (#150). */
+  initialView?: VizViewState | null;
 }
 
 export const HistorySearch: React.FC<HistorySearchProps> = ({
   visibleColumns, loadLimit, filterOptions, activeFilters, onFiltersChange, onOpenSettings,
-  projectLoaded, selectedVisualizationTargets, onVisualizationTargetsChange
+  projectLoaded, selectedVisualizationTargets, onVisualizationTargetsChange, initialView
 }) => {
   const [telegrams, setTelegrams] = useState<Telegram[]>([]);
   const [isLoaderOpen, setIsLoaderOpen] = useState(false);
@@ -50,6 +54,26 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
 
   // Snapshot of filters at the time of the last load — used to detect stale results
   const [filtersAtLoad, setFiltersAtLoad] = useState<ActiveFilters | null>(null);
+
+  // The time window of the last load — basis for shareable links (#150)
+  const [loadedRange, setLoadedRange] = useState<LoadedRange | null>(null);
+
+  // Auto-load a view shared via URL exactly once on mount (#150)
+  const initialViewLoaded = useRef(false);
+  useEffect(() => {
+    if (!initialView || initialViewLoaded.current) return;
+    initialViewLoaded.current = true;
+    const limit = initialView.limit ?? loadLimit;
+    loadHistoryTelegrams(initialView.range, limit, initialView.filters)
+      .then(({ telegrams: loaded, metadata: meta }) => {
+        setTelegrams(loaded);
+        setMetadata(meta);
+        setFiltersAtLoad(initialView.filters);
+        setLoadedRange(initialView.range);
+        setIsVisualizerOpen(true);
+      })
+      .catch(err => console.error('Failed to load shared view:', err));
+  }, [initialView, loadLimit]);
 
   const handleSort = (key: SortKey) => {
     setSortConfig(prev => {
@@ -106,7 +130,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     return items;
   }, [telegrams, sortConfig]);
 
-  const handleLoad = (loaded: Telegram[], meta?: { total_count: number; limit_reached: boolean }) => {
+  const handleLoad = (loaded: Telegram[], meta?: { total_count: number; limit_reached: boolean }, range?: LoadedRange) => {
     setTelegrams(prev => {
       const existingTs = new Set(prev.map(t => t.timestamp));
       const newUnique = loaded.filter(t => !existingTs.has(t.timestamp));
@@ -122,6 +146,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     setMetadata(meta || null);
     // Snapshot the filters at load time so we can detect when they diverge
     setFiltersAtLoad(activeFilters);
+    if (range) setLoadedRange(range);
   };
 
   // In-memory filter pass — mirrors live view filtering so changing filters
@@ -280,6 +305,12 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
               selectedTargets={selectedVisualizationTargets}
               onTargetsChange={onVisualizationTargetsChange}
               onClose={() => setIsVisualizerOpen(false)}
+              getShareLink={loadedRange ? () => buildViewUrl({
+                plot: selectedVisualizationTargets,
+                filters: activeFilters,
+                range: loadedRange,
+                limit: loadLimit,
+              }) : undefined}
             />
           ) : telegrams.length === 0 ? (
             <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '1.5rem' }}>

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -4,7 +4,7 @@ import { VisualizerSidebar } from './VisualizerSidebar';
 import { useChartData } from '../hooks/useChartData';
 import { MixedChart } from './MixedChart';
 import { TimelineChart } from './TimelineChart';
-import { Download } from 'lucide-react';
+import { Download, Link2, Check } from 'lucide-react';
 import { getCookie, setCookie } from '../utils/cookies';
 
 interface VisualizerProps {
@@ -12,13 +12,20 @@ interface VisualizerProps {
   selectedTargets: string[];
   onTargetsChange: (targets: string[]) => void;
   onClose: () => void;
+  /** Returns a shareable URL for the current view (#150); shows a Copy-link button when set. */
+  getShareLink?: () => string;
+  /** Chart-area-only rendering for iframe/dashboard embedding (#150). */
+  embed?: boolean;
 }
 
-export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTargets, onTargetsChange, onClose }) => {
+export const Visualizer: React.FC<VisualizerProps> = ({
+  telegrams, selectedTargets, onTargetsChange, onClose, getShareLink, embed = false,
+}) => {
 
   const chartWrapperRef = useRef<HTMLDivElement>(null);
   const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets);
   const [stepped, setStepped] = useState(() => getCookie('chartStepped') !== 'false');
+  const [linkCopied, setLinkCopied] = useState(false);
 
   const toggleStepped = () => {
     setStepped(s => {
@@ -36,6 +43,45 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
     // or just trigger print.
     window.print();
   };
+
+  const copyShareLink = async () => {
+    if (!getShareLink) return;
+    const absolute = new URL(getShareLink(), window.location.href).toString();
+    try {
+      await navigator.clipboard.writeText(absolute);
+      setLinkCopied(true);
+      setTimeout(() => setLinkCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (e.g. non-secure context) — show the URL instead.
+      window.prompt('Copy this link:', absolute);
+    }
+  };
+
+  const charts = (
+    <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: embed ? '0.75rem' : '1.5rem' }}>
+      {buckets.map(b => (
+        b.isBinary ? (
+          <TimelineChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} />
+        ) : (
+          <MixedChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} stepped={stepped} />
+        )
+      ))}
+
+      {buckets.length === 0 && selectedTargets.length > 0 && (
+        <div style={{ color: 'var(--text-dim)', textAlign: 'center', marginTop: '3rem' }}>
+          No plottable values (numeric or continuous) found for the selected targets.
+        </div>
+      )}
+    </div>
+  );
+
+  if (embed) {
+    return (
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg-subtle)' }}>
+        {charts}
+      </div>
+    );
+  }
 
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
@@ -75,6 +121,20 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
                 >
                   {stepped ? 'Stepped' : 'Linear'}
                 </button>
+                {getShareLink && (
+                  <button
+                    className="icon-button"
+                    onClick={() => void copyShareLink()}
+                    title="Copy a shareable link to this visualization (filters, targets and time range)"
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: '0.5rem', padding: '0.4rem 0.85rem',
+                      border: '1px solid var(--border-color)', borderRadius: '7px', fontSize: '0.8125rem',
+                      color: linkCopied ? 'var(--success)' : undefined,
+                    }}
+                  >
+                    {linkCopied ? <><Check size={16} /> Copied</> : <><Link2 size={16} /> Copy link</>}
+                  </button>
+                )}
                 <button
                   className="icon-button"
                   onClick={exportPng}
@@ -87,21 +147,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
             )}
           </div>
 
-          <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: '1.5rem' }}>
-            {buckets.map(b => (
-              b.isBinary ? (
-                <TimelineChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} />
-              ) : (
-                <MixedChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} stepped={stepped} />
-              )
-            ))}
-
-            {buckets.length === 0 && selectedTargets.length > 0 && (
-              <div style={{ color: 'var(--text-dim)', textAlign: 'center', marginTop: '3rem' }}>
-                No plottable values (numeric or continuous) found for the selected targets.
-              </div>
-            )}
-          </div>
+          {charts}
         </div>
       </div>
     </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,15 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { EmbedView } from './components/EmbedView.tsx'
+import { parseViewUrl } from './utils/viewUrl.ts'
+
+// Shared-view URLs (#150): embed mode renders only the chart area, so the
+// full app (websocket table, polling, wizards) never mounts inside an iframe.
+const sharedView = parseViewUrl(window.location.search)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    {sharedView?.embed ? <EmbedView view={sharedView} /> : <App />}
   </StrictMode>,
 )

--- a/frontend/src/utils/historyLoad.ts
+++ b/frontend/src/utils/historyLoad.ts
@@ -1,0 +1,89 @@
+import type { Telegram } from '../hooks/useWebSocket';
+import type { ActiveFilters } from '../types/filters';
+import { apiUrl } from './basePath';
+
+export interface HistoryMetadata {
+  total_count: number;
+  limit_reached: boolean;
+}
+
+/** The time window a history load was made with — kept for share links (#150). */
+export type LoadedRange =
+  | { kind: 'relative'; seconds: number }
+  | { kind: 'absolute'; startTime: string; endTime: string };
+
+/** Appends active filter state as query params to a base URL string. */
+export function applyFilterParams(url: string, filters?: ActiveFilters): string {
+  if (!filters) return url;
+  const params: string[] = [];
+  if (filters.sources.length > 0) params.push(`source_address=${encodeURIComponent(filters.sources.join(','))}`);
+  if (filters.targets.length > 0) params.push(`target_address=${encodeURIComponent(filters.targets.join(','))}`);
+  if (filters.types.length > 0) params.push(`telegram_type=${encodeURIComponent(filters.types.join(','))}`);
+  if (filters.dpts.length > 0) params.push(`dpt_main=${encodeURIComponent(filters.dpts.join(','))}`);
+  if (filters.deltaBeforeMs > 0) params.push(`delta_before_ms=${filters.deltaBeforeMs}`);
+  if (filters.deltaAfterMs > 0) params.push(`delta_after_ms=${filters.deltaAfterMs}`);
+  if (params.length === 0) return url;
+  return url + (url.includes('?') ? '&' : '?') + params.join('&');
+}
+
+/** Builds the /api/telegrams URL for a range. Times use the loader's
+ * datetime-local format ("YYYY-MM-DDTHH:MM", treated as UTC). */
+export function buildHistoryUrl(range: LoadedRange, limit: number): string {
+  let url = apiUrl(`/api/telegrams?limit=${limit}`);
+  if (range.kind === 'relative') {
+    const start = new Date(Date.now() - range.seconds * 1000).toISOString();
+    url += `&start_time=${encodeURIComponent(start)}`;
+  } else {
+    if (range.startTime) url += `&start_time=${encodeURIComponent(range.startTime + ':00Z')}`;
+    if (range.endTime) url += `&end_time=${encodeURIComponent(range.endTime + ':00Z')}`;
+  }
+  return url;
+}
+
+/**
+ * Fetches history telegrams for a range with server-side filters applied.
+ * OR source/target relation is handled with two queries merged client-side,
+ * because the knx-telegram-store library only supports AND across the two.
+ */
+export async function loadHistoryTelegrams(
+  range: LoadedRange,
+  limit: number,
+  filters?: ActiveFilters,
+): Promise<{ telegrams: Telegram[]; metadata: HistoryMetadata }> {
+  const baseUrl = buildHistoryUrl(range, limit);
+  const isOrMode = filters?.sourceTargetRelation === 'OR'
+    && (filters.sources.length > 0)
+    && (filters.targets.length > 0);
+
+  if (isOrMode) {
+    const srcFilters = { ...filters, targets: [], sourceTargetRelation: 'AND' as const };
+    const tgtFilters = { ...filters, sources: [], sourceTargetRelation: 'AND' as const };
+    const [srcRes, tgtRes] = await Promise.all([
+      fetch(applyFilterParams(baseUrl, srcFilters)),
+      fetch(applyFilterParams(baseUrl, tgtFilters)),
+    ]);
+    if (!srcRes.ok || !tgtRes.ok) throw new Error(`Server error: ${srcRes.ok ? tgtRes.status : srcRes.status}`);
+    const [srcData, tgtData] = await Promise.all([srcRes.json(), tgtRes.json()]);
+
+    const seen = new Set<string>();
+    const merged: Telegram[] = [];
+    for (const t of [...(srcData.telegrams || []), ...(tgtData.telegrams || [])]) {
+      if (!seen.has(t.timestamp)) {
+        seen.add(t.timestamp);
+        merged.push(t);
+      }
+    }
+    // Re-sort descending (both halves arrive sorted but interleaved)
+    merged.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+    const limitReached = (srcData.metadata?.limit_reached || tgtData.metadata?.limit_reached) ?? false;
+    return { telegrams: merged, metadata: { total_count: merged.length, limit_reached: limitReached } };
+  }
+
+  const res = await fetch(applyFilterParams(baseUrl, filters));
+  if (!res.ok) throw new Error(`Server error: ${res.status}`);
+  const data = await res.json();
+  return {
+    telegrams: data.telegrams || [],
+    metadata: data.metadata || { total_count: 0, limit_reached: false },
+  };
+}

--- a/frontend/src/utils/viewUrl.test.ts
+++ b/frontend/src/utils/viewUrl.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import { buildViewUrl, formatRel, parseViewUrl } from './viewUrl';
+import { DEFAULT_FILTERS } from '../types/filters';
+
+describe('parseViewUrl', () => {
+  test('returns null without view=viz', () => {
+    expect(parseViewUrl('')).toBeNull();
+    expect(parseViewUrl('?plot=1/2/3&rel=24h')).toBeNull();
+  });
+
+  test('returns null without a usable range', () => {
+    expect(parseViewUrl('?view=viz&plot=1/2/3')).toBeNull();
+    expect(parseViewUrl('?view=viz&rel=abc')).toBeNull();
+    expect(parseViewUrl('?view=viz&rel=0h')).toBeNull();
+  });
+
+  test('parses a relative view with filters', () => {
+    const v = parseViewUrl('?view=viz&plot=1/2/3,1/2/4&src=1.1.5&tgt=1/2/3&type=Write&dpt=1,9&before=500&after=1000&rel=24h&limit=5000');
+    expect(v).not.toBeNull();
+    expect(v!.plot).toEqual(['1/2/3', '1/2/4']);
+    expect(v!.range).toEqual({ kind: 'relative', seconds: 86400 });
+    expect(v!.filters.sources).toEqual(['1.1.5']);
+    expect(v!.filters.targets).toEqual(['1/2/3']);
+    expect(v!.filters.types).toEqual(['Write']);
+    expect(v!.filters.dpts).toEqual([1, 9]);
+    expect(v!.filters.deltaBeforeMs).toBe(500);
+    expect(v!.filters.deltaAfterMs).toBe(1000);
+    expect(v!.limit).toBe(5000);
+    expect(v!.embed).toBe(false);
+  });
+
+  test('parses an absolute view and embed options', () => {
+    const v = parseViewUrl('?view=viz&start=2026-01-01T00:00&end=2026-01-02T00:00&embed=1&refresh=60&theme=dark');
+    expect(v!.range).toEqual({ kind: 'absolute', startTime: '2026-01-01T00:00', endTime: '2026-01-02T00:00' });
+    expect(v!.embed).toBe(true);
+    expect(v!.refresh).toBe(60);
+    expect(v!.theme).toBe('dark');
+  });
+
+  test('parses OR source/target relation', () => {
+    const v = parseViewUrl('?view=viz&rel=1h&src=1.1.5&tgt=1/2/3&rel_st=OR');
+    expect(v!.filters.sourceTargetRelation).toBe('OR');
+  });
+});
+
+describe('buildViewUrl', () => {
+  test('round-trips through parseViewUrl', () => {
+    const state = {
+      plot: ['1/2/3', '4/5/6'],
+      filters: {
+        ...DEFAULT_FILTERS,
+        sources: ['1.1.5'],
+        targets: ['1/2/3'],
+        types: ['Write', 'Response'],
+        dpts: [9],
+        deltaBeforeMs: 250,
+        deltaAfterMs: 0,
+        sourceTargetRelation: 'OR' as const,
+      },
+      range: { kind: 'relative' as const, seconds: 6 * 3600 },
+      limit: 10000,
+    };
+    const url = buildViewUrl(state);
+    const parsed = parseViewUrl(url.slice(url.indexOf('?')));
+    expect(parsed).not.toBeNull();
+    expect(parsed!.plot).toEqual(state.plot);
+    expect(parsed!.filters).toEqual(state.filters);
+    expect(parsed!.range).toEqual(state.range);
+    expect(parsed!.limit).toBe(state.limit);
+  });
+
+  test('omits defaults for a minimal view', () => {
+    const url = buildViewUrl({
+      plot: ['1/2/3'],
+      filters: DEFAULT_FILTERS,
+      range: { kind: 'relative', seconds: 3600 },
+    });
+    expect(url).toContain('view=viz');
+    expect(url).toContain('rel=1h');
+    expect(url).not.toContain('src=');
+    expect(url).not.toContain('before=');
+    expect(url).not.toContain('limit=');
+    expect(url).not.toContain('rel_st=');
+  });
+
+  test('absolute ranges keep datetime-local strings', () => {
+    const url = buildViewUrl({
+      plot: [],
+      filters: DEFAULT_FILTERS,
+      range: { kind: 'absolute', startTime: '2026-01-01T00:00', endTime: '' },
+    });
+    const parsed = parseViewUrl(url.slice(url.indexOf('?')));
+    expect(parsed!.range).toEqual({ kind: 'absolute', startTime: '2026-01-01T00:00', endTime: '' });
+  });
+});
+
+describe('formatRel', () => {
+  test('picks the largest evenly-dividing unit', () => {
+    expect(formatRel(86400)).toBe('1d');
+    expect(formatRel(7 * 86400)).toBe('7d');
+    expect(formatRel(6 * 3600)).toBe('6h');
+    expect(formatRel(90 * 60)).toBe('90m');
+    expect(formatRel(45)).toBe('45s');
+  });
+});

--- a/frontend/src/utils/viewUrl.ts
+++ b/frontend/src/utils/viewUrl.ts
@@ -1,0 +1,112 @@
+import { DEFAULT_FILTERS, type ActiveFilters } from '../types/filters';
+import type { LoadedRange } from './historyLoad';
+import { getBasePath } from './basePath';
+
+/** A visualization view encoded in the URL (#150). */
+export interface VizViewState {
+  /** Group addresses to plot (selectedVisualizationTargets). */
+  plot: string[];
+  filters: ActiveFilters;
+  range: LoadedRange;
+  limit?: number;
+  /** Render only the chart area (iframe/dashboard embedding). */
+  embed: boolean;
+  /** Embed only: re-fetch interval for relative windows, seconds. */
+  refresh?: number;
+  /** Embed only: force a theme instead of the cookie/system default. */
+  theme?: 'dark' | 'light';
+}
+
+const UNIT_SECONDS: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+
+/** Parses "24h" / "90m" / "30s" / "7d" into seconds. */
+function parseRel(rel: string): number | null {
+  const m = rel.match(/^(\d+)([smhd])$/);
+  if (!m) return null;
+  const seconds = Number(m[1]) * UNIT_SECONDS[m[2]];
+  return seconds > 0 ? seconds : null;
+}
+
+/** Formats seconds as the largest unit that divides evenly ("86400" → "1d"). */
+export function formatRel(seconds: number): string {
+  for (const [unit, secs] of [['d', 86400], ['h', 3600], ['m', 60]] as const) {
+    if (seconds % secs === 0 && seconds >= secs) return `${seconds / secs}${unit}`;
+  }
+  return `${seconds}s`;
+}
+
+const list = (v: string | null): string[] => (v ? v.split(',').filter(Boolean) : []);
+
+/**
+ * Parses a shared-view URL query string. Returns null unless `view=viz`
+ * is present with a usable time range.
+ */
+export function parseViewUrl(search: string): VizViewState | null {
+  const p = new URLSearchParams(search);
+  if (p.get('view') !== 'viz') return null;
+
+  let range: LoadedRange | null = null;
+  const rel = p.get('rel');
+  if (rel) {
+    const seconds = parseRel(rel);
+    if (seconds) range = { kind: 'relative', seconds };
+  } else if (p.get('start') || p.get('end')) {
+    range = { kind: 'absolute', startTime: p.get('start') ?? '', endTime: p.get('end') ?? '' };
+  }
+  if (!range) return null;
+
+  const filters: ActiveFilters = {
+    ...DEFAULT_FILTERS,
+    sources: list(p.get('src')),
+    targets: list(p.get('tgt')),
+    types: list(p.get('type')),
+    dpts: list(p.get('dpt')).map(Number).filter(n => Number.isFinite(n)),
+    deltaBeforeMs: Math.max(0, Number(p.get('before')) || 0),
+    deltaAfterMs: Math.max(0, Number(p.get('after')) || 0),
+    sourceTargetRelation: p.get('rel_st') === 'OR' ? 'OR' : 'AND',
+  };
+
+  const limit = Number(p.get('limit'));
+  const refresh = Number(p.get('refresh'));
+  const theme = p.get('theme');
+
+  return {
+    plot: list(p.get('plot')),
+    filters,
+    range,
+    limit: Number.isFinite(limit) && limit > 0 ? limit : undefined,
+    embed: p.get('embed') === '1',
+    refresh: Number.isFinite(refresh) && refresh > 0 ? refresh : undefined,
+    theme: theme === 'dark' || theme === 'light' ? theme : undefined,
+  };
+}
+
+/** Builds a shareable URL (path + query) for a view. Omits defaults. */
+export function buildViewUrl(state: {
+  plot: string[];
+  filters: ActiveFilters;
+  range: LoadedRange;
+  limit?: number;
+  embed?: boolean;
+}): string {
+  const p = new URLSearchParams();
+  p.set('view', 'viz');
+  if (state.plot.length > 0) p.set('plot', state.plot.join(','));
+  const f = state.filters;
+  if (f.sources.length > 0) p.set('src', f.sources.join(','));
+  if (f.targets.length > 0) p.set('tgt', f.targets.join(','));
+  if (f.types.length > 0) p.set('type', f.types.join(','));
+  if (f.dpts.length > 0) p.set('dpt', f.dpts.join(','));
+  if (f.deltaBeforeMs > 0) p.set('before', String(f.deltaBeforeMs));
+  if (f.deltaAfterMs > 0) p.set('after', String(f.deltaAfterMs));
+  if (f.sourceTargetRelation === 'OR') p.set('rel_st', 'OR');
+  if (state.range.kind === 'relative') {
+    p.set('rel', formatRel(state.range.seconds));
+  } else {
+    if (state.range.startTime) p.set('start', state.range.startTime);
+    if (state.range.endTime) p.set('end', state.range.endTime);
+  }
+  if (state.limit) p.set('limit', String(state.limit));
+  if (state.embed) p.set('embed', '1');
+  return `${getBasePath()}/?${p.toString()}`;
+}


### PR DESCRIPTION
Fixes #150 — implements Phases 1 & 2 of the design posted on the issue.

## Phase 1 — view state in the URL

- New `utils/viewUrl.ts`: explicit query-param scheme `/?view=viz&plot=1/2/3,1/2/4&rel=24h` plus optional filter params (`src`, `tgt`, `type`, `dpt`, `before`, `after`, `rel_st=OR`), absolute windows (`start`/`end`) and `limit`. Defaults are omitted; round-trip covered by unit tests.
- Opening a view URL restores the filters, lands on the History tab, auto-loads the window server-side and opens the visualizer.
- **Copy link** button in the visualizer header serializes the currently loaded view (clipboard, with a prompt fallback for non-secure contexts). Links go through `getBasePath()` so sub-path deployments work.
- Refactor: the history fetch logic (incl. the OR-mode dual-query merge) moved from the `HistoryLoader` modal into `utils/historyLoad.ts`, shared by the modal, the URL-restore path and embed mode. The loader now reports *which* range was loaded — the basis for the share link.

## Phase 2 — embed mode

- `&embed=1` mounts a chart-only `EmbedView` **instead of** the full app (branch in `main.tsx`), so no websocket table, polling or wizards run inside an iframe — e.g. a Home Assistant Webpage card.
- Relative windows stay current: matching live telegrams are appended from the websocket feed, plus a periodic window re-fetch (`&refresh=<seconds>`, default 300). Absolute windows are static.
- `&theme=dark|light` forces a theme.
- Malformed view params (bad `rel`, missing range) fall back to the normal app.

## Verification (end-to-end, seeded sqlite backend + Vite + headless Chromium)

13/13 checks passed against the running app: shared URL restores all 3 plotted targets and renders charts; Copy link produces the canonical URL and round-trips to identical charts in a fresh navigation; embed renders charts only (0 app-chrome elements) with `theme=light` applied; embed works with absolute ranges; three malformed-URL probes fall back to the normal app without crashing; and the manual flow (nav → Load History → 6h → Visualize → pick target → Copy link) still works through the refactored loader, producing `rel=6h&plot=2/1/1`.

Docs: DESIGN.md section 2.8 + README feature bullet. Also folded verification-env learnings into `.claude/skills/verify/SKILL.md`.

Known limitation (documented): HA ingress URLs are session-bound, so add-on users embed via the exposed port; the app has no auth of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)