### PR TITLE
fix: keep legend visibility and series colors stable across chart updates

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -4,6 +4,8 @@ import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';
 import type { ChartBucket } from '../hooks/useChartData';
 import { useThemeTick } from '../hooks/useTheme';
+import { seriesColor } from '../utils/seriesColors';
+import { isSeriesHidden, setSeriesHidden } from '../utils/legendVisibility';
 
 interface MixedChartProps {
   bucket: ChartBucket;
@@ -11,17 +13,6 @@ interface MixedChartProps {
   maxTime: number | null;
   stepped: boolean;
 }
-
-// Generate simple distinct colors for series
-const COLORS = [
-  '#3b82f6', // blue
-  '#ef4444', // red
-  '#eab308', // yellow
-  '#22c55e', // green
-  '#a855f7', // purple
-  '#f97316', // orange
-  '#14b8a6', // teal
-];
 
 // Ensure we have a shared sync cursor across all charts
 const syncCursor = uPlot.sync('knx-time-axis');
@@ -73,6 +64,14 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
       width,
       height: isBinary ? Math.max(150, series.length * 50) : 300,
       cursor: { sync: { key: syncCursor.key } },
+      hooks: {
+        // Record legend show/hide toggles so they survive chart recreation (#192).
+        setSeries: [(u, idx, opts) => {
+          if (idx == null || idx === 0 || !('show' in opts)) return;
+          const addr = series[idx - 1]?.address;
+          if (addr) setSeriesHidden(addr, !u.series[idx].show);
+        }]
+      },
       scales: {
         x: { time: true },
         y: scaleConfig
@@ -99,13 +98,14 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
         {
           value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
         },
-        ...series.map((s, idx) => ({
+        ...series.map((s) => ({
           label: s.name,
-          stroke: COLORS[idx % COLORS.length],
+          show: !isSeriesHidden(s.address),
+          stroke: seriesColor(s.address),
           width: 2,
           spanGaps: true,
           paths: (isBinary || stepped) ? uPlot.paths.stepped?.({ align: 1 }) : undefined,
-          fill: isBinary ? COLORS[idx % COLORS.length] + '33' : undefined,
+          fill: isBinary ? seriesColor(s.address) + '33' : undefined,
           points: { show: false },
           value: (_u: uPlot, v: number | null) => {
             if (v === null) return '-';

--- a/frontend/src/utils/legendVisibility.ts
+++ b/frontend/src/utils/legendVisibility.ts
@@ -1,0 +1,14 @@
+// Legend visibility per group address (#192): charts are torn down and
+// recreated whenever new data arrives, so user toggles must live outside the
+// uPlot instance (and outside React render state — they are set from uPlot
+// event hooks). Kept for the session, like series colors.
+const hidden = new Set<string>();
+
+export function isSeriesHidden(address: string): boolean {
+  return hidden.has(address);
+}
+
+export function setSeriesHidden(address: string, value: boolean): void {
+  if (value) hidden.add(address);
+  else hidden.delete(address);
+}

--- a/frontend/src/utils/seriesColors.test.ts
+++ b/frontend/src/utils/seriesColors.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+import { seriesColor } from './seriesColors';
+
+test('assigns distinct colors to different addresses', () => {
+  expect(seriesColor('1/1/1')).not.toBe(seriesColor('1/1/2'));
+});
+
+test('color stays stable regardless of later assignments', () => {
+  const first = seriesColor('2/0/1');
+  seriesColor('2/0/2');
+  seriesColor('2/0/3');
+  expect(seriesColor('2/0/1')).toBe(first);
+});

--- a/frontend/src/utils/seriesColors.ts
+++ b/frontend/src/utils/seriesColors.ts
@@ -1,0 +1,25 @@
+// Palette for chart series lines (distinct, works on light and dark themes).
+const COLORS = [
+  '#3b82f6', // blue
+  '#ef4444', // red
+  '#eab308', // yellow
+  '#22c55e', // green
+  '#a855f7', // purple
+  '#f97316', // orange
+  '#14b8a6', // teal
+];
+
+const assigned = new Map<string, string>();
+
+/**
+ * Stable color per group address (#197): assigned on first use and kept for
+ * the session, so toggling target visibility never recolors other lines.
+ */
+export function seriesColor(address: string): string {
+  let color = assigned.get(address);
+  if (!color) {
+    color = COLORS[assigned.size % COLORS.length];
+    assigned.set(address, color);
+  }
+  return color;
+}


### PR DESCRIPTION
Fixes #192, fixes #197.

**#192 — legend-hidden series reappeared on every incoming telegram.** The uPlot options object is rebuilt whenever new data arrives, and `uplot-react` then tears down and recreates the chart, resetting all `show` flags. Legend toggles are now recorded per group address (via the `setSeries` hook) in a session-scoped store outside the uPlot instance and reapplied when the chart is rebuilt.

**#197 — line colors were reassigned when toggling target visibility.** Colors were picked by index among the currently plotted series, so enabling/disabling one target recolored the others (TabSel's blue→red example from forum post #102). Each address now keeps the color it was first assigned for the whole session.

**Verified in the running app** (Playwright against the dev server, telegrams injected over the websocket):
- Temp A plotted alone → blue; enabling Temp B (which sorts *before* A in the bucket): A stays blue, B gets red. Previously A flipped to red.
- Temp B hidden via legend click → stays hidden (`u-off`) after further live telegrams for both series.

Unit tests cover the stable color assignment; visibility behavior was verified end-to-end as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)