### PR TITLE
fix: record boolean On/Off sends in recent GAs; recents-only dropdown while empty

### DIFF
--- a/frontend/src/components/GaCombobox.test.tsx
+++ b/frontend/src/components/GaCombobox.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test } from 'vitest';
+import { GaCombobox } from './GaCombobox';
+
+const OPTIONS = [
+  { address: '1/2/3', name: 'Living room light' },
+  { address: '4/5/6', name: 'Blinds south' },
+  { address: '12/0/0', name: 'Heating mode' },
+];
+
+test('shows only recent addresses, newest first, while the input is empty', () => {
+  render(
+    <GaCombobox value="" onChange={() => {}} options={OPTIONS} recentAddresses={['12/0/0', '4/5/6']} />
+  );
+  fireEvent.focus(screen.getByRole('textbox'));
+
+  const items = screen.getAllByRole('button');
+  expect(items).toHaveLength(2);
+  expect(items[0]).toHaveTextContent('12/0/0');
+  expect(items[1]).toHaveTextContent('4/5/6');
+  expect(screen.queryByText('1/2/3')).not.toBeInTheDocument();
+});
+
+test('shows no dropdown on focus when there are no recents', () => {
+  render(<GaCombobox value="" onChange={() => {}} options={OPTIONS} recentAddresses={[]} />);
+  fireEvent.focus(screen.getByRole('textbox'));
+  expect(screen.queryAllByRole('button')).toHaveLength(0);
+});
+
+test('filters the full project list from the first typed character', () => {
+  render(<GaCombobox value="1" onChange={() => {}} options={OPTIONS} recentAddresses={['4/5/6']} />);
+  fireEvent.focus(screen.getByRole('textbox'));
+
+  const items = screen.getAllByRole('button');
+  // Matches "1/2/3" and "12/0/0" by address; recents no longer pinned while typing.
+  expect(items).toHaveLength(2);
+  expect(items[0]).toHaveTextContent('1/2/3');
+  expect(items[1]).toHaveTextContent('12/0/0');
+});

--- a/frontend/src/components/GaCombobox.tsx
+++ b/frontend/src/components/GaCombobox.tsx
@@ -8,7 +8,7 @@ interface Props {
   /** Called on every change. `option` is set only when picked from the list. */
   onChange: (address: string, option?: FilterOption) => void;
   options: FilterOption[];
-  /** Recently used addresses, newest first — listed on top while the input is empty (#187). */
+  /** Recently used addresses, newest first — the only suggestions while the input is empty (#187, #190). */
   recentAddresses?: string[];
   placeholder?: string;
   width?: number | string;
@@ -32,12 +32,11 @@ export function GaCombobox({ value, onChange, options, recentAddresses, placehol
       );
       return { matches: list.slice(0, 100), recentCount: 0 };
     }
-    // Empty input: recently sent addresses first (with project names when known)
+    // Empty input: only the recently used addresses, newest first (#190) —
+    // the full project list appears once the user starts typing.
     const byAddress = new Map(options.filter(o => o.address).map(o => [o.address!, o]));
     const recent = (recentAddresses ?? []).map(a => byAddress.get(a) ?? ({ address: a } as FilterOption));
-    const recentSet = new Set(recent.map(r => r.address));
-    const rest = options.filter(o => !recentSet.has(o.address));
-    return { matches: [...recent, ...rest].slice(0, 100), recentCount: recent.length };
+    return { matches: recent, recentCount: recent.length };
   }, [value, options, recentAddresses]);
 
   useEffect(() => {

--- a/frontend/src/components/SendTelegramBar.test.tsx
+++ b/frontend/src/components/SendTelegramBar.test.tsx
@@ -25,6 +25,7 @@ function mockFetch(routes: Record<string, unknown>) {
 }
 
 beforeEach(() => {
+  localStorage.clear();
   vi.stubGlobal('fetch', mockFetch({ '/api/knx/send/scheduled/status': IDLE }));
 });
 
@@ -71,6 +72,25 @@ test('starts a scheduled job when an interval is set and shows the cancel row', 
   const body = JSON.parse((scheduledCall![1] as RequestInit).body as string);
   expect(body.interval_seconds).toBe(5);
   expect(body.delay_seconds).toBe(0);
+});
+
+test('boolean On/Off sends are recorded in the recent GAs (#190)', async () => {
+  vi.stubGlobal('fetch', mockFetch({
+    '/api/knx/send/scheduled/status': IDLE,
+    '/api/knx/send': { status: 'sent' },
+  }));
+
+  render(
+    <SendTelegramBar
+      targets={[{ address: '12/0/0', name: 'Heating mode', main: 1, sub: 1 }]}
+      onClose={() => {}}
+    />
+  );
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '12/0/0' } });
+  fireEvent.click(screen.getByText('On'));
+
+  await waitFor(() => expect(screen.getByText(/Sent on to 12\/0\/0/)).toBeInTheDocument());
+  expect(JSON.parse(localStorage.getItem('spectrumknx-recent-send-gas')!)).toEqual(['12/0/0']);
 });
 
 test('picks up an already-running job on mount', async () => {

--- a/frontend/src/components/SendTelegramBar.tsx
+++ b/frontend/src/components/SendTelegramBar.tsx
@@ -222,6 +222,7 @@ export function SendTelegramBar({ targets, initialAddress, onClose }: Props) {
         await sendTelegram(address.trim(), on, dpt.trim() || undefined);
         setFeedback({ ok: true, msg: `Sent ${on ? 'on' : 'off'} to ${address.trim()}` });
       }
+      setRecentGas(pushRecentGa(address.trim()));
     } catch (err) {
       setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Request failed' });
     } finally {


### PR DESCRIPTION
Fixes #190.

Root cause of the "wrong ordering" report from forum post #93: the DPT-1 **On/Off send path never recorded the address** in the recents (`sendBoolean` didn't call `pushRecentGa`), while Write/Read via `run()` did. mumpf's last-sent `12/0/0` was a boolean GA, so it never showed up. Boolean sends (including scheduled ones) are now recorded on success, exactly like writes and reads.

Second expectation from the post: while the input is empty the dropdown now shows **only the recent addresses** (newest first, clock icon), not the full project list behind them; the full list appears from the first typed character, filtered as before.

**Verified in the running app** (Playwright, send API stubbed):
- Empty input + no recents → no dropdown; typing `12` → project matches appear; picking `12/0/0` prefills DPT `1.001`.
- On → `12/0/0` recorded; Write to `1/1/1` → dropdown shows `1/1/1` then `12/0/0`; Read of `2/2/2` moves it to the front.
- Probe: a failing send (HTTP 400) does **not** record the address.

Unit tests added for the boolean-send recording and the combobox empty/typing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)