### PR TITLE
feat: filter telegrams by direction (incoming/outgoing)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -468,6 +468,7 @@ function App() {
       f.sources.length === 0 &&
       f.targets.length === 0 &&
       f.types.length === 0 &&
+      f.directions.length === 0 &&
       f.dpts.length === 0;
 
     // Step 1: mark each row as matching / not-matching
@@ -502,12 +503,14 @@ function App() {
     const sources: Record<string, number> = {};
     const targets: Record<string, number> = {};
     const types: Record<string, number> = {};
+    const directions: Record<string, number> = {};
     const dpts: Record<string, number> = {};
 
     for (const t of sortedLiveTelegrams) {
       sources[t.source_address] = (sources[t.source_address] ?? 0) + 1;
       targets[t.target_address] = (targets[t.target_address] ?? 0) + 1;
       if (t.simplified_type) types[t.simplified_type] = (types[t.simplified_type] ?? 0) + 1;
+      if (t.direction) directions[t.direction] = (directions[t.direction] ?? 0) + 1;
       if (t.dpt_main != null) {
         const key = dptKey(t.dpt_main, t.dpt_sub);
         dpts[key] = (dpts[key] ?? 0) + 1;
@@ -515,11 +518,11 @@ function App() {
         if (t.dpt_sub != null) dpts[`${t.dpt_main}`] = (dpts[`${t.dpt_main}`] ?? 0) + 1;
       }
     }
-    return { sources, targets, types, dpts };
+    return { sources, targets, types, directions, dpts };
   }, [sortedLiveTelegrams]);
 
   const activeFilterCount = hasActiveFilters(activeFilters)
-    ? activeFilters.sources.length + activeFilters.targets.length + activeFilters.types.length + activeFilters.dpts.length
+    ? activeFilters.sources.length + activeFilters.targets.length + activeFilters.types.length + activeFilters.directions.length + activeFilters.dpts.length
     : 0;
 
   return (

--- a/frontend/src/components/FilterPanel.test.tsx
+++ b/frontend/src/components/FilterPanel.test.tsx
@@ -39,6 +39,24 @@ test('hides the notice while project status is unknown', () => {
   expect(screen.queryByText(/No ETS project loaded/i)).not.toBeInTheDocument();
 });
 
+test('toggles the direction filter (#194)', () => {
+  const onFiltersChange = vi.fn();
+  render(
+    <FilterPanel
+      options={EMPTY_OPTIONS}
+      activeFilters={DEFAULT_FILTERS}
+      onFiltersChange={onFiltersChange}
+      counts={{ sources: {}, targets: {}, types: {}, directions: { Incoming: 7, Outgoing: 2 }, dpts: {} }}
+      mode="live"
+      projectLoaded={true}
+    />
+  );
+
+  expect(screen.getByText('Direction')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Outgoing'));
+  expect(onFiltersChange).toHaveBeenCalledWith({ ...DEFAULT_FILTERS, directions: ['Outgoing'] });
+});
+
 test('hides the notice when a project is loaded', () => {
   render(
     <FilterPanel

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -5,6 +5,7 @@ import {
   type ActiveFilters,
   type FilterCounts,
   DEFAULT_FILTERS,
+  DIRECTIONS,
   dptKey
 } from '../types/filters';
 import { compareKnxAddress } from '../utils/knxAddress';
@@ -183,6 +184,9 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   const filteredTypes = useMemo(() =>
     options.types.filter(t => !q || t.toLowerCase().includes(q)), [options.types, q]);
 
+  const filteredDirections = useMemo(() =>
+    DIRECTIONS.filter(d => !q || d.toLowerCase().includes(q)), [q]);
+
   const filteredDpts = useMemo(() =>
     options.dpts.filter(d =>
       !q || d.label?.toLowerCase().includes(q)
@@ -198,6 +202,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
     activeFilters.sources.length +
     activeFilters.targets.length +
     activeFilters.types.length +
+    activeFilters.directions.length +
     activeFilters.dpts.length;
 
   return (
@@ -304,6 +309,16 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               count={mode === 'live' ? (counts?.types[t] ?? 0) : undefined}
               onToggle={() => update({ types: activeFilters.types.filter(v => v !== t) })}
               onRemove={() => update({ types: activeFilters.types.filter(v => v !== t) })}
+            />
+          ))}
+          {activeFilters.directions.map(d => (
+            <OptionRow
+              key={`active-dir-${d}`}
+              label={d}
+              checked={true}
+              count={mode === 'live' ? (counts?.directions[d] ?? 0) : undefined}
+              onToggle={() => update({ directions: activeFilters.directions.filter(v => v !== d) })}
+              onRemove={() => update({ directions: activeFilters.directions.filter(v => v !== d) })}
             />
           ))}
           {activeFilters.dpts.map(d => {
@@ -461,6 +476,21 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
                 checked={activeFilters.types.includes(t)}
                 count={mode === 'live' ? (counts?.types[t] ?? 0) : undefined}
                 onToggle={() => update({ types: toggle(activeFilters.types, t) })}
+              />
+            ))}
+          </Section>
+        )}
+
+        {/* Direction — orthogonal to Type: incoming bus traffic vs. self-sent telegrams (#194) */}
+        {filteredDirections.length > 0 && (
+          <Section title="Direction" defaultOpen>
+            {filteredDirections.map(d => (
+              <OptionRow
+                key={d}
+                label={d}
+                checked={activeFilters.directions.includes(d)}
+                count={mode === 'live' ? (counts?.directions[d] ?? 0) : undefined}
+                onToggle={() => update({ directions: toggle(activeFilters.directions, d) })}
               />
             ))}
           </Section>

--- a/frontend/src/types/filters.test.ts
+++ b/frontend/src/types/filters.test.ts
@@ -50,3 +50,25 @@ describe('matchesTelegram DPT filtering', () => {
     expect(matchesTelegram(telegram, { ...DEFAULT_FILTERS, dpts: ['1'] })).toBe(true);
   });
 });
+
+describe('matchesTelegram direction filtering (#194)', () => {
+  const incoming = { source_address: '1.1.1', target_address: '1/2/3', simplified_type: 'Write', direction: 'Incoming' };
+  const outgoing = { ...incoming, direction: 'Outgoing' };
+  const undirected = { ...incoming, direction: null };
+
+  test('filters by direction', () => {
+    expect(matchesTelegram(incoming, { ...DEFAULT_FILTERS, directions: ['Outgoing'] })).toBe(false);
+    expect(matchesTelegram(outgoing, { ...DEFAULT_FILTERS, directions: ['Outgoing'] })).toBe(true);
+    expect(matchesTelegram(incoming, { ...DEFAULT_FILTERS, directions: ['Incoming', 'Outgoing'] })).toBe(true);
+  });
+
+  test('is orthogonal to the type filter', () => {
+    expect(matchesTelegram(outgoing, { ...DEFAULT_FILTERS, types: ['Write'], directions: ['Outgoing'] })).toBe(true);
+    expect(matchesTelegram(outgoing, { ...DEFAULT_FILTERS, types: ['Read'], directions: ['Outgoing'] })).toBe(false);
+  });
+
+  test('telegrams without a direction pass only when unfiltered', () => {
+    expect(matchesTelegram(undirected, DEFAULT_FILTERS)).toBe(true);
+    expect(matchesTelegram(undirected, { ...DEFAULT_FILTERS, directions: ['Incoming'] })).toBe(false);
+  });
+});

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -25,6 +25,7 @@ export interface ActiveFilters {
   sources: string[];       // source_address values
   targets: string[];       // target_address values
   types: string[];         // simplified_type values (Write/Read/Response)
+  directions: string[];    // telegram direction values (Incoming/Outgoing), orthogonal to types (#194)
   dpts: string[];          // DPT keys: "1.001" for one subtype, bare "1" for all subtypes of a major DPT
   /** ms before a matching telegram to also include (0 = disabled) */
   deltaBeforeMs: number;
@@ -48,10 +49,14 @@ export interface ActiveFilters {
   sourceTargetRelation: 'AND' | 'OR';
 }
 
+/** The two telegram direction values, as set by the backend daemon. */
+export const DIRECTIONS = ['Incoming', 'Outgoing'];
+
 export const DEFAULT_FILTERS: ActiveFilters = {
   sources: [],
   targets: [],
   types: [],
+  directions: [],
   dpts: [],
   deltaBeforeMs: 0,
   deltaAfterMs: 0,
@@ -63,6 +68,7 @@ export interface FilterableTelegram {
   source_address: string;
   target_address: string;
   simplified_type?: string | null;
+  direction?: string | null;
   dpt_main?: number | null;
   dpt_sub?: number | null;
 }
@@ -91,13 +97,15 @@ export function matchesTelegram(t: FilterableTelegram, f: ActiveFilters): boolea
   const srcOk = f.sources.length === 0 || srcMatch;
   const tgtOk = f.targets.length === 0 || tgtMatch;
   const typeOk = f.types.length === 0 || f.types.includes(t.simplified_type ?? '');
+  // Telegrams without a direction (older stored data) only pass when unfiltered.
+  const dirOk = f.directions.length === 0 || f.directions.includes(t.direction ?? '');
   const dptOk = f.dpts.length === 0 || matchesDpt(f.dpts, t.dpt_main, t.dpt_sub);
 
   const srcTgtOk = f.sources.length > 0 && f.targets.length > 0
     ? (f.sourceTargetRelation === 'OR' ? (srcMatch || tgtMatch) : (srcOk && tgtOk))
     : (srcOk && tgtOk);
 
-  return srcTgtOk && typeOk && dptOk;
+  return srcTgtOk && typeOk && dirOk && dptOk;
 }
 
 export function hasActiveFilters(f: ActiveFilters): boolean {
@@ -105,6 +113,7 @@ export function hasActiveFilters(f: ActiveFilters): boolean {
     f.sources.length > 0 ||
     f.targets.length > 0 ||
     f.types.length > 0 ||
+    f.directions.length > 0 ||
     f.dpts.length > 0
   );
 }
@@ -113,5 +122,6 @@ export interface FilterCounts {
   sources: Record<string, number>;
   targets: Record<string, number>;
   types: Record<string, number>;
+  directions: Record<string, number>;
   dpts: Record<string, number>;
 }

--- a/frontend/src/utils/viewUrl.test.ts
+++ b/frontend/src/utils/viewUrl.test.ts
@@ -15,13 +15,14 @@ describe('parseViewUrl', () => {
   });
 
   test('parses a relative view with filters', () => {
-    const v = parseViewUrl('?view=viz&plot=1/2/3,1/2/4&src=1.1.5&tgt=1/2/3&type=Write&dpt=1.001,9&before=500&after=1000&rel=24h&limit=5000');
+    const v = parseViewUrl('?view=viz&plot=1/2/3,1/2/4&src=1.1.5&tgt=1/2/3&type=Write&dir=Outgoing,bogus&dpt=1.001,9&before=500&after=1000&rel=24h&limit=5000');
     expect(v).not.toBeNull();
     expect(v!.plot).toEqual(['1/2/3', '1/2/4']);
     expect(v!.range).toEqual({ kind: 'relative', seconds: 86400 });
     expect(v!.filters.sources).toEqual(['1.1.5']);
     expect(v!.filters.targets).toEqual(['1/2/3']);
     expect(v!.filters.types).toEqual(['Write']);
+    expect(v!.filters.directions).toEqual(['Outgoing']);
     expect(v!.filters.dpts).toEqual(['1.001', '9']);
     expect(v!.filters.deltaBeforeMs).toBe(500);
     expect(v!.filters.deltaAfterMs).toBe(1000);
@@ -52,6 +53,7 @@ describe('buildViewUrl', () => {
         sources: ['1.1.5'],
         targets: ['1/2/3'],
         types: ['Write', 'Response'],
+        directions: ['Incoming'],
         dpts: ['9.001'],
         deltaBeforeMs: 250,
         deltaAfterMs: 0,
@@ -78,6 +80,7 @@ describe('buildViewUrl', () => {
     expect(url).toContain('view=viz');
     expect(url).toContain('rel=1h');
     expect(url).not.toContain('src=');
+    expect(url).not.toContain('dir=');
     expect(url).not.toContain('before=');
     expect(url).not.toContain('limit=');
     expect(url).not.toContain('rel_st=');

--- a/frontend/src/utils/viewUrl.ts
+++ b/frontend/src/utils/viewUrl.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_FILTERS, type ActiveFilters } from '../types/filters';
+import { DEFAULT_FILTERS, DIRECTIONS, type ActiveFilters } from '../types/filters';
 import type { LoadedRange } from './historyLoad';
 import { getBasePath } from './basePath';
 
@@ -60,6 +60,7 @@ export function parseViewUrl(search: string): VizViewState | null {
     sources: list(p.get('src')),
     targets: list(p.get('tgt')),
     types: list(p.get('type')),
+    directions: list(p.get('dir')).filter(d => DIRECTIONS.includes(d)),
     dpts: list(p.get('dpt')).filter(d => /^\d+(\.\d+)?$/.test(d)),
     deltaBeforeMs: Math.max(0, Number(p.get('before')) || 0),
     deltaAfterMs: Math.max(0, Number(p.get('after')) || 0),
@@ -96,6 +97,7 @@ export function buildViewUrl(state: {
   if (f.sources.length > 0) p.set('src', f.sources.join(','));
   if (f.targets.length > 0) p.set('tgt', f.targets.join(','));
   if (f.types.length > 0) p.set('type', f.types.join(','));
+  if (f.directions.length > 0) p.set('dir', f.directions.join(','));
   if (f.dpts.length > 0) p.set('dpt', f.dpts.join(','));
   if (f.deltaBeforeMs > 0) p.set('before', String(f.deltaBeforeMs));
   if (f.deltaAfterMs > 0) p.set('after', String(f.deltaAfterMs));


### PR DESCRIPTION
Fixes #194.

Adds **Direction** as its own filter section in the filter panel — orthogonal to Type, exactly as requested in forum post #98 ("Was hab ich denn für Werte bisher gesendet?"). Incoming/Outgoing options come with live count bubbles, appear as active-filter chips, count toward the filter badge, and reset with clear-all.

Scope decisions (from the open questions on the issue):
- **Client-side only** — the backend history query isn't direction-constrained, so loaded history is always a superset and the shared `matchesTelegram` narrows it correctly in both the live monitor and the history view. No backend change needed.
- Telegrams **without a direction** (older stored data) pass only while the filter is inactive.
- Shareable view URLs encode the selection (`dir=Outgoing`); unknown values are dropped on parse.

**Verified in the running app** (Playwright, telegrams injected over the websocket): counts show Incoming 3 / Outgoing 2; selecting Outgoing filters the table to the 2 outgoing rows (buffer "2 / 5"); newly arriving telegrams respect the active filter; Outgoing+Type=Read yields 0 rows (orthogonality); both directions selected shows everything; clear-all resets.

Unit tests: matcher direction cases, share-URL round-trip incl. invalid-value filtering, FilterPanel toggle test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)