### PR TITLE
fix: don't drop telegrams buffered during pause on resume

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -105,7 +105,7 @@ def _build_telegram_response(telegrams: list) -> list:
 
 @router.get("/api/telegrams")
 async def get_telegrams(
-    limit: int = 25000,
+    limit: int = 100000,
     offset: int = 0,
     # Multi-value: comma-separated strings
     source_address: str | None = None,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -311,6 +311,8 @@ function App() {
       });
     } else {
       bufferRef.current.push(t);
+      // Cap at the table limit — older overflow would be cut on resume anyway.
+      if (bufferRef.current.length > loadLimit) bufferRef.current.shift();
       setBufferedCount(prev => prev + 1);
     }
   }, [isPaused, loadLimit]);
@@ -359,12 +361,16 @@ function App() {
   // ── Pause / Resume ──────────────────────────────────────────────────────────
   const togglePause = () => {
     if (isPaused) {
-      setLiveTelegrams(prev => {
-        const next = [...bufferRef.current, ...prev];
-        return next.length > loadLimit ? next.slice(0, loadLimit) : next;
-      });
+      // Detach the buffer before scheduling the merge: the state updater runs
+      // after this handler, so reading bufferRef.current inside it would see
+      // the already-cleared array and drop every buffered telegram (#196).
+      const buffered = bufferRef.current.reverse(); // arrival order → newest-first
       bufferRef.current = [];
       setBufferedCount(0);
+      setLiveTelegrams(prev => {
+        const next = [...buffered, ...prev];
+        return next.length > loadLimit ? next.slice(0, loadLimit) : next;
+      });
     }
     setIsPaused(!isPaused);
   };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -168,7 +168,7 @@ function App() {
   const [serverConfig, setServerConfig] = useState<any>(null);
 
   // ── Settings & Persistence ──────────────────────────────────────────────────
-  const [loadLimit, setLoadLimit] = useState(Number(getCookie('loadLimit') || 25000));
+  const [loadLimit, setLoadLimit] = useState(Number(getCookie('loadLimit') || 100000));
   const [visibleColumns, setVisibleColumns] = useState<{ [key: string]: boolean }>(() => {
     try {
       const cookie = getCookie('visibleColumns');
@@ -189,6 +189,7 @@ function App() {
   // ── Live State ──────────────────────────────────────────────────────────────
   const [liveTelegrams, setLiveTelegrams] = useState<Telegram[]>([]);
   const [isPaused, setIsPaused] = useState(false);
+  const PAUSE_BUFFER_CAP = 10000;
   const bufferRef = useRef<Telegram[]>([]);
   const [bufferedCount, setBufferedCount] = useState(0);
 
@@ -311,8 +312,9 @@ function App() {
       });
     } else {
       bufferRef.current.push(t);
-      // Cap at the table limit — older overflow would be cut on resume anyway.
-      if (bufferRef.current.length > loadLimit) bufferRef.current.shift();
+      // Cap the pause buffer so a forgotten pause can't grow memory unbounded;
+      // the oldest telegrams are dropped first.
+      if (bufferRef.current.length > PAUSE_BUFFER_CAP) bufferRef.current.shift();
       setBufferedCount(prev => prev + 1);
     }
   }, [isPaused, loadLimit]);

--- a/frontend/src/components/EmbedView.tsx
+++ b/frontend/src/components/EmbedView.tsx
@@ -7,7 +7,7 @@ import { wsUrl } from '../utils/basePath';
 import type { VizViewState } from '../utils/viewUrl';
 
 const DEFAULT_REFRESH_SECONDS = 300;
-const DEFAULT_LIMIT = 25000;
+const DEFAULT_LIMIT = 100000;
 
 /**
  * Chart-only rendering of a shared view (#150) for iframes / dashboard cards


### PR DESCRIPTION
Fixes #196.

Turns out pause **already buffered** incoming telegrams and showed "Paused: N" — but every one of them was silently discarded on resume, which is exactly the gap mumpf reported in forum post #100. Root cause: `togglePause` cleared `bufferRef.current` synchronously, while the `setLiveTelegrams(prev => [...bufferRef.current, ...prev])` updater only runs when React processes the update — it always read the already-emptied ref. Present since the initial commit, and independent of the live source (standalone KNX daemon and HA companion feed the same `/ws/telegrams` path; reproduced there directly).

Changes:
- Detach the buffer before scheduling the merge, so the updater works on a stable copy (also safe under StrictMode double-invocation).
- Prepend the buffer newest-first so the load-limit cut keeps the newest rows.
- Cap the pause buffer at a fixed **10 000** telegrams (oldest dropped first) so a forgotten pause can't grow memory unbounded.
- Raise the default telegram load limit from 25 000 to **100 000** (live buffer, embed view, backend history default).

**Verified in the running app** (Playwright, telegrams injected over the websocket):
- Repro before fix: 3 shown → pause → 4 arrive ("Paused: 4") → resume → rows `[8,3,2,1]`, buffered 4–7 lost.
- After fix: rows `[8..1]`, no gap.
- Probes: buffer overflow past the limit → exactly the newest rows shown; 3 rapid pause/resume cycles → nothing lost; pause with zero arrivals → no-op.

The ETS-style scroll anchoring from the same forum thread is split out as a separate feature request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
