### PR TITLE
feat: send bar GA helpers — recent addresses and row-to-send shortcut

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -147,6 +147,7 @@ function App() {
   const [latestTelegram, setLatestTelegram] = useState<Telegram | null>(null);
   const [isDatabaseOpen, setIsDatabaseOpen] = useState(false);
   const [isSendOpen, setIsSendOpen] = useState(false);
+  const [sendPrefill, setSendPrefill] = useState<{ address: string; nonce: number } | null>(null);
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
   const [projectStatus, setProjectStatus] = useState<{
     upload_feature_active: boolean;
@@ -403,6 +404,11 @@ function App() {
       };
     });
     setIsFilterOpen(true);
+  };
+
+  const handleQuickSend = (targetAddress: string) => {
+    setSendPrefill({ address: targetAddress, nonce: Date.now() });
+    setIsSendOpen(true);
   };
 
   const handleQuickVisualize = (targetAddress: string) => {
@@ -901,7 +907,12 @@ function App() {
               {/* Content body */}
               <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
                 {isSendOpen && serverConfig?.status?.write_enabled && (
-                  <SendTelegramBar targets={filterOptions.targets} onClose={() => setIsSendOpen(false)} />
+                  <SendTelegramBar
+                    key={sendPrefill?.nonce ?? 'send-bar'}
+                    targets={filterOptions.targets}
+                    initialAddress={sendPrefill?.address}
+                    onClose={() => setIsSendOpen(false)}
+                  />
                 )}
                 {isVisualizerOpen ? (
                   <Visualizer
@@ -949,6 +960,7 @@ function App() {
                     onQuickFilter={handleQuickFilter}
                     onQuickVisualize={handleQuickVisualize}
                     onQuickLastSeen={handleQuickLastSeen}
+                    onQuickSend={serverConfig?.status?.write_enabled ? handleQuickSend : undefined}
                   />
                 )}
               </div>

--- a/frontend/src/components/GaCombobox.tsx
+++ b/frontend/src/components/GaCombobox.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { Clock } from 'lucide-react';
 
 import type { FilterOption } from '../types/filters';
 
@@ -7,6 +8,8 @@ interface Props {
   /** Called on every change. `option` is set only when picked from the list. */
   onChange: (address: string, option?: FilterOption) => void;
   options: FilterOption[];
+  /** Recently used addresses, newest first — listed on top while the input is empty (#187). */
+  recentAddresses?: string[];
   placeholder?: string;
   width?: number | string;
 }
@@ -16,18 +19,26 @@ interface Props {
  * allows typing an arbitrary address (free entry), unlike a native <datalist>
  * which the browser renders unthemed.
  */
-export function GaCombobox({ value, onChange, options, placeholder, width = 220 }: Props) {
+export function GaCombobox({ value, onChange, options, recentAddresses, placeholder, width = 220 }: Props) {
   const [open, setOpen] = useState(false);
   const [highlight, setHighlight] = useState(0);
   const wrapRef = useRef<HTMLDivElement>(null);
 
-  const matches = useMemo(() => {
+  const { matches, recentCount } = useMemo(() => {
     const q = value.trim().toLowerCase();
-    const list = q === ''
-      ? options
-      : options.filter(o => (o.address ?? '').toLowerCase().includes(q) || (o.name ?? '').toLowerCase().includes(q));
-    return list.slice(0, 100);
-  }, [value, options]);
+    if (q !== '') {
+      const list = options.filter(
+        o => (o.address ?? '').toLowerCase().includes(q) || (o.name ?? '').toLowerCase().includes(q)
+      );
+      return { matches: list.slice(0, 100), recentCount: 0 };
+    }
+    // Empty input: recently sent addresses first (with project names when known)
+    const byAddress = new Map(options.filter(o => o.address).map(o => [o.address!, o]));
+    const recent = (recentAddresses ?? []).map(a => byAddress.get(a) ?? ({ address: a } as FilterOption));
+    const recentSet = new Set(recent.map(r => r.address));
+    const rest = options.filter(o => !recentSet.has(o.address));
+    return { matches: [...recent, ...rest].slice(0, 100), recentCount: recent.length };
+  }, [value, options, recentAddresses]);
 
   useEffect(() => {
     if (!open) return;
@@ -82,8 +93,9 @@ export function GaCombobox({ value, onChange, options, placeholder, width = 220 
                 background: i === highlight ? 'var(--bg-hover)' : 'transparent',
               }}
             >
-              <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.78rem', color: 'var(--text-main)' }}>
+              <span style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', fontFamily: "'JetBrains Mono', monospace", fontSize: '0.78rem', color: 'var(--text-main)' }}>
                 {o.address}
+                {i < recentCount && <Clock size={11} style={{ color: 'var(--text-dim)' }} />}
               </span>
               {o.name && <span style={{ fontSize: '0.7rem', color: 'var(--text-dim)' }}>{o.name}</span>}
             </button>

--- a/frontend/src/components/SendTelegramBar.tsx
+++ b/frontend/src/components/SendTelegramBar.tsx
@@ -13,10 +13,13 @@ import {
   type ScheduledSendStatus,
 } from '../utils/knxSend';
 import { GaCombobox } from './GaCombobox';
+import { loadRecentGas, pushRecentGa } from '../utils/recentGas';
 
 interface Props {
   /** Group addresses from the loaded project (with optional DPT main/sub). */
   targets: FilterOption[];
+  /** Address to start with (row shortcut, #187). Remount via `key` to re-apply. */
+  initialAddress?: string;
   onClose: () => void;
 }
 
@@ -30,12 +33,16 @@ const POLL_INTERVAL_MS = 1000;
  * Shown above the telegram table in live mode only, and only when the backend
  * reports the bus is writable.
  */
-export function SendTelegramBar({ targets, onClose }: Props) {
-  const [address, setAddress] = useState('');
-  const [dpt, setDpt] = useState('');
+export function SendTelegramBar({ targets, initialAddress, onClose }: Props) {
+  const [address, setAddress] = useState(initialAddress ?? '');
+  const [dpt, setDpt] = useState(() => {
+    const known = targets.find(t => t.address === initialAddress);
+    return known && known.main != null ? formatDpt(known.main, known.sub) : '';
+  });
   const [value, setValue] = useState('');
   const [delay, setDelay] = useState('');
   const [every, setEvery] = useState('');
+  const [recentGas, setRecentGas] = useState<string[]>(loadRecentGas);
   const [busy, setBusy] = useState(false);
   const [feedback, setFeedback] = useState<{ ok: boolean; msg: string } | null>(null);
   const [job, setJob] = useState<ScheduledSendStatus | null>(null);
@@ -86,6 +93,7 @@ export function SendTelegramBar({ targets, onClose }: Props) {
         await sendTelegram(address.trim(), coerceValue(value), dpt.trim() || undefined);
         setFeedback({ ok: true, msg: `Sent ${value || '(raw)'} to ${address.trim()}` });
       }
+      setRecentGas(pushRecentGa(address.trim()));
     } catch (err) {
       setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Request failed' });
     } finally {
@@ -110,6 +118,7 @@ export function SendTelegramBar({ targets, onClose }: Props) {
           value={address}
           onChange={onAddressChange}
           options={targets}
+          recentAddresses={recentGas}
           placeholder="Group address (e.g. 1/2/3)"
           width={200}
         />

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useEffect, useState, useCallback } from 'react'
 import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
-import { ChevronUp, ChevronDown, Filter, LineChart, X, Clock } from 'lucide-react';
+import { ChevronUp, ChevronDown, Filter, LineChart, X, Clock, Send } from 'lucide-react';
 import { dptKey, type ActiveFilters } from '../types/filters';
 import { getCookie, setCookie } from '../utils/cookies';
 
@@ -22,6 +22,8 @@ interface TelegramTableProps {
   onQuickFilter: (key: 'sources' | 'targets' | 'types' | 'dpts', value: string | number) => void;
   onQuickVisualize: (targetAddress: string) => void;
   onQuickLastSeen?: (address: string, mode: 'ga' | 'pa') => void;
+  /** Copies the row's GA into the send bar; only passed when the bus is writable (#187). */
+  onQuickSend?: (targetAddress: string) => void;
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
@@ -78,7 +80,7 @@ type TelegramRow = Telegram & { deltaStr: string | null };
 const cellPadding = '0.75rem 1rem'; // Unified padding for all cells
 
 export const TelegramTable: React.FC<TelegramTableProps> = ({
-  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen
+  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, onQuickSend
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -292,6 +294,15 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                   <Clock size={12} />
                 </button>
               )}
+              {onQuickSend && (
+                <button
+                  className="quick-send-btn"
+                  onClick={(e) => { e.stopPropagation(); onQuickSend(t.target_address); }}
+                  title="Send to this GA"
+                >
+                  <Send size={12} />
+                </button>
+              )}
             </div>
             {visibleColumns.targetName && (
               <div className="subtitle-name" title={t.target_name || undefined} style={{ fontSize: '0.7rem', color: 'var(--text-main)', fontWeight: 500, marginTop: '0.15rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
@@ -468,7 +479,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
 // Add styles for quick filter buttons and resize handles
 const style = document.createElement('style');
 style.textContent = `
-  .quick-filter-btn, .quick-visualize-btn, .quick-last-seen-btn {
+  .quick-filter-btn, .quick-visualize-btn, .quick-last-seen-btn, .quick-send-btn {
     background: transparent;
     border: none;
     cursor: pointer;
@@ -503,11 +514,12 @@ style.textContent = `
 
   .log-row:hover .quick-filter-btn:not(.active),
   .log-row:hover .quick-visualize-btn,
-  .log-row:hover .quick-last-seen-btn {
+  .log-row:hover .quick-last-seen-btn,
+  .log-row:hover .quick-send-btn {
     opacity: 0.6;
   }
 
-  .quick-filter-btn:hover, .quick-visualize-btn:hover, .quick-last-seen-btn:hover {
+  .quick-filter-btn:hover, .quick-visualize-btn:hover, .quick-last-seen-btn:hover, .quick-send-btn:hover {
     opacity: 1 !important;
     background: var(--bg-hover);
     color: var(--accent-primary);

--- a/frontend/src/utils/recentGas.test.ts
+++ b/frontend/src/utils/recentGas.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { loadRecentGas, pushRecentGa } from './recentGas';
+
+describe('recentGas', () => {
+  beforeEach(() => localStorage.clear());
+
+  test('starts empty and records sends newest-first', () => {
+    expect(loadRecentGas()).toEqual([]);
+    pushRecentGa('1/2/3');
+    pushRecentGa('4/5/6');
+    expect(loadRecentGas()).toEqual(['4/5/6', '1/2/3']);
+  });
+
+  test('re-sending moves the address to the front without duplicating', () => {
+    pushRecentGa('1/2/3');
+    pushRecentGa('4/5/6');
+    pushRecentGa('1/2/3');
+    expect(loadRecentGas()).toEqual(['1/2/3', '4/5/6']);
+  });
+
+  test('keeps at most 10 entries', () => {
+    for (let i = 0; i < 15; i++) pushRecentGa(`1/1/${i}`);
+    const recents = loadRecentGas();
+    expect(recents).toHaveLength(10);
+    expect(recents[0]).toBe('1/1/14');
+  });
+
+  test('tolerates corrupt storage', () => {
+    localStorage.setItem('spectrumknx-recent-send-gas', 'not json');
+    expect(loadRecentGas()).toEqual([]);
+  });
+});

--- a/frontend/src/utils/recentGas.ts
+++ b/frontend/src/utils/recentGas.ts
@@ -1,0 +1,24 @@
+const STORAGE_KEY = 'spectrumknx-recent-send-gas';
+const MAX_RECENT = 10;
+
+/** Last group addresses sent to via the send bar, newest first (#187). */
+export function loadRecentGas(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.filter(v => typeof v === 'string').slice(0, MAX_RECENT) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Records a send target and returns the updated list. */
+export function pushRecentGa(address: string): string[] {
+  const next = [address, ...loadRecentGas().filter(a => a !== address)].slice(0, MAX_RECENT);
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Storage unavailable (private mode etc.) — recents just don't persist.
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary

Implements the group-monitor send-bar helpers from forum post #90 (#187):

- **Recent GAs:** clicking the empty send box now lists the last 10 sent group addresses first (persisted in localStorage, resolved to project names when known, marked with a clock icon). Successful sends and reads record the address.
- **Row → send shortcut:** telegram rows get a send button next to the target GA that opens the send bar with that GA — and its project DPT — prefilled. Only rendered when the backend reports the bus as writable.
- **Autocomplete** by address or name already existed via `GaCombobox`; recents integrate into the same dropdown.

Prefill is applied by remounting the send bar via `key` + `initialAddress` (avoids setState-in-effect, which the new react-hooks lint rule rejects).

## Test plan

- New `recentGas.test.ts`: newest-first ordering, dedup on re-send, 10-entry cap, corrupt-storage tolerance.
- Frontend: tsc, lint, 36 tests, production build all pass.

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)