### PR TITLE
Port Group Monitor caching services from knx-frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/react-virtual": "^3.14.6",
         "date-fns": "4.4.0",
+        "idb-keyval": "^6.3.0",
         "lucide-react": "1.25.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -2677,6 +2678,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+      "integrity": "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.6",
     "date-fns": "4.4.0",
+    "idb-keyval": "^6.3.0",
     "lucide-react": "1.25.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/frontend/src/services/telegram-buffer-service.test.ts
+++ b/frontend/src/services/telegram-buffer-service.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TelegramBufferService } from './telegram-buffer-service';
+import { makeEntry, makeEntries } from '../test/telegramFactory';
+import type { TelegramEntry } from '../utils/telegramId';
+
+describe('TelegramBufferService', () => {
+  let service: TelegramBufferService;
+
+  beforeEach(() => {
+    service = new TelegramBufferService();
+  });
+
+  describe('basic operations', () => {
+    it('initializes with default settings', () => {
+      expect(service.maxSize).toBe(2000);
+      expect(service.length).toBe(0);
+      expect(service.isEmpty).toBe(true);
+      expect(service.snapshot).toEqual([]);
+    });
+
+    it('adds a single entry', () => {
+      const entry = makeEntry('2024-01-01T10:00:00.000Z');
+      const removed = service.add(entry);
+
+      expect(service.length).toBe(1);
+      expect(service.isEmpty).toBe(false);
+      expect(removed).toEqual([]);
+      expect(service.snapshot[0]).toBe(entry);
+    });
+
+    it('adds multiple entries', () => {
+      const entries = makeEntries(3);
+      const removed = service.add(entries);
+
+      expect(service.length).toBe(3);
+      expect(removed).toEqual([]);
+      expect(service.snapshot).toEqual(entries);
+    });
+
+    it('clears the buffer', () => {
+      const entries = makeEntries(3);
+      service.add(entries);
+
+      const cleared = service.clear();
+
+      expect(cleared).toEqual(entries);
+      expect(service.length).toBe(0);
+      expect(service.isEmpty).toBe(true);
+    });
+
+    it('reports id membership', () => {
+      const entry = makeEntry('2024-01-01T10:00:00.000Z');
+      service.add(entry);
+      expect(service.has(entry.id)).toBe(true);
+      expect(service.has('nope')).toBe(false);
+    });
+  });
+
+  describe('chronological ordering', () => {
+    it('maintains order when added in sequence', () => {
+      const e1 = makeEntry('2024-01-01T10:00:01.000Z', '1');
+      const e2 = makeEntry('2024-01-01T10:00:02.000Z', '2');
+      const e3 = makeEntry('2024-01-01T10:00:03.000Z', '3');
+
+      service.add(e1);
+      service.add(e2);
+      service.add(e3);
+
+      expect(service.snapshot).toEqual([e1, e2, e3]);
+    });
+
+    it('sorts when entries are added out of order', () => {
+      const e1 = makeEntry('2024-01-01T10:00:01.000Z', '1');
+      const e2 = makeEntry('2024-01-01T10:00:02.000Z', '2');
+      const e3 = makeEntry('2024-01-01T10:00:03.000Z', '3');
+
+      service.add(e3);
+      service.add(e1);
+      service.add(e2);
+
+      expect(service.snapshot).toEqual([e1, e2, e3]);
+    });
+
+    it('inserts an entry at its chronological position', () => {
+      const e1 = makeEntry('2024-01-01T10:00:01.000Z', '1');
+      const e3 = makeEntry('2024-01-01T10:00:03.000Z', '3');
+      service.add([e1, e3]);
+
+      const e2 = makeEntry('2024-01-01T10:00:02.000Z', '2');
+      service.add(e2);
+
+      expect(service.snapshot).toEqual([e1, e2, e3]);
+    });
+
+    it('sorts an unsorted first batch', () => {
+      const e1 = makeEntry('2024-01-01T10:00:01.000Z', '1');
+      const e2 = makeEntry('2024-01-01T10:00:02.000Z', '2');
+      service.add([e2, e1]);
+      expect(service.snapshot).toEqual([e1, e2]);
+    });
+  });
+
+  describe('buffer overflow', () => {
+    beforeEach(() => {
+      service = new TelegramBufferService(3);
+    });
+
+    it('removes oldest entries when the buffer overflows', () => {
+      const entries = makeEntries(5);
+      const removed = service.add(entries);
+
+      expect(service.length).toBe(3);
+      expect(removed).toEqual(entries.slice(0, 2));
+      expect(service.snapshot).toEqual(entries.slice(2));
+    });
+
+    it('handles single-entry overflow', () => {
+      const entries = makeEntries(3);
+      service.add(entries);
+
+      const extra = makeEntry('2024-01-01T10:00:04.000Z', '4');
+      const removed = service.add(extra);
+
+      expect(service.length).toBe(3);
+      expect(removed).toEqual([entries[0]]);
+      expect(service.snapshot).toEqual([entries[1], entries[2], extra]);
+    });
+  });
+
+  describe('merge', () => {
+    it('merges unique entries in chronological order', () => {
+      const e1 = makeEntry('2024-01-01T10:00:01.000Z', '1');
+      const e3 = makeEntry('2024-01-01T10:00:03.000Z', '3');
+      service.add([e1, e3]);
+
+      const newEntries = [
+        makeEntry('2024-01-01T10:00:02.000Z', '2'),
+        makeEntry('2024-01-01T10:00:04.000Z', '4'),
+      ];
+
+      const result = service.merge(newEntries);
+
+      expect(result.added).toEqual(newEntries);
+      expect(result.removed).toEqual([]);
+      expect(service.snapshot.map(e => e.ts)).toEqual(
+        [e1, newEntries[0], e3, newEntries[1]].map(e => e.ts),
+      );
+    });
+
+    it('filters out duplicate entries by id', () => {
+      const e1 = makeEntry('2024-01-01T10:00:01.000Z', '1');
+      const e2 = makeEntry('2024-01-01T10:00:02.000Z', '2');
+      service.add([e1, e2]);
+
+      const result = service.merge([
+        e1, // duplicate
+        makeEntry('2024-01-01T10:00:03.000Z', '3'), // new
+        e2, // duplicate
+      ]);
+
+      expect(result.added.length).toBe(1);
+      expect(service.length).toBe(3);
+    });
+  });
+
+  describe('size management', () => {
+    it('updates max size without overflow', () => {
+      service.add(makeEntries(3));
+      const removed = service.setMaxSize(5);
+
+      expect(service.maxSize).toBe(5);
+      expect(service.length).toBe(3);
+      expect(removed).toEqual([]);
+    });
+
+    it('removes oldest entries when reducing max size', () => {
+      const entries = makeEntries(5);
+      service.add(entries);
+
+      const removed = service.setMaxSize(3);
+
+      expect(service.maxSize).toBe(3);
+      expect(removed).toEqual(entries.slice(0, 2));
+      expect(service.snapshot).toEqual(entries.slice(2));
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty arrays', () => {
+      expect(service.add([])).toEqual([]);
+      expect(service.merge([])).toEqual({ added: [], removed: [] });
+    });
+
+    it('keeps entries with identical timestamps', () => {
+      const sameTime = '2024-01-01T10:00:00.000Z';
+      const e1 = makeEntry(sameTime, '1');
+      const e2 = makeEntry(sameTime, '2');
+
+      service.add(e1);
+      service.add(e2);
+
+      expect(service.length).toBe(2);
+    });
+
+    it('returns immutable snapshots', () => {
+      service.add(makeEntries(2));
+
+      const snapshot1 = service.snapshot;
+      const snapshot2 = service.snapshot;
+
+      expect(snapshot1).not.toBe(snapshot2);
+      expect(snapshot1).toEqual(snapshot2);
+      (snapshot1 as TelegramEntry[]).pop();
+      expect(service.length).toBe(2);
+    });
+  });
+});

--- a/frontend/src/services/telegram-buffer-service.ts
+++ b/frontend/src/services/telegram-buffer-service.ts
@@ -1,0 +1,95 @@
+import type { TelegramEntry } from '../utils/telegramId';
+
+/**
+ * In-memory telegram buffer with ring-buffer behavior, ported from the
+ * Home Assistant knx-frontend Group Monitor (#246).
+ *
+ * - Chronological insertion with a fast-path append for live telegrams.
+ * - Deduplicating `merge()` for historical loads.
+ * - Automatic overflow eviction of the oldest entries.
+ * - Immutable `snapshot` for safe use as React state.
+ */
+export class TelegramBufferService {
+  private _buffer: TelegramEntry[] = [];
+
+  private _maxSize: number;
+
+  constructor(maxSize = 2000) {
+    this._maxSize = maxSize;
+  }
+
+  /**
+   * Adds one or more entries, keeping the buffer sorted by timestamp.
+   * Only sorts when the fast path (all newer than the current tail, and
+   * themselves in order) does not apply.
+   * @returns Entries removed due to buffer overflow (empty if none).
+   */
+  add(entries: TelegramEntry | TelegramEntry[]): TelegramEntry[] {
+    const entryArray = Array.isArray(entries) ? entries : [entries];
+    if (entryArray.length === 0) return [];
+
+    const newAreSorted = entryArray.every((e, i) => i === 0 || entryArray[i - 1].ts <= e.ts);
+    const lastTs = this._buffer.length > 0 ? this._buffer[this._buffer.length - 1].ts : -Infinity;
+
+    this._buffer.push(...entryArray);
+    if (!newAreSorted || entryArray[0].ts < lastTs) {
+      this._buffer.sort((a, b) => a.ts - b.ts);
+    }
+
+    if (this._buffer.length > this._maxSize) {
+      return this._buffer.splice(0, this._buffer.length - this._maxSize);
+    }
+    return [];
+  }
+
+  /**
+   * Adds multiple entries, skipping ids already present.
+   * @returns The unique entries actually added and any overflow evictions.
+   */
+  merge(newEntries: TelegramEntry[]): { added: TelegramEntry[]; removed: TelegramEntry[] } {
+    const existingIds = new Set(this._buffer.map(e => e.id));
+    const unique = newEntries.filter(e => !existingIds.has(e.id));
+    unique.sort((a, b) => a.ts - b.ts);
+    return { added: unique, removed: this.add(unique) };
+  }
+
+  /**
+   * Updates the maximum size, evicting the oldest entries when shrinking.
+   * @returns Entries removed by the size reduction (empty if none).
+   */
+  setMaxSize(size: number): TelegramEntry[] {
+    this._maxSize = size;
+    if (this._buffer.length > size) {
+      return this._buffer.splice(0, this._buffer.length - size);
+    }
+    return [];
+  }
+
+  get maxSize(): number {
+    return this._maxSize;
+  }
+
+  get length(): number {
+    return this._buffer.length;
+  }
+
+  get isEmpty(): boolean {
+    return this._buffer.length === 0;
+  }
+
+  /** Immutable copy of the buffer, oldest first. */
+  get snapshot(): readonly TelegramEntry[] {
+    return [...this._buffer];
+  }
+
+  /** Removes everything and returns the removed entries. */
+  clear(): TelegramEntry[] {
+    const cleared = [...this._buffer];
+    this._buffer.length = 0;
+    return cleared;
+  }
+
+  has(id: string): boolean {
+    return this._buffer.some(e => e.id === id);
+  }
+}

--- a/frontend/src/services/telegram-cache-service.test.ts
+++ b/frontend/src/services/telegram-cache-service.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TelegramCacheService, MAX_CACHE_SIZE } from './telegram-cache-service';
+import { makeTelegram } from '../test/telegramFactory';
+import type { TelegramEntry } from '../utils/telegramId';
+
+// In-memory IDB stand-in: Map<key, value> per custom store.
+const _store = new Map<string, unknown>();
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => 'mock-store',
+  setMany: async (pairs: [string, unknown][]) => {
+    for (const [k, v] of pairs) _store.set(k, v);
+  },
+  entries: async () => Array.from(_store.entries()),
+  delMany: async (keys: string[]) => {
+    for (const k of keys) _store.delete(k);
+  },
+  clear: async () => _store.clear(),
+}));
+
+const entry = (id: string, ts: number): TelegramEntry => ({
+  id,
+  ts,
+  telegram: makeTelegram({ timestamp: new Date(ts).toISOString() }),
+});
+
+describe('TelegramCacheService', () => {
+  let svc: TelegramCacheService;
+
+  beforeEach(() => {
+    _store.clear();
+    svc = new TelegramCacheService();
+  });
+
+  describe('store / loadAll', () => {
+    it('stores a single entry and loads it back', async () => {
+      await svc.store([entry('id-a', 1000)]);
+      const loaded = await svc.loadAll();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].id).toBe('id-a');
+      expect(loaded[0].ts).toBe(1000);
+      expect(loaded[0].telegram.source_address).toBe('1.2.3');
+    });
+
+    it('stores a batch and returns all entries', async () => {
+      await svc.store([entry('a', 100), entry('b', 200), entry('c', 300)]);
+      expect(await svc.loadAll()).toHaveLength(3);
+    });
+
+    it('returns entries sorted newest-first', async () => {
+      await svc.store([entry('a', 100), entry('b', 300), entry('c', 200)]);
+      const loaded = await svc.loadAll();
+      expect(loaded.map(e => e.ts)).toEqual([300, 200, 100]);
+    });
+
+    it('overwrites an existing entry with the same key (idempotent)', async () => {
+      await svc.store([entry('id-a', 100)]);
+      await svc.store([entry('id-a', 200)]);
+      const loaded = await svc.loadAll();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].ts).toBe(200);
+    });
+
+    it('returns empty array when cache is empty', async () => {
+      expect(await svc.loadAll()).toEqual([]);
+    });
+
+    it('ignores empty batches', async () => {
+      await svc.store([]);
+      expect(await svc.count()).toBe(0);
+    });
+  });
+
+  describe('evictBefore', () => {
+    it('removes entries strictly before minMs', async () => {
+      await svc.store([entry('a', 100), entry('b', 200), entry('c', 300)]);
+      await svc.evictBefore(200);
+      const loaded = await svc.loadAll();
+      expect(loaded.map(e => e.id).sort()).toEqual(['b', 'c']);
+    });
+
+    it('keeps entries at exactly minMs', async () => {
+      await svc.store([entry('a', 200)]);
+      await svc.evictBefore(200);
+      expect(await svc.count()).toBe(1);
+    });
+
+    it('is a no-op when all entries are newer', async () => {
+      await svc.store([entry('a', 500)]);
+      await svc.evictBefore(200);
+      expect(await svc.count()).toBe(1);
+    });
+  });
+
+  describe('evictToSize', () => {
+    it('trims oldest entries when over maxCount', async () => {
+      await svc.store([
+        entry('a', 100),
+        entry('b', 200),
+        entry('c', 300),
+        entry('d', 400),
+        entry('e', 500),
+      ]);
+      await svc.evictToSize(3);
+      const loaded = await svc.loadAll();
+      expect(loaded).toHaveLength(3);
+      expect(loaded.map(e => e.id).sort()).toEqual(['c', 'd', 'e']);
+    });
+
+    it('returns the oldest surviving timestamp when eviction occurs', async () => {
+      await svc.store([entry('a', 100), entry('b', 200), entry('c', 300)]);
+      const oldest = await svc.evictToSize(2);
+      expect(oldest).toBe(200); // entry "b" is now the oldest surviving
+    });
+
+    it('returns null when at or below maxCount', async () => {
+      await svc.store([entry('a', 100)]);
+      const result = await svc.evictToSize(3);
+      expect(result).toBeNull();
+      expect(await svc.count()).toBe(1);
+    });
+  });
+
+  describe('loadRange', () => {
+    it('returns only entries within [startMs, endMs]', async () => {
+      await svc.store([entry('a', 100), entry('b', 200), entry('c', 300), entry('d', 400)]);
+      const result = await svc.loadRange(200, 300);
+      expect(result.map(e => e.id).sort()).toEqual(['b', 'c']);
+    });
+
+    it('returns entries sorted newest first', async () => {
+      await svc.store([entry('a', 100), entry('b', 200), entry('c', 300)]);
+      const result = await svc.loadRange(100, 300);
+      expect(result.map(e => e.ts)).toEqual([300, 200, 100]);
+    });
+
+    it('returns empty array when no entries match the range', async () => {
+      await svc.store([entry('a', 100)]);
+      expect(await svc.loadRange(500, 1000)).toEqual([]);
+    });
+  });
+
+  describe('count / clear', () => {
+    it('counts entries', async () => {
+      expect(await svc.count()).toBe(0);
+      await svc.store([entry('a', 100), entry('b', 200)]);
+      expect(await svc.count()).toBe(2);
+    });
+
+    it('clear removes all entries', async () => {
+      await svc.store([entry('a', 100), entry('b', 200)]);
+      await svc.clear();
+      expect(await svc.count()).toBe(0);
+    });
+  });
+
+  it('exports the expected cache cap', () => {
+    expect(MAX_CACHE_SIZE).toBe(100_000);
+  });
+});

--- a/frontend/src/services/telegram-cache-service.ts
+++ b/frontend/src/services/telegram-cache-service.ts
@@ -1,0 +1,95 @@
+/**
+ * Persistent telegram cache backed by IndexedDB (via idb-keyval), ported from
+ * the Home Assistant knx-frontend Group Monitor (#246).
+ *
+ * Each entry is keyed by the telegram's stable client-side id (see
+ * `utils/telegramId.ts`) and stores the epoch-ms timestamp alongside the raw
+ * telegram so old entries can be evicted without deserialising the payload.
+ *
+ * The cache is purely advisory: callers should catch errors and fall back to a
+ * backend query — a miss or storage failure must never break the app.
+ */
+
+import { clear, createStore, delMany, entries, setMany } from 'idb-keyval';
+import type { Telegram } from '../hooks/useWebSocket';
+import type { TelegramEntry } from '../utils/telegramId';
+
+/** Maximum number of telegrams kept in the persistent cache. */
+export const MAX_CACHE_SIZE = 100_000;
+
+/** IDB store name — kept stable; changing it orphans existing data. */
+const IDB_STORE = createStore('spectrum-knx-bus-monitor', 'telegrams');
+
+/** Shape of each entry stored in IndexedDB. */
+interface CachedEntry {
+  ts: number; // epoch milliseconds — used for eviction ordering
+  telegram: Telegram;
+}
+
+export class TelegramCacheService {
+  /**
+   * Persists a batch of telegrams. Existing entries with the same id are
+   * overwritten (idempotent, matches the buffer's dedup behavior).
+   */
+  async store(batch: TelegramEntry[]): Promise<void> {
+    if (batch.length === 0) return;
+    const pairs: [string, CachedEntry][] = batch.map(({ id, ts, telegram }) => [id, { ts, telegram }]);
+    await setMany(pairs, IDB_STORE);
+  }
+
+  /**
+   * Returns cached entries whose timestamp falls within [startMs, endMs],
+   * sorted newest first.
+   */
+  async loadRange(startMs: number, endMs: number): Promise<TelegramEntry[]> {
+    const all = await entries<string, CachedEntry>(IDB_STORE);
+    return all
+      .filter(([, entry]) => entry.ts >= startMs && entry.ts <= endMs)
+      .map(([id, entry]) => ({ id, ts: entry.ts, telegram: entry.telegram }))
+      .sort((a, b) => b.ts - a.ts);
+  }
+
+  /** Returns all cached entries, newest first. */
+  async loadAll(): Promise<TelegramEntry[]> {
+    const all = await entries<string, CachedEntry>(IDB_STORE);
+    return all
+      .map(([id, entry]) => ({ id, ts: entry.ts, telegram: entry.telegram }))
+      .sort((a, b) => b.ts - a.ts);
+  }
+
+  /** Deletes all entries whose timestamp is strictly before `minMs`. */
+  async evictBefore(minMs: number): Promise<void> {
+    const all = await entries<string, CachedEntry>(IDB_STORE);
+    const stale = all.filter(([, entry]) => entry.ts < minMs).map(([id]) => id);
+    if (stale.length > 0) await delMany(stale, IDB_STORE);
+  }
+
+  /**
+   * Trims the cache to at most `maxCount` entries by deleting the oldest.
+   * Returns the timestamp of the oldest surviving entry so the caller can trim
+   * coverage accordingly, or `null` if no eviction was needed.
+   */
+  async evictToSize(maxCount: number): Promise<number | null> {
+    const all = await entries<string, CachedEntry>(IDB_STORE);
+    if (all.length <= maxCount) return null;
+    all.sort((a, b) => a[1].ts - b[1].ts);
+    const toEvict = all.slice(0, all.length - maxCount);
+    await delMany(
+      toEvict.map(([id]) => id),
+      IDB_STORE,
+    );
+    // First surviving entry after eviction.
+    return all[all.length - maxCount][1].ts;
+  }
+
+  /** Returns the total number of entries in the cache. */
+  async count(): Promise<number> {
+    const all = await entries(IDB_STORE);
+    return all.length;
+  }
+
+  /** Wipes all entries from the cache. */
+  async clear(): Promise<void> {
+    await clear(IDB_STORE);
+  }
+}

--- a/frontend/src/services/telegram-coverage-service.test.ts
+++ b/frontend/src/services/telegram-coverage-service.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  TelegramCoverageService,
+  loadCoverageIntervals,
+  saveCoverageIntervals,
+  COVERAGE_STORAGE_KEY,
+} from './telegram-coverage-service';
+
+describe('TelegramCoverageService', () => {
+  let coverage: TelegramCoverageService;
+
+  beforeEach(() => {
+    coverage = new TelegramCoverageService();
+  });
+
+  describe('addCovered / covered', () => {
+    it('stores a single interval', () => {
+      coverage.addCovered(10, 20);
+      expect(coverage.covered).toEqual([[10, 20]]);
+    });
+
+    it('ignores inverted intervals', () => {
+      coverage.addCovered(20, 10);
+      expect(coverage.covered).toEqual([]);
+    });
+
+    it('keeps disjoint intervals separate and sorted', () => {
+      coverage.addCovered(100, 200);
+      coverage.addCovered(10, 20);
+      expect(coverage.covered).toEqual([
+        [10, 20],
+        [100, 200],
+      ]);
+    });
+
+    it('merges overlapping intervals', () => {
+      coverage.addCovered(10, 50);
+      coverage.addCovered(40, 80);
+      expect(coverage.covered).toEqual([[10, 80]]);
+    });
+
+    it('merges adjacent (touching) intervals', () => {
+      coverage.addCovered(10, 20);
+      coverage.addCovered(20, 30);
+      expect(coverage.covered).toEqual([[10, 30]]);
+    });
+
+    it('absorbs an interval fully contained in another', () => {
+      coverage.addCovered(10, 100);
+      coverage.addCovered(40, 50);
+      expect(coverage.covered).toEqual([[10, 100]]);
+    });
+
+    it('chains multiple merges', () => {
+      coverage.addCovered(10, 20);
+      coverage.addCovered(100, 110);
+      coverage.addCovered(15, 105);
+      expect(coverage.covered).toEqual([[10, 110]]);
+    });
+  });
+
+  describe('gaps', () => {
+    it('returns the whole range when nothing is covered', () => {
+      expect(coverage.gaps(10, 20)).toEqual([[10, 20]]);
+    });
+
+    it('returns empty when fully covered', () => {
+      coverage.addCovered(0, 100);
+      expect(coverage.gaps(10, 20)).toEqual([]);
+    });
+
+    it('returns a leading gap', () => {
+      coverage.addCovered(50, 100);
+      expect(coverage.gaps(10, 100)).toEqual([[10, 49]]);
+    });
+
+    it('returns a trailing gap', () => {
+      coverage.addCovered(10, 50);
+      expect(coverage.gaps(10, 100)).toEqual([[51, 100]]);
+    });
+
+    it('returns a middle gap between two covered intervals', () => {
+      coverage.addCovered(10, 30);
+      coverage.addCovered(60, 100);
+      expect(coverage.gaps(10, 100)).toEqual([[31, 59]]);
+    });
+
+    it('returns multiple gaps', () => {
+      coverage.addCovered(20, 30);
+      coverage.addCovered(50, 60);
+      expect(coverage.gaps(0, 100)).toEqual([
+        [0, 19],
+        [31, 49],
+        [61, 100],
+      ]);
+    });
+
+    it('ignores covered intervals outside the requested range', () => {
+      coverage.addCovered(0, 5);
+      coverage.addCovered(200, 300);
+      expect(coverage.gaps(10, 100)).toEqual([[10, 100]]);
+    });
+
+    it('returns empty for an inverted range', () => {
+      expect(coverage.gaps(100, 10)).toEqual([]);
+    });
+  });
+
+  describe('isCovered', () => {
+    it('is true when the range is fully covered', () => {
+      coverage.addCovered(0, 100);
+      expect(coverage.isCovered(10, 90)).toBe(true);
+    });
+
+    it('is false when a part is missing', () => {
+      coverage.addCovered(0, 50);
+      expect(coverage.isCovered(10, 90)).toBe(false);
+    });
+  });
+
+  describe('trim', () => {
+    it('drops intervals entirely before the minimum', () => {
+      coverage.addCovered(0, 50);
+      coverage.addCovered(100, 200);
+      coverage.trim(60);
+      expect(coverage.covered).toEqual([[100, 200]]);
+    });
+
+    it('clips an interval that straddles the minimum', () => {
+      coverage.addCovered(0, 200);
+      coverage.trim(50);
+      expect(coverage.covered).toEqual([[50, 200]]);
+    });
+  });
+
+  describe('live tracking', () => {
+    it('grows a single interval while extending', () => {
+      coverage.extendLive(100);
+      coverage.extendLive(150);
+      coverage.extendLive(200);
+      expect(coverage.covered).toEqual([[100, 200]]);
+    });
+
+    it('creates a gap after closeLive and reopening later', () => {
+      coverage.extendLive(100);
+      coverage.extendLive(150);
+      coverage.closeLive();
+      coverage.extendLive(300);
+      coverage.extendLive(350);
+      expect(coverage.covered).toEqual([
+        [100, 150],
+        [300, 350],
+      ]);
+      expect(coverage.gaps(100, 350)).toEqual([[151, 299]]);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all coverage and resets live tracking', () => {
+      coverage.addCovered(0, 100);
+      coverage.extendLive(200);
+      coverage.clear();
+      expect(coverage.covered).toEqual([]);
+      coverage.extendLive(300);
+      expect(coverage.covered).toEqual([[300, 300]]);
+    });
+  });
+});
+
+describe('coverage persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('round-trips intervals through localStorage', () => {
+    saveCoverageIntervals([
+      [10, 20],
+      [100, 200],
+    ]);
+    expect(loadCoverageIntervals()).toEqual([
+      [10, 20],
+      [100, 200],
+    ]);
+  });
+
+  it('returns empty when nothing is stored', () => {
+    expect(loadCoverageIntervals()).toEqual([]);
+  });
+
+  it('returns empty on malformed JSON', () => {
+    localStorage.setItem(COVERAGE_STORAGE_KEY, 'not-json{');
+    expect(loadCoverageIntervals()).toEqual([]);
+  });
+
+  it('drops malformed or inverted intervals', () => {
+    localStorage.setItem(
+      COVERAGE_STORAGE_KEY,
+      JSON.stringify([[10, 20], [30], 'x', [50, 40], [null, 60], [70, 80]]),
+    );
+    expect(loadCoverageIntervals()).toEqual([
+      [10, 20],
+      [70, 80],
+    ]);
+  });
+
+  it('restores into a service correctly', () => {
+    saveCoverageIntervals([
+      [10, 20],
+      [40, 50],
+    ]);
+    const svc = new TelegramCoverageService();
+    for (const [s, e] of loadCoverageIntervals()) svc.addCovered(s, e);
+    expect(svc.gaps(10, 50)).toEqual([[21, 39]]);
+  });
+});

--- a/frontend/src/services/telegram-coverage-service.ts
+++ b/frontend/src/services/telegram-coverage-service.ts
@@ -1,0 +1,158 @@
+/**
+ * A closed time interval `[start, end]` in epoch milliseconds.
+ */
+export type Interval = [number, number];
+
+/** localStorage key for persisted coverage intervals (#246). */
+export const COVERAGE_STORAGE_KEY = 'spectrum-knx-coverage';
+
+/**
+ * Tracks which time ranges have been fully loaded into the telegram buffer.
+ * Ported from the Home Assistant knx-frontend Group Monitor (#246).
+ *
+ * The Group Monitor loads history transparently: when a time range is
+ * requested, only the parts not yet covered need to be queried from the
+ * backend. This service performs the interval bookkeeping for that
+ * "coverage cache":
+ *
+ * - Covered intervals are kept sorted, merged and non-overlapping.
+ * - `gaps()` returns the sub-ranges of a request that still need loading.
+ * - A trailing "live" interval grows while telegrams stream in and is closed
+ *   when the stream pauses or disconnects, so those windows become real gaps.
+ *
+ * All math is pure and operates on epoch-millisecond numbers.
+ */
+export class TelegramCoverageService {
+  private _covered: Interval[] = [];
+
+  /** Start timestamp of the currently open live interval, or null when closed. */
+  private _liveStart: number | null = null;
+
+  /** Immutable snapshot of the covered intervals. */
+  get covered(): readonly Interval[] {
+    return this._covered.map(i => [i[0], i[1]] as Interval);
+  }
+
+  /**
+   * Marks the interval `[start, end]` as fully loaded, merging it with any
+   * existing covered intervals that overlap or are adjacent.
+   */
+  addCovered(start: number, end: number): void {
+    if (end < start) return;
+    this._covered.push([start, end]);
+    this._covered.sort((a, b) => a[0] - b[0]);
+
+    const merged: Interval[] = [];
+    for (const [s, e] of this._covered) {
+      const last = merged[merged.length - 1];
+      // Merge when overlapping or directly adjacent (touching endpoints).
+      if (last && s <= last[1]) {
+        if (e > last[1]) last[1] = e;
+      } else {
+        merged.push([s, e]);
+      }
+    }
+    this._covered = merged;
+  }
+
+  /**
+   * Returns the sub-intervals of `[start, end]` that are not yet covered.
+   * The result is sorted and non-overlapping; an empty array means the whole
+   * range is already loaded.
+   */
+  gaps(start: number, end: number): Interval[] {
+    if (end < start) return [];
+
+    const result: Interval[] = [];
+    let cursor = start;
+
+    for (const [s, e] of this._covered) {
+      if (e < cursor) continue; // covered interval entirely before the cursor
+      if (s > end) break; // covered intervals are sorted; no more overlap
+      if (s > cursor) {
+        // Gap before this covered interval (s <= end here, so s-1 <= end).
+        result.push([cursor, s - 1]);
+      }
+      cursor = Math.max(cursor, e + 1);
+      if (cursor > end) break;
+    }
+
+    if (cursor <= end) {
+      result.push([cursor, end]);
+    }
+
+    return result;
+  }
+
+  /** Whether `[start, end]` is entirely covered. */
+  isCovered(start: number, end: number): boolean {
+    return this.gaps(start, end).length === 0;
+  }
+
+  /**
+   * Drops or clips covered intervals that fall before `minMs`. Used to keep
+   * the cache within the backend's retention window.
+   */
+  trim(minMs: number): void {
+    this._covered = this._covered
+      .filter(i => i[1] >= minMs)
+      .map(i => [Math.max(i[0], minMs), i[1]] as Interval);
+    if (this._liveStart !== null) {
+      this._liveStart = Math.max(this._liveStart, minMs);
+    }
+  }
+
+  /**
+   * Extends the open "live" coverage interval up to `tsMs`. The first call
+   * (after a `closeLive()` or construction) anchors the interval start.
+   */
+  extendLive(tsMs: number): void {
+    if (this._liveStart === null) {
+      this._liveStart = tsMs;
+    }
+    this.addCovered(this._liveStart, tsMs);
+    this._liveStart = tsMs;
+  }
+
+  /**
+   * Closes the open live interval so the following pause/disconnect window is
+   * treated as a gap. The next `extendLive()` starts a fresh live interval.
+   */
+  closeLive(): void {
+    this._liveStart = null;
+  }
+
+  /** Clears all coverage state. */
+  clear(): void {
+    this._covered = [];
+    this._liveStart = null;
+  }
+}
+
+/**
+ * Restores persisted coverage intervals. Malformed or unavailable storage
+ * yields an empty list — the cache then just re-fetches from the backend.
+ */
+export function loadCoverageIntervals(): Interval[] {
+  try {
+    const raw = localStorage.getItem(COVERAGE_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (i): i is Interval =>
+        Array.isArray(i) && i.length === 2 && Number.isFinite(i[0]) && Number.isFinite(i[1]) && i[0] <= i[1],
+    );
+  } catch {
+    return [];
+  }
+}
+
+/** Persists coverage intervals; silently ignores unavailable storage. */
+export function saveCoverageIntervals(intervals: readonly Interval[]): void {
+  try {
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify(intervals));
+  } catch {
+    // Storage unavailable — coverage just won't survive the reload.
+  }
+}

--- a/frontend/src/test/telegramFactory.ts
+++ b/frontend/src/test/telegramFactory.ts
@@ -1,0 +1,46 @@
+import type { Telegram } from '../hooks/useWebSocket';
+import { toEntry, type TelegramEntry } from '../utils/telegramId';
+
+/** Creates a mock telegram for tests; addresses default to a unique-ish key. */
+export function makeTelegram(overrides: Partial<Telegram> = {}): Telegram {
+  return {
+    timestamp: '2024-01-01T10:00:00.000000Z',
+    source_address: '1.2.3',
+    source_name: 'Test Source',
+    target_address: '1/2/3',
+    target_name: 'Test Light',
+    direction: 'Incoming',
+    telegram_type: 'GroupValueWrite',
+    simplified_type: 'Write',
+    dpt: '1.001',
+    dpt_main: 1,
+    dpt_sub: 1,
+    dpt_name: 'Switch',
+    unit: null,
+    value_numeric: 1,
+    value_json: null,
+    value_formatted: 'On',
+    raw_data: '01',
+    raw_hex: '0x01',
+    ...overrides,
+  };
+}
+
+/** A TelegramEntry with the given timestamp and a distinguishing key. */
+export function makeEntry(timestamp: string, key = '1'): TelegramEntry {
+  return toEntry(
+    makeTelegram({
+      timestamp,
+      source_address: `1.2.${key}`,
+      target_address: `1/2/${key}`,
+    }),
+  );
+}
+
+/** Multiple entries with incremental timestamps, 1 second apart. */
+export function makeEntries(count: number, baseTime = '2024-01-01T10:00:00.000Z'): TelegramEntry[] {
+  const base = new Date(baseTime).getTime();
+  return Array.from({ length: count }, (_, i) =>
+    makeEntry(new Date(base + i * 1000).toISOString(), String(i)),
+  );
+}

--- a/frontend/src/utils/telegramId.test.ts
+++ b/frontend/src/utils/telegramId.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { telegramId, telegramTs, toEntry } from './telegramId';
+import { makeTelegram } from '../test/telegramFactory';
+
+describe('telegramId', () => {
+  it('derives a stable id from timestamp, addresses and payload', () => {
+    const t = makeTelegram();
+    expect(telegramId(t)).toBe('2024-01-01T10:00:00.000000Z|1.2.3|1/2/3|01');
+    expect(telegramId(t)).toBe(telegramId(makeTelegram()));
+  });
+
+  it('distinguishes telegrams differing only in payload at the same instant', () => {
+    const a = makeTelegram({ raw_data: '01' });
+    const b = makeTelegram({ raw_data: '00' });
+    expect(telegramId(a)).not.toBe(telegramId(b));
+  });
+
+  it('treats a missing payload as empty', () => {
+    const t = makeTelegram({ raw_data: null });
+    expect(telegramId(t)).toBe('2024-01-01T10:00:00.000000Z|1.2.3|1/2/3|');
+  });
+
+  it('parses the epoch-ms timestamp', () => {
+    const t = makeTelegram({ timestamp: '2024-01-01T00:00:01.000Z' });
+    expect(telegramTs(t)).toBe(Date.parse('2024-01-01T00:00:01.000Z'));
+  });
+
+  it('wraps a telegram into an entry', () => {
+    const t = makeTelegram();
+    const entry = toEntry(t);
+    expect(entry.telegram).toBe(t);
+    expect(entry.id).toBe(telegramId(t));
+    expect(entry.ts).toBe(telegramTs(t));
+  });
+});

--- a/frontend/src/utils/telegramId.ts
+++ b/frontend/src/utils/telegramId.ts
@@ -1,0 +1,30 @@
+import type { Telegram } from '../hooks/useWebSocket';
+
+/**
+ * A telegram wrapped with its client-side identity, as handled by the caching
+ * services (#246): a stable `id` for deduplication and the epoch-ms timestamp
+ * for chronological ordering and coverage bookkeeping.
+ */
+export interface TelegramEntry {
+  id: string;
+  /** Epoch milliseconds parsed from the telegram's ISO timestamp. */
+  ts: number;
+  telegram: Telegram;
+}
+
+/**
+ * Derives a stable client-side id — the backend does not expose one (#246).
+ * Timestamps carry microsecond precision, so collisions require two identical
+ * telegrams within the same microsecond; strictly finer than the previous
+ * timestamp-only dedup.
+ */
+export const telegramId = (t: Telegram): string =>
+  `${t.timestamp}|${t.source_address}|${t.target_address}|${t.raw_data ?? ''}`;
+
+export const telegramTs = (t: Telegram): number => new Date(t.timestamp).getTime();
+
+export const toEntry = (telegram: Telegram): TelegramEntry => ({
+  id: telegramId(telegram),
+  ts: telegramTs(telegram),
+  telegram,
+});


### PR DESCRIPTION
Second PR for #249 (implements the service layer of #246; design in `DESIGN_STATE_CACHING.md`, arriving via #256).

Ports the knx-frontend Group Monitor caching architecture, adapted to SpectrumKNX's `Telegram` type via a `TelegramEntry` wrapper (`{id, ts, telegram}`):

- **`services/telegram-buffer-service.ts`** — chronological in-memory ring buffer: fast-path append for live telegrams, deduplicating `merge()` for historical loads, overflow eviction, immutable `snapshot`.
- **`services/telegram-cache-service.ts`** — IndexedDB persistence via `idb-keyval` (new dependency), store `spectrum-knx-bus-monitor`, `MAX_CACHE_SIZE` 100k, `store`/`loadRange`/`loadAll`/`evictBefore`/`evictToSize`. Purely advisory — any failure degrades to a backend query.
- **`services/telegram-coverage-service.ts`** — covered-interval bookkeeping (`addCovered`, `gaps`, `trim`, `extendLive`/`closeLive`) plus guarded localStorage persistence helpers (`spectrum-knx-coverage`).
- **`utils/telegramId.ts`** — stable client-side id `timestamp|source|target|raw_data` (backend rows have no id); strictly finer than the existing timestamp-only dedup.

No app wiring yet — the `useTelegramCache` hook and App integration follow in the next PR, so this is a pure addition with zero behavior change.

68 new unit tests (ported from knx-frontend and extended: id derivation, coverage persistence round-trip, malformed-storage handling). `npm run build`, `lint`, and the full vitest suite (143 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)