### PR TITLE
Bump knx-telegram-store to 0.9.0 and document that TimescaleDB is now optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,12 @@ Thank you for your interest in making Spectrum KNX better!
 ## Development Requirements
 - **Python 3.14+**
 - **Node.js 18+ & npm**
-- **Docker Compose** (for providing the local TimescaleDB instance)
+- **Docker Compose** (for providing the local PostgreSQL/TimescaleDB instance)
 
 ## Setting up the Dev Environment
 
 ### 1. Database infrastructure
-Spin up the local TimescaleDB instance in the background:
+Spin up the local database instance in the background (the bundled container ships TimescaleDB; any plain PostgreSQL works too):
 ```bash
 docker-compose up -d db
 ```

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -5,7 +5,7 @@ Spectrum KNX is designed as a modular 12-factor application, making it agnostic 
 ## Prerequisites
 No matter the deployment, you will need:
 1. An ETS project file (`.knxproj`) parsed by the backend to translate KNX payloads.
-2. A database backend — either PostgreSQL with the **TimescaleDB** extension (default), or SQLite (no external database required).
+2. A database backend — either PostgreSQL (default), or SQLite (no external database required). The **TimescaleDB** extension is optional: when it is available on the PostgreSQL server it is used automatically (hypertable partitioning + native compression); without it, Spectrum KNX runs on plain PostgreSQL with identical functionality.
 
 ---
 
@@ -45,7 +45,7 @@ After installation, go to the **Configuration** tab of the Add-on. The following
 | `KNX_GATEWAY_IP` | IP address of your KNX IP Gateway/Router. Use `AUTO` to scan the network automatically. | `AUTO` |
 | `KNX_GATEWAY_PORT` | Port of your KNX IP Gateway. | `3671` |
 | `LOG_LEVEL` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). | `INFO` |
-| `DB_BACKEND` | Storage backend: `POSTGRES` (PostgreSQL + TimescaleDB) or `SQLITE` (local file, no external database needed). | `POSTGRES` |
+| `DB_BACKEND` | Storage backend: `POSTGRES` (PostgreSQL; TimescaleDB is used automatically when available) or `SQLITE` (local file, no external database needed). | `POSTGRES` |
 
 Example configuration (YAML view):
 ```yaml

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -20,8 +20,8 @@ The system follows a standard modern client-server architecture with real-time s
   - `xknxproject` parses ETS `.knxproj` files, allowing the app to resolve physical/group addresses into human-readable names and properly decode DPT (Data Point Type) payloads.
 - **Real-Time Streaming:** A WebSocket manager (`ws_manager.py`) broadcasts all received telegrams to connected UI clients instantly.
 
-### Storage (PostgreSQL + TimescaleDB)
-- **Database Engine:** PostgreSQL with the TimescaleDB extension, optimized for heavy time-series workloads and large-scale data retention.
+### Storage (PostgreSQL, optional TimescaleDB)
+- **Database Engine:** PostgreSQL, optimized for heavy time-series workloads and large-scale data retention. The TimescaleDB extension is optional (since `knx-telegram-store` 0.9.0): when available it is detected at startup and used automatically for hypertable partitioning and native compression; otherwise the store runs on plain PostgreSQL tables.
 - **Data Volume Expectations:** ~5,000 telegrams/hour (~120,000/day, ~43.8 million/year). Expected uncompressed text size is ~10MB/day (~3.6GB/year).
 - **Core Schema (`telegrams` hypertable):**
   - `timestamp`: The primary time column (TimescaleDB hypertable index).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -20,7 +20,7 @@ This document provides instructions for setting up the development environment, 
 - **Styling:** Vanilla CSS (Modern CSS variables, Flexbox/Grid)
 
 ### Storage & Infrastructure
-- **Database:** [PostgreSQL 15](https://www.postgresql.org/) with [TimescaleDB](https://www.timescale.com/) (default), or SQLite via `aiosqlite` for lightweight setups.
+- **Database:** [PostgreSQL](https://www.postgresql.org/) (default). The [TimescaleDB](https://www.timescale.com/) extension is optional — when available it is used automatically for hypertable partitioning and native compression; any plain PostgreSQL server works too. Alternatively SQLite via `aiosqlite` for lightweight setups.
 - **Containerization:** [Docker](https://www.docker.com/) & [Docker Compose](https://docs.docker.com/compose/).
 
 ---
@@ -56,7 +56,7 @@ Companion mode (read an external telegram store instead of running the KNX daemo
 ### 3. Database Setup
 The backend supports two storage backends selected via `DATABASE_URL`:
 
-**PostgreSQL + TimescaleDB (default):** Start the database via Docker Compose. The backend automatically creates the schema on first startup.
+**PostgreSQL (default):** Start the database via Docker Compose. The bundled container ships TimescaleDB, but any plain PostgreSQL server works as well — the backend detects the extension at startup and falls back automatically. The schema is created automatically on first startup.
 ```bash
 docker-compose up -d db
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ![Spectrum KNX Dashboard](assets/dashboard.png)
 
-Spectrum KNX is a dedicated tool to record, store, search, and visualize KNX bus telegrams indefinitely. Built for speed and reliability, it supports both a TimescaleDB backend for long-term time-series storage and a lightweight SQLite backend for simple setups — paired with a premium, real-time React web interface.
+Spectrum KNX is a dedicated tool to record, store, search, and visualize KNX bus telegrams indefinitely. Built for speed and reliability, it supports both a PostgreSQL backend for long-term time-series storage (the TimescaleDB extension is optional — used automatically for hypertable partitioning and native compression when available) and a lightweight SQLite backend for simple setups — paired with a premium, real-time React web interface.
 
 ## 📺 Demo in Action
 
@@ -74,7 +74,7 @@ Two add-ons cover the two ways to run Spectrum KNX inside Home Assistant
 | | **Spectrum KNX** (standalone) | **Spectrum KNX (HA Companion)** |
 |---|---|---|
 | Bus connection | Own tunnel/routing connection to your KNX gateway | None — uses what HA already receives |
-| Database | Own PostgreSQL/TimescaleDB or SQLite | Reads HA's KNX telegram database (read-only) |
+| Database | Own PostgreSQL (TimescaleDB optional) or SQLite | Reads HA's KNX telegram database (read-only) |
 | Live telegrams | Directly from the bus | Streamed from HA's websocket API |
 | Retention & cleanup | Managed in Spectrum KNX (Database Maintenance screen) | Managed by Home Assistant |
 | Use when… | You want an independent, full-featured recorder | You use HA's KNX integration and want its history analyzed without duplicating anything |
@@ -86,7 +86,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for local setup, [DEPLOYMENT.md](DEPLOYMENT
 
 ## 🛠 Tech Stack
 - **Backend:** Python 3.13+, FastAPI, `xknx`, WebSocket Streaming
-- **Database:** PostgreSQL + TimescaleDB, or SQLite (via `aiosqlite`)
+- **Database:** PostgreSQL (with optional TimescaleDB acceleration), or SQLite (via `aiosqlite`)
 - **Frontend:** React, TypeScript, Vite, TanStack Table, uPlot
 
 ## 🤝 Contributing

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "asyncpg",
     "fastapi",
     "httpx",
-    "knx-telegram-store",
+    "knx-telegram-store>=0.9.0",
     "pydantic",
     "python-dotenv",
     "python-multipart",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.8.0
+knx-telegram-store==0.9.0
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0


### PR DESCRIPTION
## Summary

[knx-telegram-store 0.9.0](https://github.com/XKNX/knx-telegram-store/pull/18) makes TimescaleDB optional: `PostgresStore` probes the server at startup and uses hypertable partitioning + native compression when the extension is available, falling back to plain PostgreSQL (identical functionality) otherwise. A missing extension no longer fails `check_config`/`check_connection`.

- `backend/requirements.txt`: `knx-telegram-store==0.8.0` → `==0.9.0` (also picks up the DSN percent-decoding fix for database names)
- `backend/pyproject.toml`: constrain to `>=0.9.0`
- Docs (README, DEVELOPMENT, DEPLOYMENT, DESIGN, CONTRIBUTING): PostgreSQL without TimescaleDB is now a fully supported backend; the extension is described as optional and auto-detected. The bundled Docker Compose / K8s / HA add-on stacks keep shipping TimescaleDB as before.

No code changes needed — SpectrumKNX never referenced `MISSING_TIMESCALEDB` directly.

## Test plan
- [x] Backend suite with `DATABASE_URL=sqlite+aiosqlite:///unittest.db` (as CI does) and knx-telegram-store 0.9.0 installed: 160 passed
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AyE4ke3QX2ZRPypLMDVYH