### PR TITLE
fix: rank exact GA matches first in combobox suggestions

### DIFF
--- a/frontend/src/components/GaCombobox.test.tsx
+++ b/frontend/src/components/GaCombobox.test.tsx
@@ -27,6 +27,49 @@ test('shows no dropdown on focus when there are no recents', () => {
   expect(screen.queryAllByRole('button')).toHaveLength(0);
 });
 
+test('ranks the exact address match first and preselects it, ahead of infix matches (#217)', () => {
+  const picked: string[] = [];
+  render(
+    <GaCombobox
+      value="2/4/1"
+      onChange={(addr, option) => { if (option) picked.push(addr); }}
+      options={[
+        { address: '12/4/1', name: 'Waldi: Präsenz in den letzten 5 Minuten' },
+        { address: '12/4/10', name: 'Waldi: Präsenz HKL' },
+        { address: '2/4/1', name: 'Haus: Zeit' },
+        { address: '2/4/10', name: 'Haus: Datum' },
+      ]}
+    />
+  );
+  const input = screen.getByRole('textbox');
+  fireEvent.focus(input);
+
+  const items = screen.getAllByRole('button');
+  expect(items[0]).toHaveTextContent('2/4/1');
+  // Prefix matches ("2/4/10") rank ahead of pure infix matches ("12/4/1").
+  expect(items[1]).toHaveTextContent('2/4/10');
+
+  // Enter picks the preselected exact match without arrowing down.
+  fireEvent.keyDown(input, { key: 'Enter' });
+  expect(picked).toEqual(['2/4/1']);
+});
+
+test('ranks an exact name match first (#217)', () => {
+  render(
+    <GaCombobox
+      value="blinds south"
+      onChange={() => {}}
+      options={[
+        { address: '4/5/7', name: 'Blinds south west' },
+        { address: '4/5/6', name: 'Blinds south' },
+      ]}
+    />
+  );
+  fireEvent.focus(screen.getByRole('textbox'));
+  const items = screen.getAllByRole('button');
+  expect(items[0]).toHaveTextContent('4/5/6');
+});
+
 test('filters the full project list from the first typed character', () => {
   render(<GaCombobox value="1" onChange={() => {}} options={OPTIONS} recentAddresses={['4/5/6']} />);
   fireEvent.focus(screen.getByRole('textbox'));

--- a/frontend/src/components/GaCombobox.tsx
+++ b/frontend/src/components/GaCombobox.tsx
@@ -27,9 +27,18 @@ export function GaCombobox({ value, onChange, options, recentAddresses, placehol
   const { matches, recentCount } = useMemo(() => {
     const q = value.trim().toLowerCase();
     if (q !== '') {
-      const list = options.filter(
-        o => (o.address ?? '').toLowerCase().includes(q) || (o.name ?? '').toLowerCase().includes(q)
-      );
+      // Rank so the exact match is on top and preselected, ahead of prefix and
+      // infix matches — typing "2/4/1" must not leave "12/4/1" as the top hit (#217).
+      const rank = (o: FilterOption) => {
+        const addr = (o.address ?? '').toLowerCase();
+        const name = (o.name ?? '').toLowerCase();
+        if (addr === q || name === q) return 0;
+        if (addr.startsWith(q) || name.startsWith(q)) return 1;
+        return 2;
+      };
+      const list = options
+        .filter(o => (o.address ?? '').toLowerCase().includes(q) || (o.name ?? '').toLowerCase().includes(q))
+        .sort((a, b) => rank(a) - rank(b));
       return { matches: list.slice(0, 100), recentCount: 0 };
     }
     // Empty input: only the recently used addresses, newest first (#190) —


### PR DESCRIPTION
Typing an exact group address (e.g. `2/4/1`) could leave an infix match (`12/4/1`) as the top, preselected suggestion in the send-bar GA dropdown (and every other `GaCombobox`).

Suggestions are now ranked: **exact** address/name match → **prefix** matches → **infix** matches, with the previous order kept within each group. Since the highlight resets to the first entry on every keystroke, the exact match is preselected and `Enter` sends to it directly.

Reported by mumpf in [forum post #128](https://knx-user-forum.de/forum/%C3%B6ffentlicher-bereich/knx-eib-forum/2088940-showcase-spectrumknx-%E2%80%93-neues-tool-f%C3%BCr-langzeit-analyse-telegramm-deep-dive/page9).

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)