### PR TITLE
fix: stop fabricating and inverting DPT-1 display values

### DIFF
--- a/backend/parsers.py
+++ b/backend/parsers.py
@@ -31,15 +31,26 @@ def get_simplified_type(tech_type: str) -> str:
 
 def format_value_nicely(value, dpt_main=None, dpt_sub=None):
     """Formats numeric or boolean values into clean, HA-style strings."""
+    if value is None:
+        # Payload-less telegrams (GroupValueRead) and undecoded payloads carry
+        # no value — never fabricate one (#181).
+        return None
+
     if isinstance(value, bool) or (dpt_main == 1):
-        try:
-            num_str = f"{dpt_main}.{dpt_sub:03d}" if dpt_sub is not None else "1.001"
-            tc = DPTBase.parse_transcoder(num_str)
-            if tc and hasattr(tc, "value_to_str"):
-                # Note: xknx's to_str often returns the descriptive name
-                return str(tc.to_knx(value).to_str() if hasattr(tc, "to_knx") else value).lower()
-        except Exception:
-            pass
+        # DPT-1 values arrive as bools, 0/1 numerics, or already-decoded enum
+        # names ("off", "down", ...) from Home Assistant. Strings ARE the
+        # display value — truth-testing them would render "off" as "on" (#181).
+        if isinstance(value, str):
+            return value.lower()
+        if dpt_sub is not None:
+            try:
+                tc = DPTBase.parse_transcoder(f"{dpt_main or 1}.{dpt_sub:03d}")
+                data_type = getattr(tc, "data_type", None)
+                if data_type is not None:
+                    # Subtype-specific name, e.g. 1.008: False -> "up"
+                    return data_type(bool(value)).name.lower()
+            except Exception:
+                pass
         return "on" if value else "off"
 
     if isinstance(value, int | float):

--- a/backend/tests/test_parsers.py
+++ b/backend/tests/test_parsers.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from parsers import (
     convert_value_for_db,
     format_dpt_name,
+    format_value_nicely,
     get_simplified_type,
     parse_telegram_dpt,
     parse_telegram_payload,
@@ -272,6 +273,41 @@ def test_format_dpt_name():
     assert "9.001" in name
 
     assert format_dpt_name(None, None) == (None, None)
+
+
+def test_format_value_nicely_none_is_not_fabricated():
+    # GroupValueRead telegrams carry no payload: no "None"/"off" values (#181)
+    assert format_value_nicely(None) is None
+    assert format_value_nicely(None, 1, 1) is None
+    assert format_value_nicely(None, 5, 1) is None
+
+
+def test_format_value_nicely_bools_and_numerics():
+    assert format_value_nicely(True, 1, 1) == "on"
+    assert format_value_nicely(False, 1, 1) == "off"
+    assert format_value_nicely(0, 1, 1) == "off"
+    assert format_value_nicely(1.0, 1, 1) == "on"
+    # Subtype-specific enum names
+    assert format_value_nicely(False, 1, 8) == "up"
+    assert format_value_nicely(True, 1, 8) == "down"
+    assert format_value_nicely(True, 1, 100) == "heat"
+    # Bool without a known DPT-1 subtype falls back to on/off
+    assert format_value_nicely(True) == "on"
+    assert format_value_nicely(False, 1, None) == "off"
+
+
+def test_format_value_nicely_ha_enum_strings_not_truth_tested():
+    # HA decodes DPT-1 to enum name strings; "off" must not render as "on" (#181)
+    assert format_value_nicely("off", 1, 1) == "off"
+    assert format_value_nicely("on", 1, 1) == "on"
+    assert format_value_nicely("up", 1, 8) == "up"
+    assert format_value_nicely("down", 1, 8) == "down"
+
+
+def test_format_value_nicely_other_types():
+    assert format_value_nicely(21.60, 9, 1) == "21.6"
+    assert format_value_nicely(100.00, 5, 1) == "100"
+    assert format_value_nicely("hello", 16, 0) == "hello"
 
 
 def test_format_dpt_name_invalid_inputs():


### PR DESCRIPTION
## Summary

`format_value_nicely` had two defects behind the odd boolean values in #181:

- **Fabricated values:** `value=None` (payload-less `GroupValueRead` telegrams, undecoded payloads) rendered as the literal string `"None"` — or as `"off"` when the GA's DPT main was 1. It now returns `None` so the UI shows `-`.
- **Inverted booleans in companion mode:** since xknx 3.x, DPT-1 values decode to enum members which Home Assistant serializes to name strings (`"off"`, `"on"`, `"down"`, …) in both the live websocket feed and the shared telegram store. Those strings were truth-tested (`"on" if value else "off"`), so **every** non-empty string — including `"off"` — rendered as `"on"`. Strings are now returned as-is.

Bools and 0/1 numerics additionally resolve subtype-specific names via the xknx enum (1.008 → up/down, 1.100 → cool/heat); the previous `to_knx(...).to_str()` attempt always raised and silently fell through to on/off.

Note: the store version skew (HA 2026.7.1 bundles knx-telegram-store 0.3.2) turned out to be benign — the `value` column round-trips identically across versions; the bug was purely in the formatter.

## Test plan

- New unit tests covering: None never fabricates a value, HA enum strings are not truth-tested, bool/0/1 mapping incl. subtype names.
- Full backend suite passes (165 tests, sqlite DATABASE_URL as in CI).

Fixes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)