### PR TITLE
feat: extend graphs' last segment to the newest telegram

### DIFF
--- a/frontend/src/hooks/useChartData.test.ts
+++ b/frontend/src/hooks/useChartData.test.ts
@@ -42,3 +42,34 @@ describe('useChartData — DPT backfill / duplicate graphs (#206)', () => {
     expect(result.current.buckets[0].unit).toBe('unknown');
   });
 });
+
+describe('useChartData — extend last segment to newest telegram (#208)', () => {
+  test("a binary series' held state extends to the newest telegram of another GA", () => {
+    const telegrams = [
+      // Binary GA: switched ON at t=1, then no further telegrams.
+      at(1, { target_address: '1/1/1', dpt_main: 1, value_numeric: 1 }),
+      // A different numeric GA keeps reporting until t=5 (the newest telegram).
+      at(3, { target_address: '2/2/2', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 20 }),
+      at(5, { target_address: '2/2/2', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 21 }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1', '2/2/2']));
+    const maxTime = result.current.maxTime!;
+
+    const binary = result.current.buckets.find(b => b.isBinary)!;
+    // The binary bucket's timeline now reaches the newest telegram (t=5)...
+    expect(binary.timestamps[binary.timestamps.length - 1]).toBe(maxTime);
+    // ...and the ON state (1) is carried all the way to that right edge.
+    const series = binary.series.find(s => s.address === '1/1/1')!;
+    expect(series.data[series.data.length - 1]).toBe(1);
+  });
+
+  test('does not add spurious columns when a bucket already ends at the newest telegram', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 20 }),
+      at(2, { target_address: '1/1/1', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 21 }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1']));
+    // Two telegrams → two timestamp columns; maxTime already present, no extra.
+    expect(result.current.buckets[0].timestamps).toHaveLength(2);
+  });
+});

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -83,6 +83,15 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
       // Get all unique timestamps for this bucket
       const tsSet = new Set<number>();
       rows.forEach(r => tsSet.add(r.ts));
+      // Extend every series' last segment to the newest telegram across all
+      // plotted GAs, so a state still held after its last telegram is drawn as
+      // a visible segment out to the right edge instead of a zero-width sliver
+      // (#208): the per-series forward-fill below carries the last value into
+      // this appended column. Anchoring on the newest telegram rather than
+      // wall-clock "now" keeps it correct for loaded history and needs no
+      // ticking redraw. (The single newest series still ends at its own
+      // telegram — advancing past it is left to the time-axis brush, #193.)
+      tsSet.add(maxTime);
       const timestamps = Array.from(tsSet).sort((a, b) => a - b);
 
       // Find all unique targets within this bucket


### PR DESCRIPTION
Implements [issue #208](https://github.com/martinhoefling/SpectrumKNX/issues/208).

**Problem:** each series stopped drawing at *its own* last telegram. A state still held afterwards — e.g. a presence sensor left `on` — was rendered as a barely-visible sliver at the right edge instead of a bar whose length reflects how long the state has actually held. As TabSel put it: *"der Balken stellt also rechts nicht den aktuellen Zustand dar, sondern den Zustand vor dem letzten Telegramm."*

**Fix:** align every metric bucket's right edge to the **newest telegram across all plotted GAs**; the existing per-series forward-fill then carries each series' last value out to that edge. One line in `useChartData` (`tsSet.add(maxTime)`), plus a comment.

Per martinhoefling's note in the thread, this anchors on the **newest telegram, not wall-clock `now`**, so it also works for loaded history in the History tab and needs no ticking redraw. (The single newest series still ends at its own telegram — advancing the visible window past it is left to the time-axis brush, #193.)

**Verified in a browser:** a Presence GA with one early `On` telegram now draws a full-width green "On" bar out to the newest (Temperature) telegram, instead of a left-edge sliver — screenshot behavior confirmed. Unit tests cover the extension and the no-op case where a bucket already ends at the newest telegram.

Reported by TabSel in [forum post #110](https://knx-user-forum.de/forum/%C3%B6ffentlicher-bereich/knx-eib-forum/2088940-showcase-spectrumknx-%E2%80%93-neues-tool-f%C3%BCr-langzeit-analyse-telegramm-deep-dive/page8).

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)