### PR TITLE
feat: style DPT-1 On/Off send buttons as accent action buttons

### DIFF
--- a/frontend/src/components/WriteControls.test.tsx
+++ b/frontend/src/components/WriteControls.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { WriteControls } from './WriteControls';
+
+test('DPT 1 renders On/Off as accent action buttons that write booleans (#218)', () => {
+  const onWrite = vi.fn();
+  render(<WriteControls dptMain={1} value="" onValueChange={() => {}} onWrite={onWrite} />);
+
+  const on = screen.getByRole('button', { name: /On/ });
+  const off = screen.getByRole('button', { name: /Off/ });
+
+  // Styled as filled accent action buttons (like Write), not passive tag chips.
+  expect(on.style.background).toBe('var(--accent-primary)');
+  expect(on.style.color).toBe('white');
+
+  fireEvent.click(on);
+  fireEvent.click(off);
+  expect(onWrite).toHaveBeenNthCalledWith(1, true);
+  expect(onWrite).toHaveBeenNthCalledWith(2, false);
+});
+
+test('non-DPT-1 renders a value field and a Write button', () => {
+  const onWrite = vi.fn();
+  render(<WriteControls dptMain={5} value="50" onValueChange={() => {}} onWrite={onWrite} />);
+
+  expect(screen.getByPlaceholderText(/Value/)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: /Write/ }));
+  expect(onWrite).toHaveBeenCalledWith(50);
+  expect(screen.queryByRole('button', { name: /^On$/ })).not.toBeInTheDocument();
+});
+
+test('Write is disabled while the value is empty', () => {
+  render(<WriteControls dptMain={5} value="   " onValueChange={() => {}} onWrite={() => {}} />);
+  expect(screen.getByRole('button', { name: /Write/ })).toBeDisabled();
+});

--- a/frontend/src/components/WriteControls.tsx
+++ b/frontend/src/components/WriteControls.tsx
@@ -24,8 +24,12 @@ export function WriteControls({ dptMain, value, onValueChange, onWrite, disabled
   if (dptMain === 1) {
     return (
       <div style={{ display: 'flex', gap: '0.3rem' }}>
-        <button disabled={disabled} onClick={() => onWrite(true)} style={boolBtn(disabled)}>On</button>
-        <button disabled={disabled} onClick={() => onWrite(false)} style={boolBtn(disabled)}>Off</button>
+        <button disabled={disabled} onClick={() => onWrite(true)} style={boolBtn(disabled)} title="Write ON (1) to the bus">
+          <Send size={13} /> On
+        </button>
+        <button disabled={disabled} onClick={() => onWrite(false)} style={boolBtn(disabled)} title="Write OFF (0) to the bus">
+          <Send size={13} /> Off
+        </button>
       </div>
     );
   }

--- a/frontend/src/utils/buttonStyles.ts
+++ b/frontend/src/utils/buttonStyles.ts
@@ -1,11 +1,14 @@
 /** Shared button styles for the bus-write controls, kept out of component
  * files so React Fast Refresh only sees component exports. */
 
+/** DPT-1 On/Off send buttons. Styled as accent action buttons (like Write)
+ * rather than passive toggles, so it is obvious they trigger a bus write (#218). */
 export function boolBtn(disabled: boolean): React.CSSProperties {
   return {
-    padding: '0.35rem 0.85rem', fontSize: '0.78rem', fontWeight: 600,
-    background: 'var(--bg-tag)', color: 'var(--text-main)',
-    border: '1px solid var(--border-color)', borderRadius: '6px',
+    display: 'flex', alignItems: 'center', gap: '0.3rem',
+    padding: '0.35rem 0.7rem', fontSize: '0.78rem', fontWeight: 600,
+    background: 'var(--accent-primary)', color: 'white',
+    border: 'none', borderRadius: '6px',
     cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
   };
 }


### PR DESCRIPTION
For DPT-1 group addresses the shared `WriteControls` renders **On/Off** buttons instead of a value field + **Write** button. They were styled as passive tag chips (grey `--bg-tag`), so — as mumpf reported in [forum post #127](https://knx-user-forum.de/forum/%C3%B6ffentlicher-bereich/knx-eib-forum/2088940-showcase-spectrumknx-%E2%80%93-neues-tool-f%C3%BCr-langzeit-analyse-telegramm-deep-dive/page9) — after using the value+Write variant it looked like nothing was actionable.

On/Off now get the same filled-accent styling as the Write button, with a send icon, so they clearly read as bus-write actions. Because the controls are shared (#213), this applies in both the send bar and the Last Seen Values panel.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)