### PR TITLE
Show the timestamp of the last value in the send-to-GA popover

### DIFF
--- a/frontend/src/components/SendToGaPopover.test.tsx
+++ b/frontend/src/components/SendToGaPopover.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { format } from 'date-fns';
 import { SendToGaPopover } from './SendToGaPopover';
 
 function mockFetch(routes: Record<string, unknown>) {
@@ -37,6 +38,11 @@ test('opens on click, shows the last value and sends a DPT-1 boolean', async () 
 
   // Last value loads and DPT-1 renders On/Off (no free-text field).
   await waitFor(() => expect(screen.getByText('Off')).toBeInTheDocument());
+
+  // Verify that the timestamp is also formatted and displayed.
+  const expectedTime = format(new Date('2026-07-17T09:00:00Z'), 'yyyy-MM-dd HH:mm:ss');
+  expect(screen.getByText(`(${expectedTime})`)).toBeInTheDocument();
+
   expect(screen.queryByPlaceholderText(/Value/)).not.toBeInTheDocument();
 
   fireEvent.click(screen.getByRole('button', { name: /^On$/ }));

--- a/frontend/src/components/SendToGaPopover.tsx
+++ b/frontend/src/components/SendToGaPopover.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Send, Radio, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { format } from 'date-fns';
 
 import { apiUrl } from '../utils/basePath';
 import { formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
@@ -164,6 +165,11 @@ export function SendToGaPopover({ address, name, dptMain, dptSub, title = 'Send 
           <div style={{ fontSize: '0.72rem', color: 'var(--text-dim)' }}>
             Last value:{' '}
             <span style={{ color: 'var(--text-main)', fontWeight: 600 }}>{last ? last.value : '—'}</span>
+            {last && (
+              <span style={{ marginLeft: '0.4rem', color: 'var(--text-dim)', fontSize: '0.68rem' }}>
+                ({format(new Date(last.at), 'yyyy-MM-dd HH:mm:ss')})
+              </span>
+            )}
           </div>
 
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', flexWrap: 'wrap' }}>


### PR DESCRIPTION
Ships the working-tree change Martin had staged for this: the send-to-GA popover now shows *when* the last value was received, rendered dimmed next to the value as `(yyyy-MM-dd HH:mm:ss)` in local time. Useful for judging whether the shown value is current or stale before writing — or whether to hit Read first.

Test extends the existing popover suite and formats its expectation through the same local-timezone conversion as the component, so it passes in any TZ. Only addition on top of the original diff: stripped a trailing-whitespace line.

Based directly on main. Full suite: 176 tests, build + lint clean.

Closes #255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)