### PR TITLE
feat: filter telegrams by exact sub-DPT

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -126,14 +126,22 @@ async def get_telegrams(
     # Map simplified types to technical names
     type_map_reverse = {"Write": "GroupValueWrite", "Read": "GroupValueRead", "Response": "GroupValueResponse"}
     type_list_db = [type_map_reverse.get(t, t) for t in type_list]
-    dpt_main_list = [int(d.strip()) for d in dpt_main.split(",") if d.strip().isdigit()] if dpt_main else []
+
+    # DPT entries are "main.sub" for one subtype or a bare "main" for all
+    # subtypes of a major DPT (#180)
+    dpt_pairs: list[tuple[int, int | None]] = []
+    if dpt_main:
+        for entry in dpt_main.split(","):
+            main_str, sep, sub_str = entry.strip().partition(".")
+            if main_str.isdigit() and (not sep or sub_str.isdigit()):
+                dpt_pairs.append((int(main_str), int(sub_str) if sep else None))
 
     # Build the library query
     query = TelegramQuery(
         sources=source_list,
         destinations=target_list,
         telegram_types=type_list_db,
-        dpt_mains=dpt_main_list,
+        dpts=dpt_pairs,
         start_time=start_time,
         end_time=end_time,
         delta_before_ms=delta_before_ms,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "asyncpg",
     "fastapi",
     "httpx",
-    "knx-telegram-store>=0.9.0",
+    "knx-telegram-store>=0.10.0",
     "pydantic",
     "python-dotenv",
     "python-multipart",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.9.0
+knx-telegram-store==0.10.0
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -243,6 +243,19 @@ def test_get_telegrams(mock_query):
     assert data["telegrams"][0]["raw_data"] == "01"
 
 
+@patch("database.store.query", new_callable=AsyncMock)
+def test_get_telegrams_dpt_filter_pairs(mock_query):
+    """DPT entries map to (main, sub) pairs; bare mains match all subtypes (#180)."""
+    mock_query.return_value = TelegramQueryResult(telegrams=[], total_count=0, limit_reached=False)
+
+    response = client.get("/api/telegrams?dpt_main=1.001,9.001,5,junk,2.xyz")
+    assert response.status_code == 200
+
+    query = mock_query.call_args.args[0]
+    assert query.dpts == [(1, 1), (9, 1), (5, None)]
+    assert query.dpt_mains == []
+
+
 def _stored_telegram(destination: str, value: float) -> StoredTelegram:
     return StoredTelegram(
         timestamp=datetime(2023, 1, 1),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { UpdateNotification } from './components/UpdateNotification';
 import { useUpdateCheck } from './hooks/useUpdateCheck';
 import {
   DEFAULT_FILTERS,
+  dptKey,
   hasActiveFilters,
   matchesTelegram,
   type ActiveFilters,
@@ -495,13 +496,18 @@ function App() {
     const sources: Record<string, number> = {};
     const targets: Record<string, number> = {};
     const types: Record<string, number> = {};
-    const dpts: Record<number, number> = {};
+    const dpts: Record<string, number> = {};
 
     for (const t of sortedLiveTelegrams) {
       sources[t.source_address] = (sources[t.source_address] ?? 0) + 1;
       targets[t.target_address] = (targets[t.target_address] ?? 0) + 1;
       if (t.simplified_type) types[t.simplified_type] = (types[t.simplified_type] ?? 0) + 1;
-      if (t.dpt_main != null) dpts[t.dpt_main] = (dpts[t.dpt_main] ?? 0) + 1;
+      if (t.dpt_main != null) {
+        const key = dptKey(t.dpt_main, t.dpt_sub);
+        dpts[key] = (dpts[key] ?? 0) + 1;
+        // A bare-main option ("all 1.x") counts every subtype
+        if (t.dpt_sub != null) dpts[`${t.dpt_main}`] = (dpts[`${t.dpt_main}`] ?? 0) + 1;
+      }
     }
     return { sources, targets, types, dpts };
   }, [sortedLiveTelegrams]);

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -4,7 +4,8 @@ import {
   type FilterOptions,
   type ActiveFilters,
   type FilterCounts,
-  DEFAULT_FILTERS
+  DEFAULT_FILTERS,
+  dptKey
 } from '../types/filters';
 import { compareKnxAddress } from '../utils/knxAddress';
 import { KnxAddressTree } from './KnxAddressTree';
@@ -306,7 +307,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
             />
           ))}
           {activeFilters.dpts.map(d => {
-            const label = options.dpts.find(opt => opt.main === d)?.label;
+            const label = options.dpts.find(opt => dptKey(opt.main!, opt.sub) === d)?.label;
             return (
               <OptionRow
                 key={`active-dpt-${d}`}
@@ -468,15 +469,18 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         {/* DPT */}
         {filteredDpts.length > 0 && (
           <Section title="DPT" defaultOpen={false}>
-            {filteredDpts.map(d => (
-              <OptionRow
-                key={d.main}
-                label={d.label!}
-                checked={activeFilters.dpts.includes(d.main!)}
-                count={mode === 'live' ? (counts?.dpts[d.main!] ?? 0) : undefined}
-                onToggle={() => update({ dpts: toggle(activeFilters.dpts, d.main!) })}
-              />
-            ))}
+            {filteredDpts.map(d => {
+              const key = dptKey(d.main!, d.sub);
+              return (
+                <OptionRow
+                  key={key}
+                  label={d.label!}
+                  checked={activeFilters.dpts.includes(key)}
+                  count={mode === 'live' ? (counts?.dpts[key] ?? 0) : undefined}
+                  onToggle={() => update({ dpts: toggle(activeFilters.dpts, key) })}
+                />
+              );
+            })}
           </Section>
         )}
 

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -170,7 +170,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
       (wasFiltered(atLoad.sources) && nowHasFewer(activeFilters.sources, atLoad.sources)) ||
       (wasFiltered(atLoad.targets) && nowHasFewer(activeFilters.targets, atLoad.targets)) ||
       (wasFiltered(atLoad.types)   && nowHasFewer(activeFilters.types,   atLoad.types))   ||
-      (wasFiltered(atLoad.dpts)    && nowHasFewer(activeFilters.dpts,    atLoad.dpts as number[]))
+      (wasFiltered(atLoad.dpts)    && nowHasFewer(activeFilters.dpts,    atLoad.dpts))
     );
   }, [activeFilters, filtersAtLoad, telegrams.length]);
 

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -3,7 +3,7 @@ import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
 import { ChevronUp, ChevronDown, Filter, LineChart, X, Clock } from 'lucide-react';
-import type { ActiveFilters } from '../types/filters';
+import { dptKey, type ActiveFilters } from '../types/filters';
 import { getCookie, setCookie } from '../utils/cookies';
 
 export type SortKey = 'timestamp' | 'source_address' | 'target_address' | 'simplified_type' | 'dpt_name' | 'value_numeric';
@@ -329,8 +329,8 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                 <div title={getDPTLabel(t.dpt_main)} style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: getDPTColor(t.dpt_main), flexShrink: 0 }} />
                 <span title={t.dpt_name ?? undefined} style={{ fontSize: '0.75rem', color: 'var(--text-dim)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{t.dpt_name}</span>
                 <button
-                  className={`quick-filter-btn ${activeFilters.dpts.includes(t.dpt_main) ? 'active' : ''}`}
-                  onClick={(e) => { e.stopPropagation(); if (t.dpt_main != null) onQuickFilter('dpts', t.dpt_main); }}
+                  className={`quick-filter-btn ${activeFilters.dpts.includes(dptKey(t.dpt_main, t.dpt_sub)) ? 'active' : ''}`}
+                  onClick={(e) => { e.stopPropagation(); if (t.dpt_main != null) onQuickFilter('dpts', dptKey(t.dpt_main, t.dpt_sub)); }}
                   title="Toggle DPT filter"
                 >
                   <Filter className="filter-icon" size={12} />

--- a/frontend/src/types/filters.test.ts
+++ b/frontend/src/types/filters.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { DEFAULT_FILTERS, dptKey, matchesDpt, matchesTelegram } from './filters';
+
+describe('dptKey', () => {
+  test('pads the sub to three digits', () => {
+    expect(dptKey(1, 1)).toBe('1.001');
+    expect(dptKey(9, 21)).toBe('9.021');
+    expect(dptKey(16, 100)).toBe('16.100');
+  });
+
+  test('bare main when sub is missing', () => {
+    expect(dptKey(9)).toBe('9');
+    expect(dptKey(9, null)).toBe('9');
+  });
+});
+
+describe('matchesDpt', () => {
+  test('exact subtype match only selects that subtype (#180)', () => {
+    expect(matchesDpt(['1.001'], 1, 1)).toBe(true);
+    expect(matchesDpt(['1.001'], 1, 8)).toBe(false);
+    expect(matchesDpt(['1.001'], 1, null)).toBe(false);
+    expect(matchesDpt(['1.001'], 5, 1)).toBe(false);
+  });
+
+  test('bare main matches every subtype', () => {
+    expect(matchesDpt(['1'], 1, 1)).toBe(true);
+    expect(matchesDpt(['1'], 1, 8)).toBe(true);
+    expect(matchesDpt(['1'], 1, null)).toBe(true);
+    expect(matchesDpt(['1'], 11, 1)).toBe(false);
+  });
+
+  test('telegram without a DPT never matches', () => {
+    expect(matchesDpt(['1.001'], null, null)).toBe(false);
+    expect(matchesDpt(['1'], undefined, undefined)).toBe(false);
+  });
+});
+
+describe('matchesTelegram DPT filtering', () => {
+  const telegram = {
+    source_address: '1.1.1',
+    target_address: '1/2/3',
+    simplified_type: 'Write',
+    dpt_main: 1,
+    dpt_sub: 8,
+  };
+
+  test('filters by sub-DPT key', () => {
+    expect(matchesTelegram(telegram, { ...DEFAULT_FILTERS, dpts: ['1.008'] })).toBe(true);
+    expect(matchesTelegram(telegram, { ...DEFAULT_FILTERS, dpts: ['1.001'] })).toBe(false);
+    expect(matchesTelegram(telegram, { ...DEFAULT_FILTERS, dpts: ['1'] })).toBe(true);
+  });
+});

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -25,7 +25,7 @@ export interface ActiveFilters {
   sources: string[];       // source_address values
   targets: string[];       // target_address values
   types: string[];         // simplified_type values (Write/Read/Response)
-  dpts: number[];          // dpt_main numbers
+  dpts: string[];          // DPT keys: "1.001" for one subtype, bare "1" for all subtypes of a major DPT
   /** ms before a matching telegram to also include (0 = disabled) */
   deltaBeforeMs: number;
   /** ms after a matching telegram to also include (0 = disabled) */
@@ -64,6 +64,21 @@ export interface FilterableTelegram {
   target_address: string;
   simplified_type?: string | null;
   dpt_main?: number | null;
+  dpt_sub?: number | null;
+}
+
+/**
+ * Canonical DPT filter key: "1.001" with the sub, bare "1" without.
+ * Matches the grammar of the backend's dpt_main query parameter.
+ */
+export function dptKey(main: number, sub?: number | null): string {
+  return sub != null ? `${main}.${String(sub).padStart(3, '0')}` : `${main}`;
+}
+
+/** True if the telegram's DPT matches any key ("1" matches every 1.x). */
+export function matchesDpt(keys: string[], main?: number | null, sub?: number | null): boolean {
+  if (main == null) return false;
+  return keys.some(k => k === `${main}` || k === dptKey(main, sub));
 }
 
 /**
@@ -76,7 +91,7 @@ export function matchesTelegram(t: FilterableTelegram, f: ActiveFilters): boolea
   const srcOk = f.sources.length === 0 || srcMatch;
   const tgtOk = f.targets.length === 0 || tgtMatch;
   const typeOk = f.types.length === 0 || f.types.includes(t.simplified_type ?? '');
-  const dptOk = f.dpts.length === 0 || (t.dpt_main != null && f.dpts.includes(t.dpt_main));
+  const dptOk = f.dpts.length === 0 || matchesDpt(f.dpts, t.dpt_main, t.dpt_sub);
 
   const srcTgtOk = f.sources.length > 0 && f.targets.length > 0
     ? (f.sourceTargetRelation === 'OR' ? (srcMatch || tgtMatch) : (srcOk && tgtOk))
@@ -98,5 +113,5 @@ export interface FilterCounts {
   sources: Record<string, number>;
   targets: Record<string, number>;
   types: Record<string, number>;
-  dpts: Record<number, number>;
+  dpts: Record<string, number>;
 }

--- a/frontend/src/utils/viewUrl.test.ts
+++ b/frontend/src/utils/viewUrl.test.ts
@@ -15,14 +15,14 @@ describe('parseViewUrl', () => {
   });
 
   test('parses a relative view with filters', () => {
-    const v = parseViewUrl('?view=viz&plot=1/2/3,1/2/4&src=1.1.5&tgt=1/2/3&type=Write&dpt=1,9&before=500&after=1000&rel=24h&limit=5000');
+    const v = parseViewUrl('?view=viz&plot=1/2/3,1/2/4&src=1.1.5&tgt=1/2/3&type=Write&dpt=1.001,9&before=500&after=1000&rel=24h&limit=5000');
     expect(v).not.toBeNull();
     expect(v!.plot).toEqual(['1/2/3', '1/2/4']);
     expect(v!.range).toEqual({ kind: 'relative', seconds: 86400 });
     expect(v!.filters.sources).toEqual(['1.1.5']);
     expect(v!.filters.targets).toEqual(['1/2/3']);
     expect(v!.filters.types).toEqual(['Write']);
-    expect(v!.filters.dpts).toEqual([1, 9]);
+    expect(v!.filters.dpts).toEqual(['1.001', '9']);
     expect(v!.filters.deltaBeforeMs).toBe(500);
     expect(v!.filters.deltaAfterMs).toBe(1000);
     expect(v!.limit).toBe(5000);
@@ -52,7 +52,7 @@ describe('buildViewUrl', () => {
         sources: ['1.1.5'],
         targets: ['1/2/3'],
         types: ['Write', 'Response'],
-        dpts: [9],
+        dpts: ['9.001'],
         deltaBeforeMs: 250,
         deltaAfterMs: 0,
         sourceTargetRelation: 'OR' as const,

--- a/frontend/src/utils/viewUrl.ts
+++ b/frontend/src/utils/viewUrl.ts
@@ -60,7 +60,7 @@ export function parseViewUrl(search: string): VizViewState | null {
     sources: list(p.get('src')),
     targets: list(p.get('tgt')),
     types: list(p.get('type')),
-    dpts: list(p.get('dpt')).map(Number).filter(n => Number.isFinite(n)),
+    dpts: list(p.get('dpt')).filter(d => /^\d+(\.\d+)?$/.test(d)),
     deltaBeforeMs: Math.max(0, Number(p.get('before')) || 0),
     deltaAfterMs: Math.max(0, Number(p.get('after')) || 0),
     sourceTargetRelation: p.get('rel_st') === 'OR' ? 'OR' : 'AND',


### PR DESCRIPTION
## Summary

The DPT filter listed options per subtype (`1.001 - Switch`, `1.002 - Bool`, …) but the entire pipeline only tracked **major** DPT numbers, so clicking one subtype checked every subtype of that main and all rows showed the identical count (#180). This implements true sub-DPT filtering end-to-end:

- **Backend:** the `dpt_main` query param of `/api/telegrams` now accepts `main.sub` entries alongside bare `main` (backwards compatible), mapped to `TelegramQuery.dpts` pairs from [knx-telegram-store 0.10.0](https://github.com/XKNX/knx-telegram-store/releases/tag/v0.10.0) (released for this change; bare main still matches all subtypes).
- **Frontend:** `ActiveFilters.dpts` switched from `dpt_main` numbers to `"1.001"`/`"1"` string keys with shared `dptKey`/`matchesDpt` helpers. Filter panel rows, live count bubbles, in-memory live filtering, the row quick-filter button and share/embed URLs all operate per subtype. Also fixes a React key collision on the DPT option rows (all 1.x rows shared `key={d.main}`).

## Test plan

- New backend test: param grammar `1.001,9.001,5,junk,2.xyz` → `[(1,1),(9,1),(5,None)]`, invalid entries dropped.
- New frontend `filters.test.ts`: key derivation, exact-subtype vs bare-main matching, `matchesTelegram` integration.
- Full suites pass: backend 165 tests (sqlite as in CI), frontend 32 tests + `tsc -b` + lint + production build.
- End-to-end verified against a real sqlite store through the exact API parsing path.

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)