### PR TITLE
fix: legend toggle lag and visibility reset on target reselect

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -75,10 +75,14 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
       cursor: { sync: { key: syncCursor.key } },
       hooks: {
         // Record legend show/hide toggles so they survive chart recreation (#192).
-        setSeries: [(u, idx, opts) => {
+        // Use the requested value from `opts.show` rather than reading it back
+        // off `u.series[idx].show`, which uPlot only commits after this hook —
+        // reading the stale value lagged the store by one click and made the
+        // legend appear to need a second click to stick (#205).
+        setSeries: [(_u, idx, opts) => {
           if (idx == null || idx === 0 || !('show' in opts)) return;
           const addr = series[idx - 1]?.address;
-          if (addr) setSeriesHidden(addr, !u.series[idx].show);
+          if (addr) setSeriesHidden(addr, !opts.show);
         }]
       },
       scales: {

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -6,6 +6,7 @@ import { MixedChart } from './MixedChart';
 import { TimelineChart } from './TimelineChart';
 import { Download, Link2, Check } from 'lucide-react';
 import { getCookie, setCookie } from '../utils/cookies';
+import { clearSeriesHidden } from '../utils/legendVisibility';
 
 interface VisualizerProps {
   telegrams: Telegram[];
@@ -26,6 +27,14 @@ export const Visualizer: React.FC<VisualizerProps> = ({
   const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets);
   const [stepped, setStepped] = useState(() => getCookie('chartStepped') !== 'false');
   const [linkCopied, setLinkCopied] = useState(false);
+
+  // Deselecting a target clears any legend-hide on it, so reselecting the same
+  // target shows its series again instead of staying invisible (#205).
+  const handleTargetsChange = (next: string[]) => {
+    const removed = selectedTargets.filter(a => !next.includes(a));
+    if (removed.length > 0) clearSeriesHidden(removed);
+    onTargetsChange(next);
+  };
 
   const toggleStepped = () => {
     setStepped(s => {
@@ -90,7 +99,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
         <VisualizerSidebar
           telegrams={telegrams}
           selectedTargets={selectedTargets}
-          onTargetsChange={onTargetsChange}
+          onTargetsChange={handleTargetsChange}
           onClose={onClose}
         />
 

--- a/frontend/src/utils/legendVisibility.test.ts
+++ b/frontend/src/utils/legendVisibility.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, expect, test } from 'vitest';
+import {
+  isSeriesHidden,
+  setSeriesHidden,
+  clearSeriesHidden,
+} from './legendVisibility';
+
+afterEach(() => {
+  // The store is module-level session state; reset between tests.
+  clearSeriesHidden(['1/1/1', '2/2/2', '3/3/3']);
+});
+
+test('set and read a hidden series', () => {
+  expect(isSeriesHidden('1/1/1')).toBe(false);
+  setSeriesHidden('1/1/1', true);
+  expect(isSeriesHidden('1/1/1')).toBe(true);
+  setSeriesHidden('1/1/1', false);
+  expect(isSeriesHidden('1/1/1')).toBe(false);
+});
+
+test('clearSeriesHidden resets visibility so a reselected target shows again (#205)', () => {
+  setSeriesHidden('1/1/1', true);
+  setSeriesHidden('2/2/2', true);
+
+  // Deselecting 1/1/1 clears only its flag.
+  clearSeriesHidden(['1/1/1']);
+
+  expect(isSeriesHidden('1/1/1')).toBe(false);
+  expect(isSeriesHidden('2/2/2')).toBe(true);
+});

--- a/frontend/src/utils/legendVisibility.ts
+++ b/frontend/src/utils/legendVisibility.ts
@@ -12,3 +12,9 @@ export function setSeriesHidden(address: string, value: boolean): void {
   if (value) hidden.add(address);
   else hidden.delete(address);
 }
+
+/** Clear the hidden flag for the given addresses. Called when a target is
+ * deselected so that reselecting it shows the series again (#205). */
+export function clearSeriesHidden(addresses: Iterable<string>): void {
+  for (const a of addresses) hidden.delete(a);
+}


### PR DESCRIPTION
Fixes two visualization-legend problems reported by TabSel in [issue #205](https://github.com/martinhoefling/SpectrumKNX/issues/205):

**1. Legend click sometimes needed a second click.**
The uPlot `setSeries` hook recorded a series' hidden state by reading back `u.series[idx].show`, but uPlot commits that value *after* the hook runs. The store therefore lagged one click behind, and the next chart rebuild (resize, theme change, new telegram changing the series set) restored the stale value — making the toggle look like it needed clicking twice. We now record the click's authoritative `opts.show`.

**2. A legend-hidden series stayed hidden after deselect + reselect.**
Legend visibility is kept in a session-level store keyed by GA (so toggles survive the chart teardown/rebuild from #192). Deselecting a target left its hidden flag set, so reselecting it produced an invisible series even though telegrams were arriving. Deselecting a target now clears its legend-hide via `clearSeriesHidden`, so a reselected target starts visible.

Unit tests cover the visibility-store reset; the `opts.show` change is in the uPlot hook.

Fixes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)