### PR TITLE
feat: quick send-to-GA popover on group-address references

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -147,7 +147,6 @@ function App() {
   const [latestTelegram, setLatestTelegram] = useState<Telegram | null>(null);
   const [isDatabaseOpen, setIsDatabaseOpen] = useState(false);
   const [isSendOpen, setIsSendOpen] = useState(false);
-  const [sendPrefill, setSendPrefill] = useState<{ address: string; nonce: number } | null>(null);
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
   const [projectStatus, setProjectStatus] = useState<{
     upload_feature_active: boolean;
@@ -412,11 +411,6 @@ function App() {
       };
     });
     setIsFilterOpen(true);
-  };
-
-  const handleQuickSend = (targetAddress: string) => {
-    setSendPrefill({ address: targetAddress, nonce: Date.now() });
-    setIsSendOpen(true);
   };
 
   const handleQuickVisualize = (targetAddress: string) => {
@@ -924,9 +918,7 @@ function App() {
               <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
                 {isSendOpen && serverConfig?.status?.write_enabled && (
                   <SendTelegramBar
-                    key={sendPrefill?.nonce ?? 'send-bar'}
                     targets={filterOptions.targets}
-                    initialAddress={sendPrefill?.address}
                     onClose={() => setIsSendOpen(false)}
                   />
                 )}
@@ -976,7 +968,7 @@ function App() {
                     onQuickFilter={handleQuickFilter}
                     onQuickVisualize={handleQuickVisualize}
                     onQuickLastSeen={handleQuickLastSeen}
-                    onQuickSend={serverConfig?.status?.write_enabled ? handleQuickSend : undefined}
+                    canSend={serverConfig?.status?.write_enabled}
                   />
                 )}
               </div>

--- a/frontend/src/components/LastSeenOverlay.tsx
+++ b/frontend/src/components/LastSeenOverlay.tsx
@@ -6,6 +6,7 @@ import type { FilterOptions } from '../types/filters';
 import { apiUrl } from '../utils/basePath';
 import { formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
 import { WriteControls } from './WriteControls';
+import { SendToGaPopover } from './SendToGaPopover';
 
 const LIMITS = [10, 20, 50, 100] as const;
 
@@ -219,12 +220,11 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
           ) : filteredAddresses.map(addr => {
             const isSelected = selectedAddresses.includes(addr.address ?? '');
             return (
-              <button
+              <div
                 key={addr.address}
-                onClick={() => setSelectedAddresses([addr.address ?? ''])}
+                className="last-seen-addr-row"
                 style={{
-                  width: '100%', textAlign: 'left', padding: '0.45rem 0.75rem',
-                  border: 'none', cursor: 'pointer',
+                  display: 'flex', alignItems: 'center', gap: '0.35rem',
                   background: isSelected ? 'rgba(99,102,241,0.15)' : 'transparent',
                   borderLeft: `2px solid ${isSelected ? 'var(--accent-primary)' : 'transparent'}`,
                   transition: 'background 0.1s',
@@ -232,21 +232,40 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
                 onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'var(--bg-hover)'; }}
                 onMouseLeave={e => { if (!isSelected) (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
               >
-                <div style={{
-                  fontFamily: "'JetBrains Mono', monospace", fontSize: '0.75rem',
-                  color: isSelected ? 'var(--accent-primary)' : 'var(--text-main)',
-                }}>
-                  {addr.address}
-                </div>
-                {addr.name && (
+                <button
+                  onClick={() => setSelectedAddresses([addr.address ?? ''])}
+                  style={{
+                    flex: 1, minWidth: 0, textAlign: 'left', padding: '0.45rem 0.75rem',
+                    border: 'none', background: 'transparent', cursor: 'pointer',
+                  }}
+                >
                   <div style={{
-                    fontSize: '0.65rem', color: 'var(--text-dim)', marginTop: '0.1rem',
-                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    fontFamily: "'JetBrains Mono', monospace", fontSize: '0.75rem',
+                    color: isSelected ? 'var(--accent-primary)' : 'var(--text-main)',
                   }}>
-                    {addr.name}
+                    {addr.address}
+                  </div>
+                  {addr.name && (
+                    <div style={{
+                      fontSize: '0.65rem', color: 'var(--text-dim)', marginTop: '0.1rem',
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>
+                      {addr.name}
+                    </div>
+                  )}
+                </button>
+                {writeEnabled && mode === 'ga' && addr.address && (
+                  <div style={{ paddingRight: '0.5rem', flexShrink: 0 }}>
+                    <SendToGaPopover
+                      address={addr.address}
+                      name={addr.name}
+                      dptMain={addr.main}
+                      dptSub={addr.sub}
+                      buttonClassName="quick-send-btn"
+                    />
                   </div>
                 )}
-              </button>
+              </div>
             );
           })}
         </div>

--- a/frontend/src/components/SendToGaPopover.test.tsx
+++ b/frontend/src/components/SendToGaPopover.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { SendToGaPopover } from './SendToGaPopover';
+
+function mockFetch(routes: Record<string, unknown>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    for (const [path, body] of Object.entries(routes)) {
+      if (url.includes(path)) return { ok: true, json: async () => body } as Response;
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/telegrams': { telegrams: [] } }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test('opens on click, shows the last value and sends a DPT-1 boolean', async () => {
+  const fetchMock = mockFetch({
+    '/api/telegrams': { telegrams: [{ value_formatted: 'Off', unit: null, timestamp: '2026-07-17T09:00:00Z' }] },
+    '/api/knx/send': { status: 'sent' },
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  render(<SendToGaPopover address="16/0/1" name="SRV_Alive" dptMain={1} dptSub={11} />);
+
+  // Popover is closed initially.
+  expect(screen.queryByText(/Last value/)).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /Send to this GA/ }));
+
+  // Last value loads and DPT-1 renders On/Off (no free-text field).
+  await waitFor(() => expect(screen.getByText('Off')).toBeInTheDocument());
+  expect(screen.queryByPlaceholderText(/Value/)).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: /^On$/ }));
+
+  await waitFor(() => {
+    const call = fetchMock.mock.calls.find(([u]) => String(u).includes('/api/knx/send'));
+    expect(call).toBeTruthy();
+    const body = JSON.parse((call![1] as RequestInit).body as string);
+    expect(body).toMatchObject({ address: '16/0/1', payload: true, dpt: '1.011' });
+  });
+});
+
+test('triggers a GroupValueRead from the Read button', async () => {
+  const fetchMock = mockFetch({
+    '/api/telegrams': { telegrams: [] },
+    '/api/knx/read': { status: 'ok' },
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  render(<SendToGaPopover address="1/1/97" name="Helligkeit" dptMain={9} dptSub={4} />);
+  fireEvent.click(screen.getByRole('button', { name: /Send to this GA/ }));
+
+  // Non-DPT-1 shows the free value field.
+  await waitFor(() => expect(screen.getByPlaceholderText(/Value/)).toBeInTheDocument());
+  fireEvent.click(screen.getByRole('button', { name: /Read/ }));
+
+  await waitFor(() => {
+    const call = fetchMock.mock.calls.find(([u]) => String(u).includes('/api/knx/read'));
+    expect(call).toBeTruthy();
+    expect(JSON.parse((call![1] as RequestInit).body as string)).toMatchObject({ address: '1/1/97' });
+  });
+});

--- a/frontend/src/components/SendToGaPopover.tsx
+++ b/frontend/src/components/SendToGaPopover.tsx
@@ -1,0 +1,183 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Send, Radio, AlertTriangle, CheckCircle2 } from 'lucide-react';
+
+import { apiUrl } from '../utils/basePath';
+import { formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
+import { WriteControls } from './WriteControls';
+import { secondaryBtn } from '../utils/buttonStyles';
+
+interface Props {
+  address: string;
+  name?: string | null;
+  dptMain?: number | null;
+  dptSub?: number | null;
+  /** Small icon-button label; defaults to the paper-plane send icon. */
+  title?: string;
+  /** Extra className for the trigger button (to match host styling). */
+  buttonClassName?: string;
+}
+
+/**
+ * A "Send to this GA" affordance: a small trigger button that opens a compact
+ * popover for a quick GroupValueWrite/Read on one group address, showing its
+ * last seen value (#214). Deliberately *quick* — no delayed/cyclic scheduling,
+ * which lives in the multi-GA "write to bus" panel (#215). The popover is
+ * portalled to <body> and fixed-positioned so it is never clipped by scroll
+ * containers (e.g. the virtualized telegram table).
+ */
+export function SendToGaPopover({ address, name, dptMain, dptSub, title = 'Send to this GA', buttonClassName }: Props) {
+  const [open, setOpen] = useState(false);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [last, setLast] = useState<{ value: string; at: string } | null>(null);
+
+  const dpt = formatDpt(dptMain ?? undefined, dptSub ?? undefined);
+
+  const place = () => {
+    const b = btnRef.current?.getBoundingClientRect();
+    if (!b) return;
+    // Prefer below-right of the button; clamp into the viewport.
+    const width = 320;
+    const left = Math.min(Math.max(8, b.left), window.innerWidth - width - 8);
+    setPos({ top: b.bottom + 6, left });
+  };
+
+  const toggle = () => {
+    if (open) { setOpen(false); return; }
+    place();
+    setOpen(true);
+    setFeedback(null);
+    void loadLast();
+  };
+
+  const loadLast = async () => {
+    try {
+      const res = await fetch(apiUrl(`/api/telegrams?target_address=${encodeURIComponent(address)}&limit=1`));
+      const json = await res.json();
+      const t = json.telegrams?.[0];
+      if (t) {
+        const shown = t.value_formatted ?? (t.value_numeric != null ? String(t.value_numeric) : '—');
+        setLast({ value: `${shown}${t.unit ? ' ' + t.unit : ''}`, at: t.timestamp });
+      } else {
+        setLast(null);
+      }
+    } catch {
+      setLast(null);
+    }
+  };
+
+  // Reposition on scroll/resize and close on outside interaction / Escape.
+  useLayoutEffect(() => {
+    if (!open) return;
+    place();
+    const onScroll = () => place();
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    const onDown = (e: MouseEvent) => {
+      const n = e.target as Node;
+      if (!cardRef.current?.contains(n) && !btnRef.current?.contains(n)) setOpen(false);
+    };
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('resize', onScroll);
+    window.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onDown);
+    return () => {
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('resize', onScroll);
+      window.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onDown);
+    };
+  }, [open]);
+
+  const write = async (payload: boolean | number | string) => {
+    setBusy(true);
+    setFeedback(null);
+    try {
+      await sendTelegram(address, payload, dpt || undefined);
+      const shown = typeof payload === 'boolean' ? (payload ? 'on' : 'off') : String(payload);
+      setFeedback({ ok: true, msg: `Sent ${shown}` });
+      setTimeout(() => void loadLast(), 700);
+    } catch (err) {
+      setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Send failed' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const read = async () => {
+    setBusy(true);
+    setFeedback(null);
+    try {
+      await readTelegram(address);
+      setFeedback({ ok: true, msg: 'Read request sent' });
+      setTimeout(() => void loadLast(), 700);
+    } catch (err) {
+      setFeedback({ ok: false, msg: err instanceof Error ? err.message : 'Read failed' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        className={buttonClassName}
+        onClick={e => { e.stopPropagation(); toggle(); }}
+        title={title}
+      >
+        <Send size={12} />
+      </button>
+
+      {open && pos && createPortal(
+        <div
+          ref={cardRef}
+          onMouseDown={e => e.stopPropagation()}
+          onClick={e => e.stopPropagation()}
+          style={{
+            position: 'fixed', top: pos.top, left: pos.left, zIndex: 1000, width: 320,
+            background: 'var(--bg-panel)', backdropFilter: 'var(--glass-blur)',
+            border: '1px solid var(--border-color)', borderRadius: 10, boxShadow: 'var(--shadow-lg)',
+            padding: '0.7rem 0.8rem', display: 'flex', flexDirection: 'column', gap: '0.55rem',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.4rem', flexWrap: 'wrap' }}>
+            <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.82rem', fontWeight: 600, color: 'var(--accent-primary)' }}>{address}</span>
+            {name && <span style={{ fontSize: '0.72rem', color: 'var(--text-dim)' }}>{name}</span>}
+            {dpt && <span style={{ marginLeft: 'auto', fontFamily: "'JetBrains Mono', monospace", fontSize: '0.68rem', color: 'var(--text-dim)' }}>DPT {dpt}</span>}
+          </div>
+
+          <div style={{ fontSize: '0.72rem', color: 'var(--text-dim)' }}>
+            Last value:{' '}
+            <span style={{ color: 'var(--text-main)', fontWeight: 600 }}>{last ? last.value : '—'}</span>
+          </div>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', flexWrap: 'wrap' }}>
+            <WriteControls
+              dptMain={dptMain}
+              value={value}
+              onValueChange={v => { setValue(v); setFeedback(null); }}
+              onWrite={payload => void write(payload)}
+              disabled={busy}
+            />
+            <button onClick={() => void read()} disabled={busy} style={secondaryBtn(busy)} title="Send a GroupValueRead">
+              <Radio size={13} /> Read
+            </button>
+          </div>
+
+          {feedback && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.3rem', fontSize: '0.72rem', color: feedback.ok ? 'var(--success)' : 'var(--error)' }}>
+              {feedback.ok ? <CheckCircle2 size={13} /> : <AlertTriangle size={13} />} {feedback.msg}
+            </div>
+          )}
+        </div>,
+        document.body
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -2,8 +2,9 @@ import React, { useMemo, useRef, useEffect, useLayoutEffect, useState, useCallba
 import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
-import { ChevronUp, ChevronDown, Filter, LineChart, X, Clock, Send } from 'lucide-react';
+import { ChevronUp, ChevronDown, Filter, LineChart, X, Clock } from 'lucide-react';
 import { dptKey, type ActiveFilters } from '../types/filters';
+import { SendToGaPopover } from './SendToGaPopover';
 import { getCookie, setCookie } from '../utils/cookies';
 
 export type SortKey = 'timestamp' | 'source_address' | 'target_address' | 'simplified_type' | 'dpt_name' | 'value_numeric';
@@ -22,8 +23,8 @@ interface TelegramTableProps {
   onQuickFilter: (key: 'sources' | 'targets' | 'types' | 'dpts', value: string | number) => void;
   onQuickVisualize: (targetAddress: string) => void;
   onQuickLastSeen?: (address: string, mode: 'ga' | 'pa') => void;
-  /** Copies the row's GA into the send bar; only passed when the bus is writable (#187). */
-  onQuickSend?: (targetAddress: string) => void;
+  /** Enables the per-row "Send to this GA" quick popover; true only when the bus is writable (#214). */
+  canSend?: boolean;
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
@@ -88,7 +89,7 @@ const anchorKey = (t: Telegram) =>
   `${t.timestamp}-${t.source_address}-${t.target_address}-${t.raw_hex ?? ''}`;
 
 export const TelegramTable: React.FC<TelegramTableProps> = ({
-  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, onQuickSend
+  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -442,14 +443,14 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                   <Clock size={12} />
                 </button>
               )}
-              {onQuickSend && (
-                <button
-                  className="quick-send-btn"
-                  onClick={(e) => { e.stopPropagation(); onQuickSend(t.target_address); }}
-                  title="Send to this GA"
-                >
-                  <Send size={12} />
-                </button>
+              {canSend && (
+                <SendToGaPopover
+                  address={t.target_address}
+                  name={t.target_name}
+                  dptMain={t.dpt_main}
+                  dptSub={t.dpt_sub}
+                  buttonClassName="quick-send-btn"
+                />
               )}
             </div>
             {visibleColumns.targetName && (


### PR DESCRIPTION
Implements the quick "send to this GA" popover from [issue #214](https://github.com/martinhoefling/SpectrumKNX/issues/214), following the design agreed in the issue comments (a lightweight hovercard showing the last value with quick send/read; **no** delay/cyclic scheduling — that stays with the full send bar and the upcoming multi-GA panel #215).

**What changed**
- New reusable **`SendToGaPopover`**: a small "Send to this GA" icon-button that opens a compact popover with the GA's **last seen value**, the shared DPT-aware **`WriteControls`** (On/Off for DPT-1, value+Write otherwise) and a **Read** button.
- The popover is **portalled to `<body>` with fixed positioning**, so it is never clipped by scroll containers — notably the virtualized telegram table. It repositions on scroll/resize and closes on outside-click / Escape.
- Group-monitor rows now open this popover instead of prefilling the full send bar. The full **Send to bus** bar (with delay/cyclic) remains available from the toolbar.
- Also wired into the **Last Seen Values** sidebar rows, so it works outside the group monitor.

**Deliberately deferred**
- "Send/Read shortcuts in the filter panel & GA tree" → #191 (same component, more mount points).
- "Add to write-to-bus panel" button → #215 (once that panel exists).

Reported by TabSel in [forum post #131](https://knx-user-forum.de/forum/%C3%B6ffentlicher-bereich/knx-eib-forum/2088940-showcase-spectrumknx-%E2%80%93-neues-tool-f%C3%BCr-langzeit-analyse-telegramm-deep-dive/page9); design refined with him in the issue thread.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)