### PR TITLE
Re-land: persist the Group Monitor workspace (#211)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,15 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useWebSocket, type Telegram, type ConnectionStateEvent } from './hooks/useWebSocket';
 import { parseViewUrl } from './utils/viewUrl';
+import {
+  isEmbedded,
+  loadWorkspace,
+  saveWorkspace,
+  parseMonitorSearch,
+  applyWorkspaceUrl,
+  type WorkspaceState,
+  type WorkspaceView,
+} from './utils/workspaceState';
 import { DeviceStatusOverlay } from './components/DeviceStatusOverlay';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigPref, writeSortConfigPref } from './utils/sortConfig';
@@ -137,18 +146,26 @@ function App() {
   const [theme, setTheme] = useTheme();
   // A view shared via URL (#150) starts on the History tab with its filters applied.
   const [initialView] = useState(() => parseViewUrl(window.location.search));
-  const [activeTab, setActiveTab] = useState<'live' | 'history' | 'import'>(initialView ? 'history' : 'live');
+  // Workspace restore (#211): a shared viz link wins; otherwise the HA
+  // dashboard iframe restores from localStorage and a regular tab from the
+  // view=monitor URL it maintains below.
+  const [initialWorkspace] = useState(() =>
+    initialView ? null : isEmbedded() ? loadWorkspace() : parseMonitorSearch(window.location.search),
+  );
+  const [activeTab, setActiveTab] = useState<'live' | 'history' | 'import'>(
+    initialView ? 'history' : initialWorkspace?.tab ?? 'live',
+  );
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [isFilterOpen, setIsFilterOpen] = useState(true);
-  const [isVisualizerOpen, setIsVisualizerOpen] = useState(false);
-  const [isLastSeenOpen, setIsLastSeenOpen] = useState(false);
-  const [lastSeenAddresses, setLastSeenAddresses] = useState<string[]>([]);
-  const [lastSeenMode, setLastSeenMode] = useState<'ga' | 'pa'>('ga');
-  const [isStatisticsOpen, setIsStatisticsOpen] = useState(false);
-  const [isBuildingOpen, setIsBuildingOpen] = useState(false);
+  const [isFilterOpen, setIsFilterOpen] = useState(initialWorkspace?.filterOpen ?? true);
+  const [isVisualizerOpen, setIsVisualizerOpen] = useState(initialWorkspace?.view === 'visualizer');
+  const [isLastSeenOpen, setIsLastSeenOpen] = useState(initialWorkspace?.view === 'lastseen');
+  const [lastSeenAddresses, setLastSeenAddresses] = useState<string[]>(initialWorkspace?.lastSeenAddresses ?? []);
+  const [lastSeenMode, setLastSeenMode] = useState<'ga' | 'pa'>(initialWorkspace?.lastSeenMode ?? 'ga');
+  const [isStatisticsOpen, setIsStatisticsOpen] = useState(initialWorkspace?.view === 'statistics');
+  const [isBuildingOpen, setIsBuildingOpen] = useState(initialWorkspace?.view === 'building');
   const [statusDevice, setStatusDevice] = useState<DeviceNode | null>(null);
   const [latestTelegram, setLatestTelegram] = useState<Telegram | null>(null);
-  const [isDatabaseOpen, setIsDatabaseOpen] = useState(false);
+  const [isDatabaseOpen, setIsDatabaseOpen] = useState(initialWorkspace?.view === 'database');
   const [isSendOpen, setIsSendOpen] = useState(false);
   const hasActiveView = isStatisticsOpen || isBuildingOpen || isLastSeenOpen || isDatabaseOpen;
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
@@ -187,7 +204,9 @@ function App() {
   const [rateMode, setRateMode] = useState<'s' | 'm' | 'h'>((getPref('rateMode') as 's' | 'm' | 'h') || 's');
 
   const [isHistoryLoaderOpen, setIsHistoryLoaderOpen] = useState(false);
-  const [selectedVisualizationTargets, setSelectedVisualizationTargets] = useState<string[]>(initialView?.plot ?? []);
+  const [selectedVisualizationTargets, setSelectedVisualizationTargets] = useState<string[]>(
+    initialView?.plot ?? initialWorkspace?.plot ?? [],
+  );
 
   // ── Live State ──────────────────────────────────────────────────────────────
   // Buffer + IndexedDB cache + coverage bookkeeping (#246): cached telegrams
@@ -211,7 +230,9 @@ function App() {
 
   // ── Filter State ────────────────────────────────────────────────────────────
   const [filterOptions, setFilterOptions] = useState<FilterOptions>(EMPTY_FILTER_OPTIONS);
-  const [activeFilters, setActiveFilters] = useState<ActiveFilters>(initialView?.filters ?? DEFAULT_FILTERS);
+  const [activeFilters, setActiveFilters] = useState<ActiveFilters>(
+    initialView?.filters ?? initialWorkspace?.filters ?? DEFAULT_FILTERS,
+  );
 
   const handleFiltersChange = useCallback((newFilters: ActiveFilters | ((prev: ActiveFilters) => ActiveFilters)) => {
     setActiveFilters((prevFilters) => {
@@ -353,6 +374,38 @@ function App() {
     setPref('visibleColumns', JSON.stringify(visibleColumns));
     setPref('rateMode', rateMode);
   }, [loadLimit, visibleColumns, rateMode]);
+
+  // ── Persist workspace (#211) ────────────────────────────────────────────────
+  const workspaceView: WorkspaceView = isVisualizerOpen
+    ? 'visualizer'
+    : isLastSeenOpen
+      ? 'lastseen'
+      : isStatisticsOpen
+        ? 'statistics'
+        : isBuildingOpen
+          ? 'building'
+          : isDatabaseOpen
+            ? 'database'
+            : 'none';
+  useEffect(() => {
+    // A shared viz link owns the URL for this session; don't overwrite it or
+    // persist its transient state as the workspace.
+    if (initialView) return;
+    const workspace: WorkspaceState = {
+      tab: activeTab,
+      view: workspaceView,
+      filterOpen: isFilterOpen,
+      filters: activeFilters,
+      plot: selectedVisualizationTargets,
+      lastSeenAddresses,
+      lastSeenMode,
+    };
+    const handle = setTimeout(() => {
+      if (isEmbedded()) saveWorkspace(workspace);
+      else applyWorkspaceUrl(workspace);
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [initialView, activeTab, workspaceView, isFilterOpen, activeFilters, selectedVisualizationTargets, lastSeenAddresses, lastSeenMode]);
 
   // ── Sync filter panel visibility with active views ───────────────────────────
   useEffect(() => {

--- a/frontend/src/utils/workspaceState.test.ts
+++ b/frontend/src/utils/workspaceState.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_WORKSPACE,
+  WORKSPACE_STORAGE_KEY,
+  saveWorkspace,
+  loadWorkspace,
+  buildMonitorSearch,
+  parseMonitorSearch,
+  applyWorkspaceUrl,
+  type WorkspaceState,
+} from './workspaceState';
+import { DEFAULT_FILTERS } from '../types/filters';
+
+const sampleWorkspace = (): WorkspaceState => ({
+  tab: 'live',
+  view: 'visualizer',
+  filterOpen: false,
+  filters: {
+    ...DEFAULT_FILTERS,
+    sources: ['1.2.3'],
+    targets: ['0/1/2', '0/1/3'],
+    types: ['Write'],
+    directions: ['Incoming'],
+    dpts: ['1.001', '9'],
+    deltaBeforeMs: 500,
+    deltaAfterMs: 1000,
+    sourceTargetRelation: 'OR',
+  },
+  plot: ['0/1/2'],
+  lastSeenAddresses: ['0/1/2'],
+  lastSeenMode: 'pa',
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  window.history.replaceState(null, '', '/');
+});
+
+describe('workspace localStorage persistence', () => {
+  it('round-trips a workspace', () => {
+    const ws = sampleWorkspace();
+    saveWorkspace(ws);
+    expect(loadWorkspace()).toEqual(ws);
+  });
+
+  it('returns null when nothing is stored', () => {
+    expect(loadWorkspace()).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    localStorage.setItem(WORKSPACE_STORAGE_KEY, '{broken');
+    expect(loadWorkspace()).toBeNull();
+  });
+
+  it('returns null on an unknown version', () => {
+    localStorage.setItem(WORKSPACE_STORAGE_KEY, JSON.stringify({ v: 99, tab: 'live' }));
+    expect(loadWorkspace()).toBeNull();
+  });
+
+  it('sanitizes invalid fields back to defaults', () => {
+    localStorage.setItem(
+      WORKSPACE_STORAGE_KEY,
+      JSON.stringify({
+        v: 1,
+        tab: 'bogus',
+        view: 'bogus',
+        filterOpen: 'yes',
+        filters: { sources: ['1.2.3', 42], dpts: ['1.001', 'nope'], deltaBeforeMs: -5, sourceTargetRelation: 'XOR' },
+        plot: 'not-an-array',
+        lastSeenMode: 'xy',
+      }),
+    );
+    const ws = loadWorkspace();
+    expect(ws).toEqual({
+      ...DEFAULT_WORKSPACE,
+      filters: { ...DEFAULT_FILTERS, sources: ['1.2.3'], dpts: ['1.001'] },
+    });
+  });
+});
+
+describe('monitor URL encoding', () => {
+  it('encodes a default workspace as an empty query', () => {
+    expect(buildMonitorSearch(DEFAULT_WORKSPACE)).toBe('');
+  });
+
+  it('round-trips a workspace through the URL', () => {
+    const ws = sampleWorkspace();
+    const search = buildMonitorSearch(ws);
+    expect(search).toContain('view=monitor');
+    expect(parseMonitorSearch('?' + search)).toEqual(ws);
+  });
+
+  it('encodes only non-default fields', () => {
+    const search = buildMonitorSearch({
+      ...DEFAULT_WORKSPACE,
+      filters: { ...DEFAULT_FILTERS, targets: ['0/1/2'] },
+    });
+    const p = new URLSearchParams(search);
+    expect([...p.keys()].sort()).toEqual(['tgt', 'view']);
+  });
+
+  it('returns null for non-monitor queries', () => {
+    expect(parseMonitorSearch('')).toBeNull();
+    expect(parseMonitorSearch('?view=viz&rel=1h')).toBeNull();
+    expect(parseMonitorSearch('?tab=history')).toBeNull();
+  });
+
+  it('sanitizes hostile URL values', () => {
+    const ws = parseMonitorSearch('?view=monitor&tab=evil&panel=evil&dpt=1.001,drop&lsm=zz');
+    expect(ws).toEqual({
+      ...DEFAULT_WORKSPACE,
+      filters: { ...DEFAULT_FILTERS, dpts: ['1.001'] },
+    });
+  });
+});
+
+describe('applyWorkspaceUrl', () => {
+  it('reflects a non-default workspace into the address bar', () => {
+    applyWorkspaceUrl({ ...DEFAULT_WORKSPACE, tab: 'history' });
+    expect(window.location.search).toContain('view=monitor');
+    expect(window.location.search).toContain('tab=history');
+  });
+
+  it('clears the query again for a default workspace', () => {
+    applyWorkspaceUrl({ ...DEFAULT_WORKSPACE, tab: 'history' });
+    applyWorkspaceUrl(DEFAULT_WORKSPACE);
+    expect(window.location.search).toBe('');
+  });
+});

--- a/frontend/src/utils/workspaceState.ts
+++ b/frontend/src/utils/workspaceState.ts
@@ -1,0 +1,180 @@
+import { DEFAULT_FILTERS, DIRECTIONS, type ActiveFilters } from '../types/filters';
+import { getBasePath } from './basePath';
+
+/**
+ * Group Monitor workspace persistence (#211).
+ *
+ * The workspace is the session state lost when the app is torn down: active
+ * tab, filters, open panel, visualization targets. Where it is persisted
+ * depends on how the app is hosted (#249):
+ *
+ * - Embedded (Home Assistant dashboard iframe): `localStorage`. HA recreates
+ *   the iframe with the original URL on every dashboard switch, so the URL
+ *   cannot carry state — the workspace is restored from storage instead.
+ * - Regular browser tab: the URL (`view=monitor` query), so reloads and
+ *   bookmarks restore the workspace and the address bar stays shareable.
+ *
+ * Durable UI *preferences* (theme, columns, sort, …) live in `utils/prefs.ts`
+ * and are deliberately not part of the workspace.
+ */
+
+export type WorkspaceTab = 'live' | 'history' | 'import';
+export type WorkspaceView = 'none' | 'visualizer' | 'lastseen' | 'statistics' | 'building' | 'database';
+
+export interface WorkspaceState {
+  tab: WorkspaceTab;
+  view: WorkspaceView;
+  filterOpen: boolean;
+  filters: ActiveFilters;
+  /** Group addresses selected for visualization. */
+  plot: string[];
+  lastSeenAddresses: string[];
+  lastSeenMode: 'ga' | 'pa';
+}
+
+export const DEFAULT_WORKSPACE: WorkspaceState = {
+  tab: 'live',
+  view: 'none',
+  filterOpen: true,
+  filters: DEFAULT_FILTERS,
+  plot: [],
+  lastSeenAddresses: [],
+  lastSeenMode: 'ga',
+};
+
+export const WORKSPACE_STORAGE_KEY = 'spectrum-knx-workspace';
+
+const TABS: WorkspaceTab[] = ['live', 'history', 'import'];
+const VIEWS: WorkspaceView[] = ['none', 'visualizer', 'lastseen', 'statistics', 'building', 'database'];
+
+/**
+ * Whether the app runs inside another page (Home Assistant dashboard iframe /
+ * ingress). Cross-origin access to `window.top` may throw — which itself
+ * proves we are framed.
+ */
+export function isEmbedded(): boolean {
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+}
+
+// ── localStorage (embedded mode) ─────────────────────────────────────────────
+
+interface StoredWorkspace extends WorkspaceState {
+  v: number;
+}
+
+export function saveWorkspace(state: WorkspaceState): void {
+  try {
+    const stored: StoredWorkspace = { v: 1, ...state };
+    localStorage.setItem(WORKSPACE_STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Storage unavailable — the workspace just won't survive the teardown.
+  }
+}
+
+export function loadWorkspace(): WorkspaceState | null {
+  try {
+    const raw = localStorage.getItem(WORKSPACE_STORAGE_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as Partial<StoredWorkspace>;
+    if (p.v !== 1) return null;
+    return sanitize(p);
+  } catch {
+    return null;
+  }
+}
+
+/** Validates a stored/parsed candidate field-by-field, defaulting the rest. */
+function sanitize(p: Partial<WorkspaceState>): WorkspaceState {
+  const strings = (v: unknown): string[] =>
+    Array.isArray(v) ? v.filter((x): x is string => typeof x === 'string') : [];
+  const f = (p.filters ?? {}) as Partial<ActiveFilters>;
+  return {
+    tab: TABS.includes(p.tab as WorkspaceTab) ? (p.tab as WorkspaceTab) : 'live',
+    view: VIEWS.includes(p.view as WorkspaceView) ? (p.view as WorkspaceView) : 'none',
+    filterOpen: typeof p.filterOpen === 'boolean' ? p.filterOpen : true,
+    filters: {
+      ...DEFAULT_FILTERS,
+      sources: strings(f.sources),
+      targets: strings(f.targets),
+      types: strings(f.types),
+      directions: strings(f.directions).filter(d => DIRECTIONS.includes(d)),
+      dpts: strings(f.dpts).filter(d => /^\d+(\.\d+)?$/.test(d)),
+      deltaBeforeMs: Math.max(0, Number(f.deltaBeforeMs) || 0),
+      deltaAfterMs: Math.max(0, Number(f.deltaAfterMs) || 0),
+      sourceTargetRelation: f.sourceTargetRelation === 'OR' ? 'OR' : 'AND',
+    },
+    plot: strings(p.plot),
+    lastSeenAddresses: strings(p.lastSeenAddresses),
+    lastSeenMode: p.lastSeenMode === 'pa' ? 'pa' : 'ga',
+  };
+}
+
+// ── URL (regular mode) ───────────────────────────────────────────────────────
+// Filter params reuse the share-link vocabulary from viewUrl.ts (#150) so the
+// two URL formats stay consistent.
+
+/** Builds the query string for a workspace; empty when everything is default. */
+export function buildMonitorSearch(state: WorkspaceState): string {
+  const p = new URLSearchParams();
+  if (state.tab !== 'live') p.set('tab', state.tab);
+  if (state.view !== 'none') p.set('panel', state.view);
+  if (!state.filterOpen) p.set('fp', '0');
+  const f = state.filters;
+  if (f.sources.length > 0) p.set('src', f.sources.join(','));
+  if (f.targets.length > 0) p.set('tgt', f.targets.join(','));
+  if (f.types.length > 0) p.set('type', f.types.join(','));
+  if (f.directions.length > 0) p.set('dir', f.directions.join(','));
+  if (f.dpts.length > 0) p.set('dpt', f.dpts.join(','));
+  if (f.deltaBeforeMs > 0) p.set('before', String(f.deltaBeforeMs));
+  if (f.deltaAfterMs > 0) p.set('after', String(f.deltaAfterMs));
+  if (f.sourceTargetRelation === 'OR') p.set('rel_st', 'OR');
+  if (state.plot.length > 0) p.set('plot', state.plot.join(','));
+  if (state.lastSeenAddresses.length > 0) p.set('ls', state.lastSeenAddresses.join(','));
+  if (state.lastSeenMode !== 'ga') p.set('lsm', state.lastSeenMode);
+  if ([...p.keys()].length === 0) return '';
+  p.set('view', 'monitor');
+  return p.toString();
+}
+
+const list = (v: string | null): string[] => (v ? v.split(',').filter(Boolean) : []);
+
+/** Parses a `view=monitor` workspace URL; null for any other query. */
+export function parseMonitorSearch(search: string): WorkspaceState | null {
+  const p = new URLSearchParams(search);
+  if (p.get('view') !== 'monitor') return null;
+  return sanitize({
+    tab: p.get('tab') as WorkspaceTab,
+    view: p.get('panel') as WorkspaceView,
+    filterOpen: p.get('fp') !== '0',
+    filters: {
+      ...DEFAULT_FILTERS,
+      sources: list(p.get('src')),
+      targets: list(p.get('tgt')),
+      types: list(p.get('type')),
+      directions: list(p.get('dir')),
+      dpts: list(p.get('dpt')),
+      deltaBeforeMs: Number(p.get('before')) || 0,
+      deltaAfterMs: Number(p.get('after')) || 0,
+      sourceTargetRelation: p.get('rel_st') === 'OR' ? 'OR' : 'AND',
+    },
+    plot: list(p.get('plot')),
+    lastSeenAddresses: list(p.get('ls')),
+    lastSeenMode: (p.get('lsm') as 'ga' | 'pa') ?? 'ga',
+  });
+}
+
+/** Reflects the workspace into the address bar without adding history entries. */
+export function applyWorkspaceUrl(state: WorkspaceState): void {
+  const search = buildMonitorSearch(state);
+  const url = `${getBasePath()}/${search ? '?' + search : ''}`;
+  try {
+    window.history.replaceState(null, '', url);
+  } catch {
+    // Sandboxed contexts may forbid history access — the workspace is simply
+    // not reflected.
+  }
+}


### PR DESCRIPTION
Re-lands #260, which was merged into the (already-merged) `feat/telegram-cache-hook-relanded` branch instead of main — same trap as #258, so the workspace persistence code is currently absent from main. This is the identical commit cherry-picked onto main; it applied cleanly and the full suite (173 tests) passes.

See #260 for the full description. Closes #211 (for real this time). Based directly on main — safe to merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)