### PR TITLE
fix: DPT-aware write controls in Last Seen Values, shared with send bar

### DIFF
--- a/frontend/src/components/LastSeenOverlay.test.tsx
+++ b/frontend/src/components/LastSeenOverlay.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { LastSeenOverlay } from './LastSeenOverlay';
+import type { FilterOptions } from '../types/filters';
+
+const FILTER_OPTIONS: FilterOptions = {
+  sources: [],
+  targets: [
+    { address: '16/0/1', name: 'SRV_Alive', main: 1, sub: 11 },
+    { address: '1/1/97', name: 'EGD_BWM55TG2A_Helligkeit', main: 9, sub: 4 },
+  ],
+  types: [],
+  dpts: [],
+  ga_group_names: {},
+  pa_line_names: {},
+};
+
+function mockFetch(routes: Record<string, unknown>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    for (const [path, body] of Object.entries(routes)) {
+      if (url.includes(path)) {
+        return { ok: true, json: async () => body } as Response;
+      }
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/telegrams': { telegrams: [] } }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test('write row renders On/Off for a DPT 1 GA and sends a boolean, like the send bar (#213)', async () => {
+  const fetchMock = mockFetch({
+    '/api/telegrams': { telegrams: [] },
+    '/api/knx/send': { status: 'sent' },
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  render(
+    <LastSeenOverlay
+      filterOptions={FILTER_OPTIONS}
+      initialAddresses={['16/0/1']}
+      initialMode="ga"
+      writeEnabled
+      onClose={() => {}}
+    />
+  );
+
+  // DPT-aware controls instead of a free value field that would cause a ConversionError.
+  expect(screen.queryByPlaceholderText(/Value/)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByText('On'));
+
+  await waitFor(() => {
+    const sendCall = fetchMock.mock.calls.find(([u]) => String(u).includes('/api/knx/send'));
+    expect(sendCall).toBeTruthy();
+    const body = JSON.parse((sendCall![1] as RequestInit).body as string);
+    expect(body).toMatchObject({ address: '16/0/1', payload: true, dpt: '1.011' });
+  });
+});
+
+test('write row keeps the value field and Write button for non-boolean DPTs', async () => {
+  render(
+    <LastSeenOverlay
+      filterOptions={FILTER_OPTIONS}
+      initialAddresses={['1/1/97']}
+      initialMode="ga"
+      writeEnabled
+      onClose={() => {}}
+    />
+  );
+
+  expect(await screen.findByPlaceholderText(/Value/)).toBeInTheDocument();
+  expect(screen.getByText('Write', { selector: 'button' })).toBeInTheDocument();
+  expect(screen.queryByText('On')).not.toBeInTheDocument();
+});

--- a/frontend/src/components/LastSeenOverlay.tsx
+++ b/frontend/src/components/LastSeenOverlay.tsx
@@ -4,7 +4,8 @@ import { format, formatDistanceToNowStrict } from 'date-fns';
 import type { Telegram } from '../hooks/useWebSocket';
 import type { FilterOptions } from '../types/filters';
 import { apiUrl } from '../utils/basePath';
-import { coerceValue, formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
+import { formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
+import { WriteControls } from './WriteControls';
 
 const LIMITS = [10, 20, 50, 100] as const;
 
@@ -117,11 +118,11 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
     }
   };
 
-  const handleWrite = async (dpt: string) => {
+  const handleWrite = async (payload: boolean | number | string, dpt: string) => {
     setBusy(true);
     setSendError(null);
     try {
-      await sendTelegram(selectedAddresses[0], coerceValue(writeValue), dpt || undefined);
+      await sendTelegram(selectedAddresses[0], payload, dpt || undefined);
       refreshSoon();
     } catch (err) {
       setSendError(err instanceof Error ? err.message : 'Write failed');
@@ -353,30 +354,16 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
             <span style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', fontSize: '0.75rem', fontWeight: 600, color: 'var(--accent-primary)' }}>
               <Send size={14} /> Write
             </span>
-            <input
-              className="glass-input"
-              placeholder="Value (e.g. 50, 21.5, on)"
+            <WriteControls
+              dptMain={selectedInfo?.main}
               value={writeValue}
-              onChange={e => { setWriteValue(e.target.value); setSendError(null); }}
-              onKeyDown={e => { if (e.key === 'Enter' && writeValue.trim() && !busy) handleWrite(formatDpt(selectedInfo?.main, selectedInfo?.sub)); }}
-              style={{ width: 200 }}
+              onValueChange={v => { setWriteValue(v); setSendError(null); }}
+              onWrite={payload => void handleWrite(payload, formatDpt(selectedInfo?.main, selectedInfo?.sub))}
+              disabled={busy}
             />
             <span style={{ fontSize: '0.72rem', color: 'var(--text-dim)', fontFamily: "'JetBrains Mono', monospace" }}>
               DPT {formatDpt(selectedInfo?.main, selectedInfo?.sub) || '—'}
             </span>
-            <button
-              onClick={() => handleWrite(formatDpt(selectedInfo?.main, selectedInfo?.sub))}
-              disabled={busy || writeValue.trim() === ''}
-              style={{
-                display: 'flex', alignItems: 'center', gap: '0.3rem',
-                padding: '0.3rem 0.75rem', fontSize: '0.76rem', fontWeight: 600,
-                background: 'var(--accent-primary)', color: 'white', border: 'none', borderRadius: 6,
-                cursor: busy || writeValue.trim() === '' ? 'not-allowed' : 'pointer',
-                opacity: busy || writeValue.trim() === '' ? 0.5 : 1,
-              }}
-            >
-              <Send size={13} /> Send
-            </button>
             {sendError && <span style={{ fontSize: '0.72rem', color: 'var(--error)' }}>{sendError}</span>}
           </div>
         )}

--- a/frontend/src/components/SendTelegramBar.tsx
+++ b/frontend/src/components/SendTelegramBar.tsx
@@ -3,7 +3,6 @@ import { Send, Radio, X, AlertTriangle, CheckCircle2, Timer } from 'lucide-react
 
 import type { FilterOption } from '../types/filters';
 import {
-  coerceValue,
   formatDpt,
   readTelegram,
   sendTelegram,
@@ -13,6 +12,8 @@ import {
   type ScheduledSendStatus,
 } from '../utils/knxSend';
 import { GaCombobox } from './GaCombobox';
+import { WriteControls } from './WriteControls';
+import { secondaryBtn } from '../utils/buttonStyles';
 import { loadRecentGas, pushRecentGa } from '../utils/recentGas';
 
 interface Props {
@@ -80,19 +81,31 @@ export function SendTelegramBar({ targets, initialAddress, onClose }: Props) {
     if (match && match.main != null) setDpt(formatDpt(match.main, match.sub));
   };
 
-  const run = async (action: 'send' | 'read') => {
+  const write = async (payload: boolean | number | string) => {
     setBusy(true);
     setFeedback(null);
     try {
-      if (action === 'read') {
-        await readTelegram(address.trim());
-        setFeedback({ ok: true, msg: `Read request sent to ${address.trim()}` });
-      } else if (isScheduled) {
-        await startScheduled(coerceValue(value));
+      if (isScheduled) {
+        await startScheduled(payload);
       } else {
-        await sendTelegram(address.trim(), coerceValue(value), dpt.trim() || undefined);
-        setFeedback({ ok: true, msg: `Sent ${value || '(raw)'} to ${address.trim()}` });
+        await sendTelegram(address.trim(), payload, dpt.trim() || undefined);
+        const shown = typeof payload === 'boolean' ? (payload ? 'on' : 'off') : value || '(raw)';
+        setFeedback({ ok: true, msg: `Sent ${shown} to ${address.trim()}` });
       }
+      setRecentGas(pushRecentGa(address.trim()));
+    } catch (err) {
+      setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Request failed' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const read = async () => {
+    setBusy(true);
+    setFeedback(null);
+    try {
+      await readTelegram(address.trim());
+      setFeedback({ ok: true, msg: `Read request sent to ${address.trim()}` });
       setRecentGas(pushRecentGa(address.trim()));
     } catch (err) {
       setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Request failed' });
@@ -132,20 +145,13 @@ export function SendTelegramBar({ targets, initialAddress, onClose }: Props) {
           style={{ width: 110, fontFamily: "'JetBrains Mono', monospace", fontSize: '0.8rem' }}
         />
 
-        {dptMain === 1 ? (
-          <div style={{ display: 'flex', gap: '0.3rem' }}>
-            <button disabled={sendDisabled} onClick={() => void sendBoolean(true)} style={boolBtn(sendDisabled)}>On</button>
-            <button disabled={sendDisabled} onClick={() => void sendBoolean(false)} style={boolBtn(sendDisabled)}>Off</button>
-          </div>
-        ) : (
-          <input
-            className="glass-input"
-            placeholder="Value (e.g. 50, 21.5, on)"
-            value={value}
-            onChange={e => { setValue(e.target.value); setFeedback(null); }}
-            style={{ width: 170 }}
-          />
-        )}
+        <WriteControls
+          dptMain={dptMain}
+          value={value}
+          onValueChange={v => { setValue(v); setFeedback(null); }}
+          onWrite={payload => void write(payload)}
+          disabled={sendDisabled}
+        />
 
         <input
           className="glass-input"
@@ -165,18 +171,8 @@ export function SendTelegramBar({ targets, initialAddress, onClose }: Props) {
           style={{ width: 70 }}
         />
 
-        {dptMain !== 1 && (
-          <button
-            onClick={() => run('send')}
-            disabled={sendDisabled || value.trim() === ''}
-            style={primaryBtn(sendDisabled || value.trim() === '')}
-          >
-            <Send size={14} /> Write
-          </button>
-        )}
-
         <button
-          onClick={() => run('read')}
+          onClick={() => void read()}
           disabled={busy || !addressValid}
           style={secondaryBtn(busy || !addressValid)}
           title="Send a GroupValueRead; the response updates the last value"
@@ -211,24 +207,6 @@ export function SendTelegramBar({ targets, initialAddress, onClose }: Props) {
       )}
     </div>
   );
-
-  async function sendBoolean(on: boolean) {
-    setBusy(true);
-    setFeedback(null);
-    try {
-      if (isScheduled) {
-        await startScheduled(on);
-      } else {
-        await sendTelegram(address.trim(), on, dpt.trim() || undefined);
-        setFeedback({ ok: true, msg: `Sent ${on ? 'on' : 'off'} to ${address.trim()}` });
-      }
-      setRecentGas(pushRecentGa(address.trim()));
-    } catch (err) {
-      setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Request failed' });
-    } finally {
-      setBusy(false);
-    }
-  }
 
   async function startScheduled(payload: unknown) {
     if (intervalSeconds > 0 && intervalSeconds < 1) {
@@ -305,31 +283,3 @@ function describeJob(job: ScheduledSendStatus): string {
   return `Sending to ${job.address}…`;
 }
 
-function boolBtn(disabled: boolean): React.CSSProperties {
-  return {
-    padding: '0.35rem 0.85rem', fontSize: '0.78rem', fontWeight: 600,
-    background: 'var(--bg-tag)', color: 'var(--text-main)',
-    border: '1px solid var(--border-color)', borderRadius: '6px',
-    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
-  };
-}
-
-function primaryBtn(disabled: boolean): React.CSSProperties {
-  return {
-    display: 'flex', alignItems: 'center', gap: '0.35rem',
-    padding: '0.35rem 0.8rem', fontSize: '0.78rem', fontWeight: 600,
-    background: 'var(--accent-primary)', color: 'white',
-    border: 'none', borderRadius: '6px',
-    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
-  };
-}
-
-function secondaryBtn(disabled: boolean): React.CSSProperties {
-  return {
-    display: 'flex', alignItems: 'center', gap: '0.35rem',
-    padding: '0.35rem 0.8rem', fontSize: '0.78rem', fontWeight: 600,
-    background: 'transparent', color: 'var(--accent-primary)',
-    border: '1px solid var(--accent-primary)', borderRadius: '6px',
-    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
-  };
-}

--- a/frontend/src/components/WriteControls.tsx
+++ b/frontend/src/components/WriteControls.tsx
@@ -1,0 +1,49 @@
+import { Send } from 'lucide-react';
+
+import { coerceValue } from '../utils/knxSend';
+import { boolBtn, primaryBtn } from '../utils/buttonStyles';
+
+interface Props {
+  /** DPT main number of the target GA, when known. DPT 1 renders On/Off buttons. */
+  dptMain?: number | null;
+  value: string;
+  onValueChange: (value: string) => void;
+  /** Fires with the payload to write: `true`/`false` for DPT 1, the coerced free value otherwise. */
+  onWrite: (payload: boolean | number | string) => void;
+  /** Disables all controls (busy, invalid address, active scheduled job). */
+  disabled?: boolean;
+}
+
+/**
+ * DPT-aware write controls, shared by every place that writes to the bus
+ * (send bar, Last Seen Values) so the same GA renders identically everywhere
+ * (#213): On/Off buttons for DPT 1, a free-value field plus Write button
+ * otherwise. Enter in the value field writes.
+ */
+export function WriteControls({ dptMain, value, onValueChange, onWrite, disabled = false }: Props) {
+  if (dptMain === 1) {
+    return (
+      <div style={{ display: 'flex', gap: '0.3rem' }}>
+        <button disabled={disabled} onClick={() => onWrite(true)} style={boolBtn(disabled)}>On</button>
+        <button disabled={disabled} onClick={() => onWrite(false)} style={boolBtn(disabled)}>Off</button>
+      </div>
+    );
+  }
+
+  const writeDisabled = disabled || value.trim() === '';
+  return (
+    <>
+      <input
+        className="glass-input"
+        placeholder="Value (e.g. 50, 21.5, on)"
+        value={value}
+        onChange={e => onValueChange(e.target.value)}
+        onKeyDown={e => { if (e.key === 'Enter' && !writeDisabled) onWrite(coerceValue(value)); }}
+        style={{ width: 170 }}
+      />
+      <button onClick={() => onWrite(coerceValue(value))} disabled={writeDisabled} style={primaryBtn(writeDisabled)}>
+        <Send size={14} /> Write
+      </button>
+    </>
+  );
+}

--- a/frontend/src/utils/buttonStyles.ts
+++ b/frontend/src/utils/buttonStyles.ts
@@ -1,0 +1,31 @@
+/** Shared button styles for the bus-write controls, kept out of component
+ * files so React Fast Refresh only sees component exports. */
+
+export function boolBtn(disabled: boolean): React.CSSProperties {
+  return {
+    padding: '0.35rem 0.85rem', fontSize: '0.78rem', fontWeight: 600,
+    background: 'var(--bg-tag)', color: 'var(--text-main)',
+    border: '1px solid var(--border-color)', borderRadius: '6px',
+    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
+  };
+}
+
+export function primaryBtn(disabled: boolean): React.CSSProperties {
+  return {
+    display: 'flex', alignItems: 'center', gap: '0.35rem',
+    padding: '0.35rem 0.8rem', fontSize: '0.78rem', fontWeight: 600,
+    background: 'var(--accent-primary)', color: 'white',
+    border: 'none', borderRadius: '6px',
+    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
+  };
+}
+
+export function secondaryBtn(disabled: boolean): React.CSSProperties {
+  return {
+    display: 'flex', alignItems: 'center', gap: '0.35rem',
+    padding: '0.35rem 0.8rem', fontSize: '0.78rem', fontWeight: 600,
+    background: 'transparent', color: 'var(--accent-primary)',
+    border: '1px solid var(--accent-primary)', borderRadius: '6px',
+    cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
+  };
+}


### PR DESCRIPTION
The **Last Seen Values** panel rendered a single free-text value field for every DPT. For DPT 1 GAs (e.g. `16/0/1`, DPT 1.011) entering a value like `21` produced `ConversionError: Value not supported for State in DPTState (1.011)`, while the **Send to bus** panel for the same GA correctly offers On/Off buttons.

This extracts the send bar's DPT-aware controls into a shared `WriteControls` component (On/Off buttons for DPT 1, value field + Write button otherwise) and uses it in both the send bar and the Last Seen Values write row, so any GA renders the same write UI everywhere. Button style helpers move to `utils/buttonStyles.ts` (keeps React Fast Refresh happy).

Reported by TabSel in [forum post #131/#132](https://knx-user-forum.de/forum/%C3%B6ffentlicher-bereich/knx-eib-forum/2088940-showcase-spectrumknx-%E2%80%93-neues-tool-f%C3%BCr-langzeit-analyse-telegramm-deep-dive/page9); see the screenshot in the issue.

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)