### PR TITLE
fix: live-updating charts — keep cursor alive & collapse duplicate graphs

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -41,6 +41,15 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
     ...series.map(s => s.data)
   ];
 
+  // Only the chart's *structure* (size, theme, series identity, unit) should
+  // rebuild `options`; a new telegram changes `data`, not `options`, so
+  // uplot-react updates via setData instead of destroying and recreating the
+  // chart — which would drop the cursor/hover on every telegram (#207).
+  const structureKey = [
+    width, isBinary, unit, stepped, themeTick,
+    series.map(s => `${s.address}~${s.name}`).join('|'),
+  ].join('§');
+
   const options: uPlot.Options = useMemo(() => {
     const style = getComputedStyle(document.documentElement);
     const gridStroke = style.getPropertyValue('--border-subtle').trim();
@@ -116,7 +125,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
       ]
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [width, bucket, stepped, themeTick]);
+  }, [structureKey]);
 
   return (
     <div style={{ marginBottom: '2rem', background: 'var(--bg-inset)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)' }}>

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -37,6 +37,14 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
   const rowGap = 4;
   const chartHeight = series.length * (rowHeight + rowGap) + 60;
 
+  // Rebuild `options` only on structural changes (size, theme, series identity),
+  // never on data — so a new telegram updates the chart via setData rather than
+  // recreating it, keeping the cursor/hover alive (#207). The draw plugin below
+  // therefore reads timestamps/values from `u.data`, not from this closure.
+  const structureKey = [
+    width, themeTick, series.map(s => s.name).join('|'),
+  ].join('§');
+
   const options: uPlot.Options = useMemo(() => {
     const style = getComputedStyle(document.documentElement);
     const gridStroke = style.getPropertyValue('--border-subtle').trim();
@@ -54,18 +62,23 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
           ctx.rect(left, top, width, height);
           ctx.clip();
 
-          series.forEach((_, sIdx) => {
+          // Read x (seconds) and y from the live uPlot data, not the closure,
+          // so the plugin stays correct while `options` is kept stable (#207).
+          const xs = u.data[0];
+          const seriesCount = u.data.length - 1;
+
+          for (let sIdx = 0; sIdx < seriesCount; sIdx++) {
             const yData = u.data[sIdx + 1];
             const yTop = top + sIdx * (rowHeight + rowGap) + rowGap;
 
-            for (let i = 0; i < timestamps.length; i++) {
+            for (let i = 0; i < xs.length; i++) {
               const val = yData[i];
               if (val === null) continue;
 
-              const xStart = u.valToPos(timestamps[i] / 1000, 'x', true);
+              const xStart = u.valToPos(xs[i], 'x', true);
               let xEnd;
-              if (i < timestamps.length - 1) {
-                xEnd = u.valToPos(timestamps[i + 1] / 1000, 'x', true);
+              if (i < xs.length - 1) {
+                xEnd = u.valToPos(xs[i + 1], 'x', true);
               } else {
                 xEnd = left + width;
               }
@@ -84,18 +97,19 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
                 ctx.fillText(isOn ? 'On' : 'Off', xStart + (xEnd - xStart) / 2, yTop + rowHeight / 2);
               }
             }
-          });
+          }
 
           ctx.restore();
 
-          series.forEach((s, sIdx) => {
+          // Series labels (structural: names come from the closure, count from data).
+          for (let sIdx = 0; sIdx < seriesCount; sIdx++) {
             const yTop = top + sIdx * (rowHeight + rowGap) + rowGap;
             ctx.fillStyle = accentPrimary;
             ctx.font = '600 12px sans-serif';
             ctx.textAlign = 'left';
             ctx.textBaseline = 'middle';
-            ctx.fillText(s.name, left + width + 15, yTop + rowHeight / 2);
-          });
+            ctx.fillText(series[sIdx]?.name ?? '', left + width + 15, yTop + rowHeight / 2);
+          }
         }]
       }
     });
@@ -138,7 +152,7 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
       ]
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [width, bucket, themeTick]);
+  }, [structureKey]);
 
   return (
     <div style={{ marginBottom: '2rem', background: 'var(--bg-inset)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)', overflow: 'visible' }}>

--- a/frontend/src/hooks/useChartData.test.ts
+++ b/frontend/src/hooks/useChartData.test.ts
@@ -1,0 +1,44 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { useChartData } from './useChartData';
+import type { Telegram } from './useWebSocket';
+
+const base: Telegram = {
+  timestamp: '2026-07-16T10:00:00.000Z',
+  source_address: '1.1.1',
+  target_address: '1/1/1',
+  telegram_type: 'GroupValueWrite',
+  dpt: null, dpt_main: null, dpt_sub: null, dpt_name: null,
+  value_numeric: null, value_json: null, raw_data: null,
+};
+
+const at = (s: number, o: Partial<Telegram>): Telegram => ({
+  ...base,
+  timestamp: `2026-07-16T10:00:${String(s).padStart(2, '0')}.000Z`,
+  ...o,
+});
+
+describe('useChartData — DPT backfill / duplicate graphs (#206)', () => {
+  test('a GA decoded after import collapses to one bucket, dropping pre-import raw rows', () => {
+    const telegrams = [
+      // pre-import: no DPT, raw numeric payload
+      at(1, { target_address: '1/1/1', value_json: 100 }),
+      at(2, { target_address: '1/1/1', value_json: 101 }),
+      // post-import: decoded °C
+      at(3, { target_address: '1/1/1', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 20 }),
+      at(4, { target_address: '1/1/1', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 21 }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1']));
+    expect(result.current.buckets.map(b => b.unit)).toEqual(['°C']);
+  });
+
+  test('a GA that is never decoded still plots in the unknown bucket', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', value_json: 100 }),
+      at(2, { target_address: '1/1/1', value_json: 101 }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1']));
+    expect(result.current.buckets).toHaveLength(1);
+    expect(result.current.buckets[0].unit).toBe('unknown');
+  });
+});

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -26,12 +26,26 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
       return { buckets: [], minTime: null, maxTime: null };
     }
 
+    // A GA whose DPT is known from the project produces decoded telegrams
+    // (dpt_main set). Telegrams received *before* a project import stay
+    // undecoded (dpt_main null, only a raw payload), so plotting both puts the
+    // same GA in an "unknown" bucket next to its real-unit bucket — two graphs
+    // for one address (#206). Once a GA has any decoded telegram, ignore its
+    // undecoded ones so it collapses to a single, correctly-scaled series.
+    const decodedGas = new Set(
+      telegrams
+        .filter(t => t.target_address && selectedTargets.includes(t.target_address) && t.dpt_main != null)
+        .map(t => t.target_address)
+    );
+
     // 1. Filter out only relevant telegrams and parse timestamps
     const relevant = telegrams
       .filter(t => t.target_address && selectedTargets.includes(t.target_address))
       // Filter out reads/responses if they don't have a value (to keep plot clean), usually we plot values.
       // Easiest is to ensure value_numeric or value_json is != null
       .filter(t => t.value_numeric !== null || t.value_json !== null)
+      // Drop pre-import undecoded rows for GAs that are decoded elsewhere (#206).
+      .filter(t => t.dpt_main != null || !decodedGas.has(t.target_address))
       .map(t => ({
         ...t,
         ts: new Date(t.timestamp).getTime()


### PR DESCRIPTION
Two visualization bugs reported on the KNX forum (thread page 8).

### #207 — hover crosshair/legend lost on every telegram
The synced vertical crosshair across stacked graphs (which TabSel called "genial") disappeared the instant any telegram arrived. Root cause is the same class as the #192 legend bug: `uplot-react` destroys and recreates the uPlot instance whenever the `options` object changes by reference, and both charts rebuilt `options` on every data tick (their `useMemo` depended on the whole `bucket`). Each telegram tore the chart down, dropping the cursor.

Fix: memoize `options` on a **structural key** (size, theme, series identity, unit) only. New data flows through the separate `data` prop, which uplot-react applies via `setData` — no teardown, so the cursor, hover legend and zoom survive. `TimelineChart`'s custom draw plugin now reads timestamps/values from `u.data` instead of the closure so it stays correct while `options` is held stable. Bonus: the #192 legend-visibility fix is now more robust (no recreation to undo a toggle).

### #206 — duplicate graphs for one GA after project import
Telegrams received before a `.knxproj` import are stored undecoded (no DPT); telegrams for the same GA after import carry a DPT/unit. The undecoded rows landed in an "unknown" bucket next to the real-unit bucket → two graphs for one address (TabSel, post #106).

Fix: `useChartData` drops a GA's undecoded rows once that GA has any decoded telegram, collapsing it to a single correctly-scaled series. GAs that are never decoded still plot in the unknown bucket. (This is the "wenigstens metric unbekannt rausfiltern" resolution TabSel offered; a full historical re-decode/backfill would be a larger, separate change.)

### Verified in the running app (Playwright + websocket injection)
- **#207**: marked the `.uplot` DOM node, hovered, injected telegrams → node is **not recreated** (marker kept), crosshair stays visible, legend keeps live-updating values (24°C→25°C). Screenshot: crosshair + synced legend intact after telegram.
- **#206**: reproduced two charts ("Metrics (unknown)" + "Metrics (°C)") for one GA → after fix, **one** chart. Guard: a GA with only undecoded rows still plots; a decoded GA alongside it still shows both correctly.
- Unit test added for the #206 dedup (decoded-collapses, unknown-still-plots). Suite 48 green, typecheck + lint clean.

Closes #207, closes #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)