### PR TITLE
fix: report live-feed status in companion settings instead of bus disconnected

### DIFF
--- a/backend/ha_live_bridge.py
+++ b/backend/ha_live_bridge.py
@@ -32,6 +32,13 @@ POLL_INTERVAL = float(os.getenv("LIVE_POLL_INTERVAL", "1.0"))
 
 _task: asyncio.Task | None = None
 _last_seen: datetime | None = None
+_active_source: str = "none"  # resolved live source after fallbacks
+_connected: bool = False
+
+
+def live_feed_status() -> dict:
+    """Current live-feed state for the status API (companion mode, #184)."""
+    return {"source": _active_source, "connected": _connected}
 
 
 def _ha_token() -> str:
@@ -120,6 +127,7 @@ async def _replay_gap() -> None:
 
 async def _bridge_loop() -> None:
     """Subscribe to HA's KNX telegram stream and forward it to our live feed."""
+    global _connected
     backoff = 1.0
     while True:
         try:
@@ -137,6 +145,7 @@ async def _bridge_loop() -> None:
                     raise RuntimeError(f"knx/subscribe_telegrams failed: {result}")
 
                 logger.info("Connected to Home Assistant websocket, subscribed to KNX telegrams")
+                _connected = True
                 backoff = 1.0
                 await _replay_gap()
 
@@ -148,8 +157,10 @@ async def _bridge_loop() -> None:
                     _note_seen(telegram["timestamp"])
                     await manager.broadcast(telegram)
         except asyncio.CancelledError:
+            _connected = False
             raise
         except Exception as err:
+            _connected = False
             logger.warning(f"HA websocket bridge disconnected: {err} — retrying in {backoff:.0f}s")
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 30.0)
@@ -157,22 +168,26 @@ async def _bridge_loop() -> None:
 
 async def _poll_loop() -> None:
     """Poll the shared store for new rows and broadcast them."""
-    global _last_seen
+    global _connected, _last_seen
     _last_seen = datetime.now(UTC)  # history is loaded by the frontend separately
+    _connected = True  # store readability was verified at startup
     while True:
         await asyncio.sleep(POLL_INTERVAL)
         try:
             for telegram in await _fetch_since(_last_seen):
                 await manager.broadcast(telegram)
+            _connected = True
         except asyncio.CancelledError:
+            _connected = False
             raise
         except Exception as err:
+            _connected = False
             logger.warning(f"Live poll of telegram store failed: {err}")
 
 
 async def companion_startup() -> None:
     """Initialize the read-only store and start the configured live source."""
-    global _task
+    global _task, _active_source
 
     conn_check = await store.check_connection()
     if not conn_check.ok:
@@ -196,10 +211,13 @@ async def companion_startup() -> None:
     if LIVE_SOURCE == "ha_websocket":
         if not _ha_token():
             logger.warning("No SUPERVISOR_TOKEN/HA_TOKEN available — falling back to store polling")
+            _active_source = "poll"
             _task = asyncio.create_task(_poll_loop())
         else:
+            _active_source = "ha_websocket"
             _task = asyncio.create_task(_bridge_loop())
     elif LIVE_SOURCE == "poll":
+        _active_source = "poll"
         _task = asyncio.create_task(_poll_loop())
     elif LIVE_SOURCE == "none":
         logger.info("Live updates disabled (LIVE_SOURCE=none)")
@@ -209,7 +227,8 @@ async def companion_startup() -> None:
 
 async def companion_shutdown() -> None:
     """Stop the live source and close the store."""
-    global _task
+    global _task, _connected
+    _connected = False
     if _task is not None:
         _task.cancel()
         try:

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -473,7 +473,33 @@ def get_server_config() -> dict:
         if os.path.exists(default_file):
             ets_project_file = default_file
 
+    if READ_ONLY:
+        # Companion mode: Home Assistant owns the bus connection and the
+        # telegram store — reporting the daemon's (nonexistent) bus connection
+        # as "Disconnected" here was misleading (#184). Report the live-feed
+        # state instead and drop the gateway/security settings that don't apply.
+        import ha_live_bridge
+
+        feed = ha_live_bridge.live_feed_status()
+        return {
+            "mode": "companion",
+            "connection": {
+                "type": "HOME_ASSISTANT",
+                "live_source": feed["source"],
+            },
+            "security": {},
+            "files": {
+                "project_file": ets_project_file,
+                "project_loaded": global_knx_project is not None,
+            },
+            "status": {
+                "connected": feed["connected"],
+                "write_enabled": False,
+            },
+        }
+
     return {
+        "mode": "standalone",
         "connection": {
             "type": os.getenv("KNX_CONNECTION_TYPE", "AUTOMATIC"),
             "gateway_ip": os.getenv("KNX_GATEWAY_IP", "AUTO"),

--- a/backend/tests/test_ha_live_bridge.py
+++ b/backend/tests/test_ha_live_bridge.py
@@ -104,3 +104,17 @@ async def test_fetch_since_filters_and_advances(mock_query):
     query = mock_query.call_args[0][0]
     assert query.start_time == since
     assert query.order_descending is False
+
+
+def test_live_feed_status_reflects_bridge_state():
+    with (
+        patch.object(ha_live_bridge, "_active_source", "poll"),
+        patch.object(ha_live_bridge, "_connected", True),
+    ):
+        assert ha_live_bridge.live_feed_status() == {"source": "poll", "connected": True}
+
+    with (
+        patch.object(ha_live_bridge, "_active_source", "none"),
+        patch.object(ha_live_bridge, "_connected", False),
+    ):
+        assert ha_live_bridge.live_feed_status() == {"source": "none", "connected": False}

--- a/backend/tests/test_knx_daemon.py
+++ b/backend/tests/test_knx_daemon.py
@@ -380,3 +380,36 @@ async def test_send_group_value_without_connection_raises():
     with patch.object(knx_daemon, "xknx_instance", None):
         with pytest.raises(RuntimeError, match="Not connected"):
             await knx_daemon.send_group_value("1/2/3", True, "1.001")
+
+
+def test_get_server_config_standalone_reports_mode():
+    import knx_daemon
+
+    with patch.object(knx_daemon, "READ_ONLY", False):
+        config = knx_daemon.get_server_config()
+
+    assert config["mode"] == "standalone"
+    assert "gateway_ip" in config["connection"]
+    assert "knxkeys_found" in config["files"]
+
+
+@pytest.mark.parametrize("feed_connected", [True, False])
+def test_get_server_config_companion_reports_live_feed(feed_connected):
+    """Companion mode must not report the daemon's bus connection (#184)."""
+    import ha_live_bridge
+    import knx_daemon
+
+    with (
+        patch.object(knx_daemon, "READ_ONLY", True),
+        patch.object(ha_live_bridge, "_active_source", "ha_websocket"),
+        patch.object(ha_live_bridge, "_connected", feed_connected),
+    ):
+        config = knx_daemon.get_server_config()
+
+    assert config["mode"] == "companion"
+    assert config["status"]["connected"] is feed_connected
+    assert config["status"]["write_enabled"] is False
+    assert config["connection"] == {"type": "HOME_ASSISTANT", "live_source": "ha_websocket"}
+    # No gateway/security noise that doesn't apply in companion mode
+    assert config["security"] == {}
+    assert "knxkeys_found" not in config["files"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -767,9 +767,12 @@ function App() {
                 </h3>
                 {serverConfig ? (
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', fontSize: '0.8rem' }}>
-                    {/* Connection Status */}
+                    {/* Connection Status — in companion mode Home Assistant owns the
+                        bus; what matters is whether our live feed from HA works (#184) */}
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <span style={{ color: 'var(--text-dim)' }}>KNX Connection:</span>
+                      <span style={{ color: 'var(--text-dim)' }}>
+                        {serverConfig.mode === 'companion' ? 'Home Assistant Feed:' : 'KNX Connection:'}
+                      </span>
                       <span style={{
                         color: serverConfig.status?.connected ? 'var(--success)' : 'var(--error)',
                         fontWeight: 600
@@ -798,12 +801,14 @@ function App() {
                           {serverConfig.files?.project_loaded ? '● Loaded' : '○ Not loaded'}
                         </span>
                       </div>
-                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '0.25rem' }}>
-                        <span style={{ color: 'var(--text-dim)' }}>KNX keys file:</span>
-                        <span style={{ color: serverConfig.files?.knxkeys_found ? 'var(--success)' : 'var(--text-dim)', fontSize: '0.75rem' }}>
-                          {serverConfig.files?.knxkeys_found ? '● Found' : '○ Not found'}
-                        </span>
-                      </div>
+                      {serverConfig.files?.knxkeys_found !== undefined && (
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '0.25rem' }}>
+                          <span style={{ color: 'var(--text-dim)' }}>KNX keys file:</span>
+                          <span style={{ color: serverConfig.files?.knxkeys_found ? 'var(--success)' : 'var(--text-dim)', fontSize: '0.75rem' }}>
+                            {serverConfig.files?.knxkeys_found ? '● Found' : '○ Not found'}
+                          </span>
+                        </div>
+                      )}
                     </div>
 
                     {/* Security */}


### PR DESCRIPTION
## Summary

In Home Assistant companion mode the settings page showed **KNX Connection: ● Disconnected** (red) plus gateway/security settings that don't apply — although HA owns the bus connection and telegrams were flowing. Forum users found this confusing enough to think the setup was broken (post #83).

- `ha_live_bridge` now tracks the resolved live source (`ha_websocket`/`poll`/`none`) and its connection state: set on successful websocket auth+subscribe, cleared on disconnect; for polling, set while store reads succeed.
- `get_server_config` branches on companion mode: reports `mode: companion`, connection `type: HOME_ASSISTANT` + `live_source`, the feed's connected state, and drops the gateway/knxkeys/security fields that only exist in standalone mode.
- The settings page labels the status **Home Assistant Feed** in companion mode and only renders the KNX keys row when that field applies.

## Test plan

- New tests: `get_server_config` shape in standalone vs companion (both feed states), `live_feed_status` reflecting bridge state.
- Full backend suite passes (169 tests), frontend tsc + lint + tests pass.

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)