### PR TITLE
release: prepare v1.13.3

### DIFF
--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.13.3
+
+### Fixed
+
+- **Chart hover survives live telegrams**: the synced crosshair and value legend across stacked graphs are no longer reset every time a telegram arrives — charts now update in place instead of being recreated, which also preserves zoom and legend visibility toggles (#207).
+- **No duplicate graph per group address after import**: telegrams received before a project import (undecoded, no DPT) no longer produce a separate "unknown metric" graph next to the decoded one for the same GA; the address collapses to a single, correctly-scaled series (#206).
+
 ## 1.13.2
 
 ### Added

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "1.13.2"
+version: "1.13.3"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.13.3
+
+### Fixed
+
+- **Chart hover survives live telegrams**: the synced crosshair and value legend across stacked graphs are no longer reset every time a telegram arrives — charts now update in place instead of being recreated, which also preserves zoom and legend visibility toggles (#207).
+- **No duplicate graph per group address after import**: telegrams received before a project import (undecoded, no DPT) no longer produce a separate "unknown metric" graph next to the decoded one for the same GA; the address collapses to a single, correctly-scaled series (#206).
+
 ## 1.13.2
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.13.2"
+version: "1.13.3"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Version bump + changelog for **v1.13.3** (patch). Bumps both add-on `config.yaml` files to 1.13.3 and prepends matching CHANGELOG entries.

Two visualization bug fixes from KNX-forum reports (merged in #209):

**Fixed**
- Chart hover crosshair/legend no longer reset by incoming telegrams — charts update in place, preserving cursor, zoom and legend toggles (#207)
- No more duplicate "unknown metric" graph per GA after project import (#206)

After merge, tagging `v1.13.3` triggers the release workflow (GHCR images, GitHub Release, Debian + Windows artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)