### PR TITLE
release: prepare v1.13.2

### DIFF
--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.13.2
+
+### Added
+
+- **Direction filter**: filter the Group Monitor by telegram direction (Incoming / Outgoing), as a dimension independent of the Type filter — useful for isolating self-sent telegrams in an analysis session (#194).
+- **ETS-style scroll anchoring**: the live telegram list now auto-scrolls only while parked at the live edge. Scroll away and your position is held while telegrams keep arriving; a "N new telegrams" pill jumps back to live (#202).
+
+### Changed
+
+- **Higher default buffer size**: the default number of telegrams kept in the live view and loaded from history was raised from 25,000 to 100,000 (#196).
+
+### Fixed
+
+- **Pause no longer drops telegrams**: pausing the Group Monitor and resuming discarded every telegram received during the pause; they are now buffered and backfilled on resume (#196).
+- **Chart legend visibility persists**: hiding a series by clicking it in the legend is no longer undone when a new telegram for that series arrives (#192).
+- **Stable chart colors**: line colors are no longer reassigned when toggling target visibility (#197).
+- **Send bar recent addresses**: On/Off (DPT-1) sends are now recorded in the recent-GA dropdown, and the dropdown lists only recent addresses while the box is empty — typing shows the full project list (#190).
+
 ## 1.13.1
 
 ### Changed

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "1.13.1"
+version: "1.13.2"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.13.2
+
+### Added
+
+- **Direction filter**: filter the Group Monitor by telegram direction (Incoming / Outgoing), as a dimension independent of the Type filter — useful for isolating self-sent telegrams in an analysis session (#194).
+- **ETS-style scroll anchoring**: the live telegram list now auto-scrolls only while parked at the live edge. Scroll away and your position is held while telegrams keep arriving; a "N new telegrams" pill jumps back to live (#202).
+
+### Changed
+
+- **Higher default buffer size**: the default number of telegrams kept in the live view and loaded from history was raised from 25,000 to 100,000 (#196).
+
+### Fixed
+
+- **Pause no longer drops telegrams**: pausing the Group Monitor and resuming discarded every telegram received during the pause; they are now buffered and backfilled on resume (#196).
+- **Chart legend visibility persists**: hiding a series by clicking it in the legend is no longer undone when a new telegram for that series arrives (#192).
+- **Stable chart colors**: line colors are no longer reassigned when toggling target visibility (#197).
+- **Send bar recent addresses**: On/Off (DPT-1) sends are now recorded in the recent-GA dropdown, and the dropdown lists only recent addresses while the box is empty — typing shows the full project list (#190).
+
 ## 1.13.1
 
 ### Fixed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.13.1"
+version: "1.13.2"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Version-bump + changelog for **v1.13.2**. Bumps both add-on `config.yaml` files to 1.13.2 and prepends matching CHANGELOG entries.

Changes since 1.13.1 (all shipped, forum-driven):

**Added**
- Direction filter (Incoming/Outgoing), orthogonal to Type — #194
- ETS-style scroll anchoring in the group monitor — #202

**Changed**
- Default buffer/history limit 25,000 → 100,000

**Fixed**
- Pause no longer drops telegrams received during the pause — #196
- Chart legend visibility persists across live updates — #192
- Stable chart line colors when toggling targets — #197
- Send bar records On/Off sends in recents; recents-only dropdown while empty — #190

After merge, tagging `v1.13.2` triggers the release workflow (GHCR images, GitHub Release, Debian + Windows artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)