### PR TITLE
feat: dots at telegram timestamps on graphs

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -12,12 +12,14 @@ interface MixedChartProps {
   minTime: number | null;
   maxTime: number | null;
   stepped: boolean;
+  /** Draw a dot at each telegram timestamp so cyclic repeats are visible (#195). */
+  showDots: boolean;
 }
 
 // Ensure we have a shared sync cursor across all charts
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
+export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped, showDots }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const themeTick = useThemeTick();
@@ -46,9 +48,20 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
   // uplot-react updates via setData instead of destroying and recreating the
   // chart — which would drop the cursor/hover on every telegram (#207).
   const structureKey = [
-    width, isBinary, unit, stepped, themeTick,
+    width, isBinary, unit, stepped, showDots, themeTick,
     series.map(s => `${s.address}~${s.name}`).join('|'),
   ].join('§');
+
+  // Indices (per series) where an actual telegram was received, so dots mark
+  // real receipts rather than every forward-filled column (#195). Held in a ref
+  // that is refreshed every render, so the points.filter (kept in the stable
+  // memoized options for #207) reads live data instead of a stale snapshot.
+  const realIndicesRef = useRef<number[][]>([]);
+  // Written in render (not an effect) so it is fresh before uPlot's child draw
+  // effect runs on this commit; only ever read inside the imperative points
+  // filter, never during React render.
+  // eslint-disable-next-line react-hooks/refs
+  realIndicesRef.current = series.map(s => s.real.flatMap((r, i) => (r ? [i] : [])));
 
   const options: uPlot.Options = useMemo(() => {
     const style = getComputedStyle(document.documentElement);
@@ -111,7 +124,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
         {
           value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
         },
-        ...series.map((s) => ({
+        ...series.map((s, sIdx) => ({
           label: s.name,
           show: !isSeriesHidden(s.address),
           stroke: seriesColor(s.address),
@@ -119,7 +132,9 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, stepped }) => {
           spanGaps: true,
           paths: (isBinary || stepped) ? uPlot.paths.stepped?.({ align: 1 }) : undefined,
           fill: isBinary ? seriesColor(s.address) + '33' : undefined,
-          points: { show: false },
+          points: showDots
+            ? { show: true, size: 5, space: 0, filter: () => realIndicesRef.current[sIdx] ?? null }
+            : { show: false },
           value: (_u: uPlot, v: number | null) => {
             if (v === null) return '-';
             if (isBinary) return v === 1 ? 'On' : 'Off';

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -9,14 +9,24 @@ interface TimelineChartProps {
   bucket: ChartBucket;
   minTime: number | null;
   maxTime: number | null;
+  /** Draw a tick at each telegram timestamp so cyclic repeats are visible (#195). */
+  showDots: boolean;
 }
 
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
+export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, showDots }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const themeTick = useThemeTick();
+
+  // Per-series real-telegram flags, refreshed every render and read from the
+  // (stable, memoized) draw plugin so dots stay correct on live updates (#195/#207).
+  // Written in render so it is fresh before uPlot's child draw effect on this
+  // commit; only ever read inside the imperative draw plugin, never in render.
+  const realRef = useRef<boolean[][]>([]);
+  // eslint-disable-next-line react-hooks/refs
+  realRef.current = bucket.series.map(s => s.real);
 
   useLayoutEffect(() => {
     if (!containerRef.current) return;
@@ -42,7 +52,7 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
   // recreating it, keeping the cursor/hover alive (#207). The draw plugin below
   // therefore reads timestamps/values from `u.data`, not from this closure.
   const structureKey = [
-    width, themeTick, series.map(s => s.name).join('|'),
+    width, themeTick, showDots, series.map(s => s.name).join('|'),
   ].join('§');
 
   const options: uPlot.Options = useMemo(() => {
@@ -95,6 +105,26 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket }) => {
                 ctx.textAlign = 'center';
                 ctx.textBaseline = 'middle';
                 ctx.fillText(isOn ? 'On' : 'Off', xStart + (xEnd - xStart) / 2, yTop + rowHeight / 2);
+              }
+            }
+
+            // Telegram dots: mark each actual receipt (not forward-filled holds),
+            // so cyclic same-value repeats — e.g. a 90 s "server alive" — are
+            // visible as ticks along the bar (#195). `real` is read from the ref
+            // so it tracks live data while `options` stay stable (#207).
+            if (showDots) {
+              const real = realRef.current[sIdx];
+              const yMid = yTop + rowHeight / 2;
+              for (let i = 0; i < xs.length; i++) {
+                if (!real?.[i] || yData[i] === null) continue;
+                const x = u.valToPos(xs[i], 'x', true);
+                ctx.beginPath();
+                ctx.arc(x, yMid, 2.5, 0, Math.PI * 2);
+                ctx.fillStyle = 'rgba(255,255,255,0.9)';
+                ctx.fill();
+                ctx.lineWidth = 1;
+                ctx.strokeStyle = 'rgba(0,0,0,0.55)';
+                ctx.stroke();
               }
             }
           }

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -26,6 +26,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
   const chartWrapperRef = useRef<HTMLDivElement>(null);
   const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets);
   const [stepped, setStepped] = useState(() => getCookie('chartStepped') !== 'false');
+  const [showDots, setShowDots] = useState(() => getCookie('chartDots') !== 'false');
   const [linkCopied, setLinkCopied] = useState(false);
 
   // Deselecting a target clears any legend-hide on it, so reselecting the same
@@ -40,6 +41,14 @@ export const Visualizer: React.FC<VisualizerProps> = ({
     setStepped(s => {
       const next = !s;
       setCookie('chartStepped', String(next));
+      return next;
+    });
+  };
+
+  const toggleDots = () => {
+    setShowDots(d => {
+      const next = !d;
+      setCookie('chartDots', String(next));
       return next;
     });
   };
@@ -70,9 +79,9 @@ export const Visualizer: React.FC<VisualizerProps> = ({
     <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: embed ? '0.75rem' : '1.5rem' }}>
       {buckets.map(b => (
         b.isBinary ? (
-          <TimelineChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} />
+          <TimelineChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} showDots={showDots} />
         ) : (
-          <MixedChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} stepped={stepped} />
+          <MixedChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} stepped={stepped} showDots={showDots} />
         )
       ))}
 
@@ -129,6 +138,19 @@ export const Visualizer: React.FC<VisualizerProps> = ({
                   }}
                 >
                   {stepped ? 'Stepped' : 'Linear'}
+                </button>
+                <button
+                  onClick={toggleDots}
+                  title={showDots ? 'Hide telegram dots' : 'Show a dot at each telegram (makes cyclic repeats visible)'}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '0.5rem',
+                    padding: '0.4rem 0.85rem', border: '1px solid var(--border-color)',
+                    borderRadius: '7px', fontSize: '0.8125rem', cursor: 'pointer',
+                    background: showDots ? 'rgba(99,102,241,0.15)' : 'transparent',
+                    color: showDots ? 'var(--accent-primary)' : 'var(--text-dim)',
+                  }}
+                >
+                  Dots
                 </button>
                 {getShareLink && (
                   <button

--- a/frontend/src/hooks/useChartData.test.ts
+++ b/frontend/src/hooks/useChartData.test.ts
@@ -63,6 +63,34 @@ describe('useChartData — extend last segment to newest telegram (#208)', () =>
     expect(series.data[series.data.length - 1]).toBe(1);
   });
 
+  test('marks each real telegram column so cyclic same-value repeats are dotted (#195)', () => {
+    const telegrams = [
+      // A cyclic "alive" GA sending the same value 1 three times.
+      at(1, { target_address: '1/1/1', dpt_main: 1, dpt_sub: 11, value_numeric: 1 }),
+      at(3, { target_address: '1/1/1', dpt_main: 1, dpt_sub: 11, value_numeric: 1 }),
+      at(5, { target_address: '1/1/1', dpt_main: 1, dpt_sub: 11, value_numeric: 1 }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1']));
+    const series = result.current.buckets[0].series[0];
+    // Every telegram is a real receipt even though the value never changes.
+    expect(series.real).toEqual([true, true, true]);
+    expect(series.data).toEqual([1, 1, 1]);
+  });
+
+  test('forward-filled columns from another GA are not marked real (#195)', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 20 }),
+      // A second GA in the same bucket adds a timestamp column at t=3; GA 1/1/1
+      // holds its value there (forward-fill) but did not receive a telegram.
+      at(3, { target_address: '2/2/2', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 30 }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1', '2/2/2']));
+    const s1 = result.current.buckets[0].series.find(s => s.address === '1/1/1')!;
+    // Column order is [t1, t3]; 1/1/1 is real only at t1.
+    expect(s1.real).toEqual([true, false]);
+    expect(s1.data).toEqual([20, 20]);
+  });
+
   test('does not add spurious columns when a bucket already ends at the newest telegram', () => {
     const telegrams = [
       at(1, { target_address: '1/1/1', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 20 }),

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -5,6 +5,10 @@ export interface ChartSeries {
   address: string;
   name: string;
   data: (number | null)[]; // y-values corresponding to the shared timestamps array
+  /** Per-column flag: true where this series actually received a telegram (vs a
+   * forward-filled hold). Drives the telegram dots (#195), so cyclic repeats of
+   * the same value are visible instead of hidden inside a flat segment. */
+  real: boolean[];
 }
 
 export interface ChartBucket {
@@ -103,9 +107,11 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
 
         // Map timestamps to values
         let lastVal: number | null = null;
+        const real: boolean[] = [];
         const data = timestamps.map(ts => {
           // Find if there's a telegram for this exact target at this exact timestamp
           const match = rows.find(r => r.target_address === addr && r.ts === ts);
+          real.push(!!match);
           if (match) {
             let val = match.value_numeric;
             if (val === null && typeof match.value_json === 'boolean') {
@@ -118,7 +124,7 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
           return lastVal;
         });
 
-        return { address: addr, name, data };
+        return { address: addr, name, data, real };
       });
 
       buckets.push({


### PR DESCRIPTION
Implements the core of [issue #195](https://github.com/martinhoefling/SpectrumKNX/issues/195).

**Problem:** cyclic telegrams that don't change the plotted value — e.g. a DPT 1.011 "server alive" resending the same bit every 90 s — were invisible in the graphs (one flat bar / line). TabSel asked for a small dot at each telegram (x = receive time, y = value) so repeats are visible.

**What changed**
- `useChartData` now marks, per series, which timeline columns are **actual telegram receipts** vs forward-filled holds (`real: boolean[]`).
- **Numeric `MixedChart`**: uPlot point markers drawn only at real receipts (via `points.filter`).
- **Binary `TimelineChart`**: a small tick/dot along the state bar at each real receipt, drawn in the existing timeline plugin.
- A header **Dots** toggle (cookie-persisted, on by default) so dense buses can turn them off.

The real-column flags are read from a ref at draw time so dots stay correct on live telegram updates **without recreating the chart** — preserving the cursor/hover fix from #207.

**Verified in a browser:** a cyclic DPT 1.011 "ServerAlive" now shows a dot at each of its 90 s telegrams along the green "On" bar (previously a featureless bar); the numeric chart dots each real telegram; the toggle hides/shows them. Unit tests cover the `real` flags (cyclic same-value repeats marked real; forward-filled columns from another GA not).

**Deferred:** non-graphable DPTs (e.g. DPT 16 text) as a dedicated event lane with a value tooltip — needs a new lane/tooltip concept and has open spec questions in the issue.

Reported by TabSel in [forum post #99](https://knx-user-forum.de/forum/%C3%B6ffentlicher-bereich/knx-eib-forum/2088940-showcase-spectrumknx-%E2%80%93-neues-tool-f%C3%BCr-langzeit-analyse-telegramm-deep-dive/page7).

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)