### PR TITLE
fix: pad zero-width time range so single-telegram graphs show real times

### DIFF
--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -8,6 +8,7 @@ import { TimeBrush } from './TimeBrush';
 import { Download, Link2, Check } from 'lucide-react';
 import { getCookie, setCookie } from '../utils/cookies';
 import { clearSeriesHidden } from '../utils/legendVisibility';
+import { expandDegenerateRange } from '../utils/timeRange';
 
 interface VisualizerProps {
   telegrams: Telegram[];
@@ -31,7 +32,9 @@ export const Visualizer: React.FC<VisualizerProps> = ({
   const [linkCopied, setLinkCopied] = useState(false);
 
   const defaultRange = useMemo<[number, number]>(() => {
-    return [minTime ?? 0, maxTime ?? 0];
+    // Pad a zero-width extent (a single telegram, or several at the same instant)
+    // so the time axis renders real times instead of collapsing to 00:00 (#239).
+    return expandDegenerateRange(minTime ?? 0, maxTime ?? 0);
   }, [minTime, maxTime]);
 
   const [zoomRange, setZoomRange] = useState<[number, number] | null>(null);

--- a/frontend/src/utils/timeRange.test.ts
+++ b/frontend/src/utils/timeRange.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest';
+import { expandDegenerateRange, DEGENERATE_RANGE_PAD_MS } from './timeRange';
+
+test('leaves a normal range untouched', () => {
+  expect(expandDegenerateRange(1000, 5000)).toEqual([1000, 5000]);
+});
+
+test('pads a zero-width range so the axis is not degenerate (#239)', () => {
+  const t = 1_700_000_000_000;
+  expect(expandDegenerateRange(t, t)).toEqual([t - DEGENERATE_RANGE_PAD_MS, t + DEGENERATE_RANGE_PAD_MS]);
+});
+
+test('pads an inverted range as well (defensive)', () => {
+  const [a, b] = expandDegenerateRange(5000, 4000);
+  expect(b).toBeGreaterThan(a);
+});
+
+test('honours a custom pad', () => {
+  expect(expandDegenerateRange(10, 10, 5)).toEqual([5, 15]);
+});

--- a/frontend/src/utils/timeRange.ts
+++ b/frontend/src/utils/timeRange.ts
@@ -1,0 +1,18 @@
+/** Default padding applied to a zero-width time range, per side (ms). */
+export const DEGENERATE_RANGE_PAD_MS = 60_000;
+
+/**
+ * Widen a zero-width time range so charts get a valid x-scale.
+ *
+ * A single telegram (or several at the same instant) yields `min === max`,
+ * which collapses uPlot's time axis and renders every tick as 00:00 (#239).
+ * Pad symmetrically around the point so the axis shows real times.
+ */
+export function expandDegenerateRange(
+  min: number,
+  max: number,
+  padMs: number = DEGENERATE_RANGE_PAD_MS,
+): [number, number] {
+  if (max > min) return [min, max];
+  return [min - padMs, max + padMs];
+}


### PR DESCRIPTION
Fixes [#239](https://github.com/martinhoefling/SpectrumKNX/issues/239).

**Problem:** in the visualization, a GA with exactly one received telegram (or several at the same millisecond) produced `minTime === maxTime`. The charts bind their x-scale to that range, so a zero-width extent collapsed uPlot's time axis and rendered every tick as **00:00**.

**Fix:** a small `expandDegenerateRange` helper pads a zero-width extent symmetrically (±1 min) before it is passed to the charts, so the axis shows real times centered on the telegram. Normal (non-degenerate) ranges are untouched.

Unit tests cover the pad / no-pad / custom-pad cases.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)