### PR TITLE
fix: sync zoom timeline when chart range is selected

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -14,12 +14,13 @@ interface MixedChartProps {
   stepped: boolean;
   /** Draw a dot at each telegram timestamp so cyclic repeats are visible (#195). */
   showDots: boolean;
+  onZoomRangeChange?: (value: [number, number] | null) => void;
 }
 
 // Ensure we have a shared sync cursor across all charts
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime, stepped, showDots }) => {
+export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime, stepped, showDots, onZoomRangeChange }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const themeTick = useThemeTick();
@@ -86,7 +87,10 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
     return {
       width,
       height: isBinary ? Math.max(150, series.length * 50) : 300,
-      cursor: { sync: { key: syncCursor.key } },
+      cursor: {
+        sync: { key: syncCursor.key },
+        drag: { x: true, y: false, setScale: false }
+      },
       hooks: {
         // Record legend show/hide toggles so they survive chart recreation (#192).
         // Use the requested value from `opts.show` rather than reading it back
@@ -97,7 +101,23 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
           if (idx == null || idx === 0 || !('show' in opts)) return;
           const addr = series[idx - 1]?.address;
           if (addr) setSeriesHidden(addr, !opts.show);
-        }]
+        }],
+        setSelect: [
+          (u) => {
+            if (u.select.width > 0) {
+              const min = u.posToVal(u.select.left, 'x');
+              const max = u.posToVal(u.select.left + u.select.width, 'x');
+              onZoomRangeChange?.([min * 1000, max * 1000]);
+            }
+          }
+        ],
+        ready: [
+          (u) => {
+            u.over.addEventListener('dblclick', () => {
+              onZoomRangeChange?.(null);
+            });
+          }
+        ]
       },
       scales: {
         x: {

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -11,11 +11,12 @@ interface TimelineChartProps {
   maxTime: number | null;
   /** Draw a tick at each telegram timestamp so cyclic repeats are visible (#195). */
   showDots: boolean;
+  onZoomRangeChange?: (value: [number, number] | null) => void;
 }
 
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, maxTime, showDots }) => {
+export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, maxTime, showDots, onZoomRangeChange }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const themeTick = useThemeTick();
@@ -148,7 +149,28 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
       width,
       height: chartHeight,
       padding: [0, 180, 0, 0],
-      cursor: { sync: { key: syncCursor.key } },
+      cursor: {
+        sync: { key: syncCursor.key },
+        drag: { x: true, y: false, setScale: false }
+      },
+      hooks: {
+        setSelect: [
+          (u) => {
+            if (u.select.width > 0) {
+              const min = u.posToVal(u.select.left, 'x');
+              const max = u.posToVal(u.select.left + u.select.width, 'x');
+              onZoomRangeChange?.([min * 1000, max * 1000]);
+            }
+          }
+        ],
+        ready: [
+          (u) => {
+            u.over.addEventListener('dblclick', () => {
+              onZoomRangeChange?.(null);
+            });
+          }
+        ]
+      },
       plugins: [timelinePlugin()],
       scales: {
         x: {

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -90,9 +90,9 @@ export const Visualizer: React.FC<VisualizerProps> = ({
     <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: embed ? '0.75rem' : '1.5rem' }}>
       {buckets.map(b => (
         b.isBinary ? (
-          <TimelineChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} />
+          <TimelineChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} onZoomRangeChange={setZoomRange} />
         ) : (
-          <MixedChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} stepped={stepped} showDots={showDots} />
+          <MixedChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} stepped={stepped} showDots={showDots} onZoomRangeChange={setZoomRange} />
         )
       ))}
 


### PR DESCRIPTION
This PR fixes #248 by:
1. Configuring uPlot to disable the default automatic local scale updates on selection.
2. Propagating the selection values to the parent 's  state via a new  callback.
3. Adding a double-click event listener to the uPlot canvas overlay () to trigger resetting of the zoom when double-clicked.

This ensures all charts and the Pan & Zoom Timeline brush stay completely in sync.

Closes #248.