### PR TITLE
Wire telegram caching into the Group Monitor with async history loads

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import { getCookie, setCookie } from './utils/cookies';
 import { useTheme } from './hooks/useTheme';
 import { apiUrl, wsUrl } from './utils/basePath';
 import { HistoryLoader } from './components/HistoryLoader';
+import { useTelegramCache } from './hooks/useTelegramCache';
+import { rangeToMs } from './utils/historyLoad';
 import { HistorySearch } from './components/HistorySearch';
 import { ImportExportView } from './components/ImportExportView';
 import { Visualizer } from './components/Visualizer';
@@ -188,11 +190,20 @@ function App() {
   const [selectedVisualizationTargets, setSelectedVisualizationTargets] = useState<string[]>(initialView?.plot ?? []);
 
   // ── Live State ──────────────────────────────────────────────────────────────
-  const [liveTelegrams, setLiveTelegrams] = useState<Telegram[]>([]);
+  // Buffer + IndexedDB cache + coverage bookkeeping (#246): cached telegrams
+  // reappear instantly after a reload and only the gaps are fetched (#211).
+  const {
+    telegrams: liveTelegrams,
+    addLive,
+    setConnected: setCacheConnected,
+    setPaused: setCachePaused,
+    pausedCount,
+    loadRange,
+    isLoading: isHistoryLoading,
+    loadError: historyLoadError,
+    clear: clearTelegrams,
+  } = useTelegramCache(loadLimit);
   const [isPaused, setIsPaused] = useState(false);
-  const PAUSE_BUFFER_CAP = 10000;
-  const bufferRef = useRef<Telegram[]>([]);
-  const [bufferedCount, setBufferedCount] = useState(0);
 
   // ── Rate Estimation ─────────────────────────────────────────────────────────
   const [busRate, setBusRate] = useState(0);
@@ -306,19 +317,10 @@ function App() {
       arrivalTimesRef.current.shift();
     }
 
-    if (!isPaused) {
-      setLiveTelegrams(prev => {
-        const next = [t, ...prev];
-        return next.length > loadLimit ? next.slice(0, loadLimit) : next;
-      });
-    } else {
-      bufferRef.current.push(t);
-      // Cap the pause buffer so a forgotten pause can't grow memory unbounded;
-      // the oldest telegrams are dropped first.
-      if (bufferRef.current.length > PAUSE_BUFFER_CAP) bufferRef.current.shift();
-      setBufferedCount(prev => prev + 1);
-    }
-  }, [isPaused, loadLimit]);
+    // The cache keeps ingesting while paused; only the snapshot is frozen, so
+    // nothing is lost and resume simply reveals what arrived in between.
+    addLive(t);
+  }, [addLive]);
 
   const handleConnectionState = useCallback((e: ConnectionStateEvent) => {
     // Flip the badge immediately, then refetch for authoritative state
@@ -338,6 +340,12 @@ function App() {
 
   const wsEndpoint = wsUrl('/ws/telegrams');
   const { isConnected } = useWebSocket(wsEndpoint, handleTelegram, handleConnectionState);
+
+  // Mirror the WS state into the cache so offline windows become coverage
+  // gaps that are automatically re-fetched on reconnect.
+  useEffect(() => {
+    setCacheConnected(isConnected);
+  }, [isConnected, setCacheConnected]);
 
   // ── Persist settings to cookies ─────────────────────────────────────────────
   useEffect(() => {
@@ -371,32 +379,13 @@ function App() {
 
   // ── Pause / Resume ──────────────────────────────────────────────────────────
   const togglePause = () => {
-    if (isPaused) {
-      // Detach the buffer before scheduling the merge: the state updater runs
-      // after this handler, so reading bufferRef.current inside it would see
-      // the already-cleared array and drop every buffered telegram (#196).
-      const buffered = bufferRef.current.reverse(); // arrival order → newest-first
-      bufferRef.current = [];
-      setBufferedCount(0);
-      setLiveTelegrams(prev => {
-        const next = [...buffered, ...prev];
-        return next.length > loadLimit ? next.slice(0, loadLimit) : next;
-      });
-    }
-    setIsPaused(!isPaused);
+    const next = !isPaused;
+    setCachePaused(next);
+    setIsPaused(next);
   };
 
   const toggleColumn = (col: string) =>
     setVisibleColumns(prev => ({ ...prev, [col]: !prev[col] }));
-
-  const handleHistoricalLoad = (newTelegrams: Telegram[]) => {
-    setLiveTelegrams(prev => {
-      const existingTs = new Set(prev.map(t => t.timestamp));
-      const deduped = newTelegrams.filter(t => !existingTs.has(t.timestamp));
-      const next = [...deduped, ...prev];
-      return next.length > loadLimit ? next.slice(0, loadLimit) : next;
-    });
-  };
 
   // ── Sorting ─────────────────────────────────────────────────────────────────
   const [sortConfig, setSortConfig] = useState<SortConfig>(readSortConfigCookie);
@@ -598,12 +587,26 @@ function App() {
                   </span>
                   {isPaused && (
                     <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: '#fbbf24' }}>
-                      Paused: <span style={{ fontWeight: 600 }}>{bufferedCount}</span>
+                      Paused: <span style={{ fontWeight: 600 }}>{pausedCount}</span>
                     </span>
                   )}
                   <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--text-dim)' }}>
                     WS: <span style={{ color: isConnected ? 'var(--success)' : 'var(--error)', fontWeight: 500 }}>{isConnected ? 'Active' : 'Offline'}</span>
                   </span>
+                  {/* Background history reads run without blocking the UI (#222) */}
+                  {isHistoryLoading && (
+                    <span style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.4rem', color: 'var(--accent-primary)' }}>
+                      <span className="chip-spinner" /> History: loading…
+                    </span>
+                  )}
+                  {!isHistoryLoading && historyLoadError && (
+                    <span
+                      title={historyLoadError}
+                      style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.35rem', color: 'var(--error)' }}
+                    >
+                      <AlertTriangle size={13} /> History: failed
+                    </span>
+                  )}
                   {filteredLiveTelegrams.length >= loadLimit && (
                     <span
                       style={{ fontSize: '0.75rem', display: 'flex', alignItems: 'center', gap: '0.35rem', color: '#fbbf24', cursor: 'pointer' }}
@@ -686,11 +689,16 @@ function App() {
                 <button className="icon-button" onClick={togglePause} title={isPaused ? 'Resume' : 'Pause'}>
                   {isPaused ? <Play size={18} fill="currentColor" /> : <Pause size={18} fill="currentColor" />}
                 </button>
-                <button className="icon-button" onClick={() => setIsHistoryLoaderOpen(true)} title="Load history">
+                <button
+                  className="icon-button"
+                  onClick={() => setIsHistoryLoaderOpen(true)}
+                  title={isHistoryLoading ? 'History read in progress…' : 'Load history'}
+                  style={{ color: isHistoryLoading ? 'var(--accent-primary)' : undefined }}
+                >
                   <Download size={18} />
                 </button>
                 <div style={{ width: 1, height: 18, background: 'var(--border-color)' }} />
-                <button className="icon-button" onClick={() => { setLiveTelegrams([]); bufferRef.current = []; setBufferedCount(0); }} title="Clear" style={{ color: 'var(--text-dim)' }}>
+                <button className="icon-button" onClick={() => { void clearTelegrams(); }} title="Clear (also wipes the local telegram cache)" style={{ color: 'var(--text-dim)' }}>
                   <Trash2 size={18} />
                 </button>
               </>
@@ -1026,7 +1034,12 @@ function App() {
       {isHistoryLoaderOpen && (
         <HistoryLoader
           onClose={() => setIsHistoryLoaderOpen(false)}
-          onLoad={handleHistoricalLoad}
+          onAsyncLoad={(range) => {
+            // Fire-and-forget: the modal closes and the header chip shows
+            // progress; cached sub-ranges appear instantly (#222).
+            const { startMs, endMs } = rangeToMs(range);
+            void loadRange(startMs, endMs);
+          }}
           limit={loadLimit}
           mode="monitor"
         />
@@ -1077,6 +1090,8 @@ function App() {
         .nav-item:hover { background: var(--bg-hover); color: var(--text-main); }
         .nav-item.active { background: rgba(99,102,241,0.1); color: var(--accent-primary); }
         .icon-button { background: transparent; border: none; cursor: pointer; color: var(--text-dim); transition: all 0.2s; }
+        .chip-spinner { width: 12px; height: 12px; border: 2px solid rgba(99,102,241,0.2); border-top-color: var(--accent-primary); border-radius: 50%; animation: chip-spin 0.8s linear infinite; display: inline-block; }
+        @keyframes chip-spin { to { transform: rotate(360deg); } }
         .icon-button:hover { color: var(--text-main); transform: scale(1.1); }
         .setting-item { display: flex; align-items: center; gap: 0.6rem; background: transparent; border: none; color: var(--text-main); cursor: pointer; width: 100%; padding: 0.35rem 0; text-align: left; }
         .checkbox.checked { background: var(--accent-primary); border-color: var(--accent-primary); }

--- a/frontend/src/components/HistoryLoader.tsx
+++ b/frontend/src/components/HistoryLoader.tsx
@@ -7,7 +7,10 @@ import { loadHistoryTelegrams, type HistoryMetadata, type LoadedRange } from '..
 
 interface HistoryLoaderProps {
   onClose: () => void;
-  onLoad: (telegrams: Telegram[], metadata?: HistoryMetadata, range?: LoadedRange) => void;
+  onLoad?: (telegrams: Telegram[], metadata?: HistoryMetadata, range?: LoadedRange) => void;
+  /** Fire-and-forget alternative to onLoad: the modal closes immediately and
+   * the caller loads the range in the background (Group Monitor, #222). */
+  onAsyncLoad?: (range: LoadedRange) => void;
   limit: number;
   /** 'monitor' = no date range pickers (Group Monitor); 'search' = full options (History Search) */
   mode?: 'monitor' | 'search';
@@ -27,7 +30,7 @@ const UNIT_TO_SECONDS: Record<Unit, number> = {
   days: 86400,
 };
 
-export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, limit, mode = 'search', filters, timeRange, onTimeRangeChange }) => {
+export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, onAsyncLoad, limit, mode = 'search', filters, timeRange, onTimeRangeChange }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<'idle' | 'loading' | 'success'>('idle');
@@ -74,6 +77,13 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
   };
 
   const doFetch = useCallback(async (range: LoadedRange) => {
+    if (onAsyncLoad) {
+      // Background mode: hand the range off and close — progress is shown in
+      // the caller's status area instead of blocking this modal (#222).
+      onAsyncLoad(range);
+      onClose();
+      return;
+    }
     setIsLoading(true);
     setError(null);
     setStatus('loading');
@@ -82,7 +92,7 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
       const { telegrams, metadata } = await loadHistoryTelegrams(range, limit, filters);
       setResultMeta(metadata);
       setStatus('success');
-      onLoad(telegrams, metadata, range);
+      onLoad?.(telegrams, metadata, range);
       setTimeout(onClose, 1500);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred';
@@ -91,7 +101,7 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, l
     } finally {
       setIsLoading(false);
     }
-  }, [filters, limit, onLoad, onClose]);
+  }, [filters, limit, onLoad, onAsyncLoad, onClose]);
 
   const handleLoadRelative = useCallback((seconds: number) => {
     doFetch({ kind: 'relative', seconds });

--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTelegramCache } from './useTelegramCache';
+import { makeTelegram } from '../test/telegramFactory';
+import { toEntry } from '../utils/telegramId';
+import { COVERAGE_STORAGE_KEY } from '../services/telegram-coverage-service';
+import type { Telegram } from './useWebSocket';
+
+// In-memory IDB stand-in shared with the cache service.
+const _idb = new Map<string, { ts: number; telegram: Telegram }>();
+
+vi.mock('idb-keyval', () => ({
+  createStore: () => 'mock-store',
+  setMany: async (pairs: [string, { ts: number; telegram: Telegram }][]) => {
+    for (const [k, v] of pairs) _idb.set(k, v);
+  },
+  entries: async () => Array.from(_idb.entries()),
+  delMany: async (keys: string[]) => {
+    for (const k of keys) _idb.delete(k);
+  },
+  clear: async () => _idb.clear(),
+}));
+
+/** Telegram with a distinct identity at the given epoch-ms timestamp. */
+const tg = (ts: number, key = String(ts)): Telegram =>
+  makeTelegram({
+    timestamp: new Date(ts).toISOString(),
+    source_address: `1.2.${key}`,
+  });
+
+const seedIdb = (telegrams: Telegram[]) => {
+  for (const t of telegrams) {
+    const e = toEntry(t);
+    _idb.set(e.id, { ts: e.ts, telegram: e.telegram });
+  }
+};
+
+interface MockResponse {
+  telegrams: Telegram[];
+  limitReached?: boolean;
+}
+
+let telegramResponses: MockResponse[];
+let fetchCalls: string[];
+
+const jsonRes = (body: unknown) =>
+  ({ ok: true, json: async () => body }) as Response;
+
+beforeEach(() => {
+  _idb.clear();
+  localStorage.clear();
+  telegramResponses = [];
+  fetchCalls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: RequestInfo | URL) => {
+      const u = String(url);
+      fetchCalls.push(u);
+      if (u.includes('/api/database')) {
+        return jsonRes({ retention_days: null });
+      }
+      const next = telegramResponses.shift() ?? { telegrams: [] };
+      return jsonRes({
+        telegrams: next.telegrams,
+        metadata: { limit_reached: next.limitReached ?? false },
+      });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Waits for the startup restore + gap fill to settle. */
+const settle = async (result: { current: { isLoading: boolean } }) => {
+  await waitFor(() => expect(result.current.isLoading).toBe(false));
+};
+
+describe('useTelegramCache', () => {
+  it('starts empty and fetches nothing without prior coverage or cache', async () => {
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    expect(result.current.telegrams).toEqual([]);
+    expect(fetchCalls.filter(u => u.includes('/api/telegrams'))).toEqual([]);
+  });
+
+  it('paints cached telegrams on startup and fetches only the gap up to now', async () => {
+    const t1 = tg(1000, 'a');
+    const t2 = tg(2000, 'b');
+    seedIdb([t1, t2]);
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1000, 2000]]));
+    const gapTelegram = tg(5000, 'c');
+    telegramResponses.push({ telegrams: [gapTelegram] });
+
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    // Newest first: gap fill result, then the cached entries.
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual([
+      '1.2.c',
+      '1.2.b',
+      '1.2.a',
+    ]);
+
+    const gapCall = fetchCalls.find(u => u.includes('/api/telegrams'));
+    expect(gapCall).toBeDefined();
+    // The covered range [1000, 2000] is not re-fetched: the gap starts after it.
+    const params = new URLSearchParams(gapCall!.split('?')[1]);
+    expect(Date.parse(params.get('start_time')!)).toBe(2001);
+  });
+
+  it('publishes live telegrams newest first', async () => {
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    act(() => {
+      result.current.addLive(tg(1000, 'a'));
+      result.current.addLive(tg(2000, 'b'));
+    });
+
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.b', '1.2.a']);
+  });
+
+  it('deduplicates a live telegram already delivered by a fetch', async () => {
+    const dup = tg(5000, 'dup');
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1000, 1000]]));
+    telegramResponses.push({ telegrams: [dup] });
+
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+    expect(result.current.telegrams).toHaveLength(1);
+
+    act(() => {
+      result.current.addLive(dup);
+    });
+    expect(result.current.telegrams).toHaveLength(1);
+  });
+
+  it('freezes the snapshot while paused and reveals everything on resume', async () => {
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    act(() => {
+      result.current.addLive(tg(1000, 'a'));
+    });
+    act(() => {
+      result.current.setPaused(true);
+    });
+    act(() => {
+      result.current.addLive(tg(2000, 'b'));
+      result.current.addLive(tg(3000, 'c'));
+    });
+
+    // Snapshot frozen, but ingestion keeps counting.
+    expect(result.current.telegrams).toHaveLength(1);
+    expect(result.current.pausedCount).toBe(2);
+
+    act(() => {
+      result.current.setPaused(false);
+    });
+    expect(result.current.telegrams).toHaveLength(3);
+    expect(result.current.pausedCount).toBe(0);
+  });
+
+  it('loadRange serves cache hits and fetches only the gaps', async () => {
+    const cached = tg(1500, 'cached');
+    seedIdb([cached]);
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1000, 2000]]));
+    // Startup gap [2001, now], then the explicit load's gap [0, 999].
+    telegramResponses.push({ telegrams: [] });
+    telegramResponses.push({ telegrams: [tg(500, 'older')] });
+
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    await act(async () => {
+      await result.current.loadRange(0, 2000);
+    });
+
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual([
+      '1.2.cached',
+      '1.2.older',
+    ]);
+    const loadCall = fetchCalls.filter(u => u.includes('/api/telegrams')).at(-1)!;
+    const params = new URLSearchParams(loadCall.split('?')[1]);
+    expect(Date.parse(params.get('start_time')!)).toBe(0);
+    expect(Date.parse(params.get('end_time')!)).toBe(999);
+  });
+
+  it('keeps the unfetched remainder uncovered when the limit is reached', async () => {
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[10_000, 10_000]]));
+    telegramResponses.push({ telegrams: [] }); // startup gap fill
+
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    // Only the newest row of [0, 9999] arrives.
+    telegramResponses.push({ telegrams: [tg(9000, 'partial')], limitReached: true });
+    await act(async () => {
+      await result.current.loadRange(0, 10_000);
+    });
+
+    const saved = JSON.parse(localStorage.getItem(COVERAGE_STORAGE_KEY)!) as [number, number][];
+    // [0, 8999] must remain a gap; coverage starts at the oldest returned row.
+    expect(saved.some(([s]) => s === 9000)).toBe(true);
+    expect(saved.some(([s]) => s === 0)).toBe(false);
+  });
+
+  it('records a load failure without breaking the buffer', async () => {
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    act(() => {
+      result.current.addLive(tg(1000, 'a'));
+    });
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500 }) as Response));
+
+    await act(async () => {
+      await result.current.loadRange(0, 500);
+    });
+
+    expect(result.current.loadError).toContain('500');
+    expect(result.current.telegrams).toHaveLength(1);
+  });
+
+  it('clear wipes buffer, persistent cache and coverage', async () => {
+    seedIdb([tg(1000, 'a')]);
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1000, 1000]]));
+    telegramResponses.push({ telegrams: [] });
+
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+    expect(result.current.telegrams).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.clear();
+    });
+
+    expect(result.current.telegrams).toEqual([]);
+    expect(_idb.size).toBe(0);
+    expect(JSON.parse(localStorage.getItem(COVERAGE_STORAGE_KEY)!)).toEqual([]);
+  });
+
+  it('evicts the oldest telegrams when shrinking the buffer limit', async () => {
+    const { result, rerender } = renderHook(({ limit }) => useTelegramCache(limit), {
+      initialProps: { limit: 3 },
+    });
+    await settle(result);
+
+    act(() => {
+      result.current.addLive(tg(1000, 'a'));
+      result.current.addLive(tg(2000, 'b'));
+      result.current.addLive(tg(3000, 'c'));
+    });
+    expect(result.current.telegrams).toHaveLength(3);
+
+    rerender({ limit: 2 });
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.c', '1.2.b']);
+  });
+});

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -1,0 +1,329 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import type { Telegram } from './useWebSocket';
+import { apiUrl } from '../utils/basePath';
+import { toEntry, type TelegramEntry } from '../utils/telegramId';
+import { TelegramBufferService } from '../services/telegram-buffer-service';
+import { TelegramCacheService, MAX_CACHE_SIZE } from '../services/telegram-cache-service';
+import {
+  TelegramCoverageService,
+  loadCoverageIntervals,
+  saveCoverageIntervals,
+} from '../services/telegram-coverage-service';
+
+/** How often the pending live batch is flushed to IndexedDB. */
+const FLUSH_INTERVAL_MS = 2000;
+/** Flush early once this many live telegrams are pending. */
+const FLUSH_BATCH_SIZE = 200;
+/** Cache size enforcement cadence (in flush ticks: 30 × 2 s = every minute). */
+const EVICT_EVERY_TICKS = 30;
+
+export interface TelegramCache {
+  /** Current buffer contents, newest first. Frozen while paused. */
+  telegrams: Telegram[];
+  /** Ingest a live telegram from the WebSocket. */
+  addLive: (t: Telegram) => void;
+  /** Reflect the WS connection so offline windows become coverage gaps. */
+  setConnected: (connected: boolean) => void;
+  /** Freeze/unfreeze the published snapshot; ingestion continues while paused. */
+  setPaused: (paused: boolean) => void;
+  /** Telegrams ingested since the snapshot was frozen. */
+  pausedCount: number;
+  /** Load a time range: cache hits appear immediately, gaps fetch in background. */
+  loadRange: (startMs: number, endMs: number) => Promise<void>;
+  /** True while any backend history fetch is in flight (#222). */
+  isLoading: boolean;
+  /** Last background load failure, cleared by the next successful load. */
+  loadError: string | null;
+  /** Wipe buffer, persistent cache and coverage. */
+  clear: () => Promise<void>;
+}
+
+interface FetchResult {
+  entries: TelegramEntry[];
+  limitReached: boolean;
+}
+
+/** Fetches a time range from the backend, newest first, unfiltered. */
+async function fetchRange(startMs: number, endMs: number, limit: number): Promise<FetchResult> {
+  const params = new URLSearchParams({
+    limit: String(limit),
+    start_time: new Date(startMs).toISOString(),
+    end_time: new Date(endMs).toISOString(),
+  });
+  const res = await fetch(apiUrl(`/api/telegrams?${params}`));
+  if (!res.ok) throw new Error(`Server error: ${res.status}`);
+  const data = await res.json();
+  return {
+    entries: ((data.telegrams || []) as Telegram[]).map(toEntry),
+    limitReached: data.metadata?.limit_reached ?? false,
+  };
+}
+
+/**
+ * Composes the buffer, IndexedDB cache and coverage services (#246) into the
+ * Group Monitor's telegram state:
+ *
+ * - On mount, cached telegrams paint immediately; only coverage gaps up to
+ *   "now" are fetched from the backend, in the background (#211, #222).
+ * - Live telegrams extend the open coverage interval and are flushed to
+ *   IndexedDB in batches.
+ * - Disconnect/close windows become gaps that are re-fetched on reconnect.
+ *
+ * The persistent cache is advisory: every IDB/backend failure degrades to
+ * live-only behavior identical to the pre-cache app.
+ */
+export function useTelegramCache(maxSize: number): TelegramCache {
+  const bufferRef = useRef<TelegramBufferService | null>(null);
+  bufferRef.current ??= new TelegramBufferService(maxSize);
+  const cacheRef = useRef<TelegramCacheService | null>(null);
+  cacheRef.current ??= new TelegramCacheService();
+  const coverageRef = useRef<TelegramCoverageService | null>(null);
+  coverageRef.current ??= new TelegramCoverageService();
+
+  /** Ids currently in the buffer — O(1) dedup for the live path. */
+  const idsRef = useRef<Set<string>>(new Set());
+  /** Live telegrams awaiting the next IDB flush. */
+  const pendingRef = useRef<TelegramEntry[]>([]);
+  const connectedRef = useRef(false);
+  const pausedRef = useRef(false);
+
+  const [telegrams, setTelegrams] = useState<Telegram[]>([]);
+  const [pausedCount, setPausedCount] = useState(0);
+  const [activeLoads, setActiveLoads] = useState(0);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  /** Publishes the buffer as a newest-first snapshot unless frozen by pause. */
+  const publish = useCallback(() => {
+    if (pausedRef.current) return;
+    setTelegrams(bufferRef.current!.snapshot.map(e => e.telegram).reverse());
+  }, []);
+
+  const trackRemoved = useCallback((removed: TelegramEntry[]) => {
+    for (const e of removed) idsRef.current.delete(e.id);
+  }, []);
+
+  /** Merges entries into the buffer; returns whether anything changed. */
+  const mergeIntoBuffer = useCallback(
+    (entries: TelegramEntry[]): boolean => {
+      const { added, removed } = bufferRef.current!.merge(entries);
+      for (const e of added) idsRef.current.add(e.id);
+      trackRemoved(removed);
+      return added.length > 0 || removed.length > 0;
+    },
+    [trackRemoved],
+  );
+
+  const saveCoverage = useCallback(() => {
+    saveCoverageIntervals(coverageRef.current!.covered);
+  }, []);
+
+  /** Fetches every uncovered sub-range of [startMs, endMs] from the backend. */
+  const fillGaps = useCallback(
+    async (startMs: number, endMs: number) => {
+      const coverage = coverageRef.current!;
+      for (const [gapStart, gapEnd] of coverage.gaps(startMs, endMs)) {
+        const { entries, limitReached } = await fetchRange(gapStart, gapEnd, maxSize);
+        if (mergeIntoBuffer(entries)) publish();
+        cacheRef.current!.store(entries).catch(() => {});
+        if (limitReached && entries.length > 0) {
+          // Only the newest `limit` rows arrived — the older remainder of the
+          // gap stays uncovered so a later load can still fetch it.
+          const oldestTs = entries[entries.length - 1].ts;
+          coverage.addCovered(oldestTs, gapEnd);
+        } else {
+          coverage.addCovered(gapStart, gapEnd);
+        }
+      }
+      saveCoverage();
+    },
+    [maxSize, mergeIntoBuffer, publish, saveCoverage],
+  );
+
+  /** Wraps a background load with the shared loading/error state. */
+  const runLoad = useCallback(
+    async (work: () => Promise<void>) => {
+      setActiveLoads(n => n + 1);
+      try {
+        await work();
+        setLoadError(null);
+      } catch (err) {
+        setLoadError(err instanceof Error ? err.message : 'History load failed');
+      } finally {
+        setActiveLoads(n => n - 1);
+      }
+    },
+    [],
+  );
+
+  const loadRange = useCallback(
+    (startMs: number, endMs: number) =>
+      runLoad(async () => {
+        // Cache hits paint immediately; the backend only fills the gaps.
+        const cached = await cacheRef.current!.loadRange(startMs, endMs).catch(() => []);
+        if (cached.length > 0 && mergeIntoBuffer(cached)) publish();
+        await fillGaps(startMs, endMs);
+      }),
+    [runLoad, mergeIntoBuffer, publish, fillGaps],
+  );
+
+  // ── Startup: restore cache + coverage, then fill gaps up to now ─────────────
+  useEffect(() => {
+    let cancelled = false;
+    void runLoad(async () => {
+      const coverage = coverageRef.current!;
+      for (const [s, e] of loadCoverageIntervals()) coverage.addCovered(s, e);
+
+      // Clamp everything to the backend's retention window when known.
+      try {
+        const res = await fetch(apiUrl('/api/database'));
+        const info = await res.json();
+        if (info.retention_days != null) {
+          const minMs = Date.now() - (info.retention_days + 1) * 86_400_000;
+          coverage.trim(minMs);
+          cacheRef.current!.evictBefore(minMs).catch(() => {});
+        }
+      } catch {
+        // Retention unknown — keep coverage as persisted.
+      }
+      if (cancelled) return;
+
+      const cached = await cacheRef.current!.loadAll().catch(() => [] as TelegramEntry[]);
+      if (cancelled) return;
+      if (cached.length > 0 && mergeIntoBuffer(cached)) publish();
+
+      // Fill everything between the oldest known data and now (#211): the
+      // dashboard-switch / closed-tab window arrives without user action.
+      const coveredStart = coverage.covered[0]?.[0];
+      const oldestCached = cached.length > 0 ? cached[cached.length - 1].ts : undefined;
+      const start = Math.min(coveredStart ?? Infinity, oldestCached ?? Infinity);
+      if (Number.isFinite(start)) {
+        await fillGaps(start, Date.now());
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Startup restore runs exactly once per mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── Periodic flush: IDB batch, coverage save, size eviction ─────────────────
+  useEffect(() => {
+    let ticks = 0;
+
+    const flush = () => {
+      const pending = pendingRef.current;
+      if (pending.length > 0) {
+        pendingRef.current = [];
+        cacheRef.current!.store(pending).catch(() => {});
+      }
+      // A quiet-but-connected stream still covers the elapsed time.
+      if (connectedRef.current) coverageRef.current!.extendLive(Date.now());
+      saveCoverage();
+    };
+
+    const interval = setInterval(() => {
+      flush();
+      if (++ticks % EVICT_EVERY_TICKS === 0) {
+        void cacheRef.current!
+          .evictToSize(MAX_CACHE_SIZE)
+          .then(oldestSurviving => {
+            if (oldestSurviving !== null) {
+              coverageRef.current!.trim(oldestSurviving);
+              saveCoverage();
+            }
+          })
+          .catch(() => {});
+      }
+    }, FLUSH_INTERVAL_MS);
+
+    window.addEventListener('pagehide', flush);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('pagehide', flush);
+      flush();
+    };
+  }, [saveCoverage]);
+
+  // Shrink/grow the buffer when the configured load limit changes.
+  useEffect(() => {
+    const removed = bufferRef.current!.setMaxSize(maxSize);
+    if (removed.length > 0) {
+      trackRemoved(removed);
+      publish();
+    }
+  }, [maxSize, trackRemoved, publish]);
+
+  const addLive = useCallback(
+    (t: Telegram) => {
+      const entry = toEntry(t);
+      // A gap fetch racing the live stream may already have delivered this row.
+      if (idsRef.current.has(entry.id)) return;
+      trackRemoved(bufferRef.current!.add(entry));
+      idsRef.current.add(entry.id);
+      coverageRef.current!.extendLive(entry.ts);
+      pendingRef.current.push(entry);
+      if (pendingRef.current.length >= FLUSH_BATCH_SIZE) {
+        const batch = pendingRef.current;
+        pendingRef.current = [];
+        cacheRef.current!.store(batch).catch(() => {});
+      }
+      if (pausedRef.current) setPausedCount(c => c + 1);
+      else publish();
+    },
+    [trackRemoved, publish],
+  );
+
+  const setConnected = useCallback(
+    (connected: boolean) => {
+      if (connectedRef.current === connected) return;
+      connectedRef.current = connected;
+      const coverage = coverageRef.current!;
+      if (connected) {
+        // Anchor the live interval at the (re)connect instant and pull in
+        // whatever happened while the stream was down.
+        const now = Date.now();
+        coverage.extendLive(now);
+        const coveredStart = coverage.covered[0]?.[0];
+        if (coveredStart !== undefined) void runLoad(() => fillGaps(coveredStart, now));
+      } else {
+        // Everything up to this instant was seen; afterwards is a gap.
+        coverage.extendLive(Date.now());
+        coverage.closeLive();
+        saveCoverage();
+      }
+    },
+    [runLoad, fillGaps, saveCoverage],
+  );
+
+  const setPaused = useCallback(
+    (paused: boolean) => {
+      pausedRef.current = paused;
+      setPausedCount(0);
+      // Resuming reveals everything ingested while frozen.
+      if (!paused) publish();
+    },
+    [publish],
+  );
+
+  const clear = useCallback(async () => {
+    trackRemoved(bufferRef.current!.clear());
+    pendingRef.current = [];
+    coverageRef.current!.clear();
+    saveCoverage();
+    setTelegrams([]);
+    await cacheRef.current!.clear().catch(() => {});
+  }, [trackRemoved, saveCoverage]);
+
+  return {
+    telegrams,
+    addLive,
+    setConnected,
+    setPaused,
+    pausedCount,
+    loadRange,
+    isLoading: activeLoads > 0,
+    loadError,
+    clear,
+  };
+}

--- a/frontend/src/utils/historyLoad.ts
+++ b/frontend/src/utils/historyLoad.ts
@@ -40,6 +40,17 @@ export function buildHistoryUrl(range: LoadedRange, limit: number): string {
   return url;
 }
 
+/** Resolves a LoadedRange to concrete epoch-ms bounds (open ends → 0 / now). */
+export function rangeToMs(range: LoadedRange, nowMs = Date.now()): { startMs: number; endMs: number } {
+  if (range.kind === 'relative') {
+    return { startMs: nowMs - range.seconds * 1000, endMs: nowMs };
+  }
+  return {
+    startMs: range.startTime ? Date.parse(range.startTime + ':00Z') : 0,
+    endMs: range.endTime ? Date.parse(range.endTime + ':00Z') : nowMs,
+  };
+}
+
 /**
  * Fetches history telegrams for a range with server-side filters applied.
  * OR source/target relation is handled with two queries merged client-side,


### PR DESCRIPTION
Third PR for #249 — closes #222 and delivers the telegram-restore half of #211. Stacked on #257 (service ports); design in `DESIGN_STATE_CACHING.md` (#256).

## `hooks/useTelegramCache.ts`

Composes the three ported services into the Group Monitor's telegram state:

- **Startup**: restores coverage intervals from localStorage, trims everything to the backend retention window (`/api/database`), paints all cached telegrams from IndexedDB immediately, then background-fetches only the gaps between the oldest known data and now. Switching back to the dashboard restores the buffer "up to now" without user action.
- **Live path**: telegrams extend the open coverage interval and are flushed to IndexedDB in batches (2 s / 200 telegrams); a quiet-but-connected stream still extends coverage on the flush tick. WS disconnects close the live interval; reconnects gap-fill the offline window automatically.
- **Partial loads**: when the backend reports `limit_reached`, only `[oldest returned row, gap end]` is marked covered, so the remainder stays fetchable.
- **Advisory storage**: every IDB/backend failure degrades to live-only behavior identical to the pre-cache app.

## Behavior changes

- **Pause is now a view freeze**: ingestion continues into buffer/cache while only the published snapshot is frozen. This retires the 10k drop-oldest pause buffer — "Zero Loss" now genuinely holds up to the load limit. The "Paused: N" counter still shows telegrams received since pausing.
- **Async history loads (#222)**: the Group Monitor's Load History modal closes immediately (`onAsyncLoad`); a spinner chip ("History: loading…") appears next to the WS badge, with an error chip on failure. Cache hits render before the backend responds. History Search is untouched and keeps its blocking modal with server-side filters.
- **Clear wipes the persistent cache** too — otherwise a reload would resurrect cleared telegrams (noted in the button tooltip).
- Live dedup is by `timestamp|source|target|payload` id instead of timestamp alone.

10 new hook tests (cache-first paint, gap computation from persisted coverage, live dedup against fetched rows, pause freeze/resume, partial-coverage on `limit_reached`, load-failure resilience, clear, buffer shrink). Full suite: 153 tests, build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)