### PR TITLE
Persist write-to-bus rows across panel visibility toggling

### DIFF
--- a/frontend/src/components/WriteToBusPanel.test.tsx
+++ b/frontend/src/components/WriteToBusPanel.test.tsx
@@ -98,6 +98,55 @@ test('picks up an already-running job on mount', async () => {
   await waitFor(() => expect(screen.getByText(/Cyclic send to 1\/2\/3/)).toBeInTheDocument());
 });
 
+// ── Row persistence across panel toggling (#254) ─────────────────────────────
+
+const ROWS_KEY = 'spectrumknx-write-panel-rows';
+
+test('restores persisted rows on mount (#254)', () => {
+  localStorage.setItem(ROWS_KEY, JSON.stringify([
+    { address: '1/2/3', dpt: '9.001', value: '21.5', delay: '', every: '' },
+    { address: '4/5/6', dpt: '', value: '1', delay: '2', every: '10' },
+  ]));
+
+  render(<WriteToBusPanel targets={[]} onClose={() => {}} />);
+
+  const gaInputs = screen.getAllByPlaceholderText(/Group address/);
+  expect(gaInputs).toHaveLength(2);
+  expect(gaInputs[0]).toHaveValue('1/2/3');
+  expect(gaInputs[1]).toHaveValue('4/5/6');
+  expect(screen.getAllByPlaceholderText(/Value/)[0]).toHaveValue('21.5');
+  expect(screen.getByDisplayValue('10')).toBeInTheDocument(); // "Every s" of row 2
+  expect(screen.getByText('DPT 9.001')).toBeInTheDocument();
+});
+
+test('persists row edits so toggling the panel keeps them (#254)', async () => {
+  const { unmount } = render(<WriteToBusPanel targets={[]} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '7/0/1' } });
+  fireEvent.change(screen.getByPlaceholderText(/Value/), { target: { value: '42' } });
+  fireEvent.change(screen.getByPlaceholderText('Delay s'), { target: { value: '3' } });
+
+  await waitFor(() => {
+    expect(JSON.parse(localStorage.getItem(ROWS_KEY)!)).toEqual([
+      { address: '7/0/1', dpt: '', value: '42', delay: '3', every: '' },
+    ]);
+  });
+
+  // Simulate the visibility toggle: unmount and mount a fresh panel.
+  unmount();
+  render(<WriteToBusPanel targets={[]} onClose={() => {}} />);
+  expect(screen.getByPlaceholderText(/Group address/)).toHaveValue('7/0/1');
+  expect(screen.getByPlaceholderText(/Value/)).toHaveValue('42');
+  expect(screen.getByPlaceholderText('Delay s')).toHaveValue('3');
+});
+
+test('falls back to a single empty row on malformed storage', () => {
+  localStorage.setItem(ROWS_KEY, '{broken');
+  render(<WriteToBusPanel targets={[]} onClose={() => {}} />);
+  const gaInputs = screen.getAllByPlaceholderText(/Group address/);
+  expect(gaInputs).toHaveLength(1);
+  expect(gaInputs[0]).toHaveValue('');
+});
+
 test('DPT-1 target renders On/Off and records the GA in recents', async () => {
   vi.stubGlobal('fetch', mockFetch({
     '/api/knx/send/scheduled/status': IDLE,

--- a/frontend/src/components/WriteToBusPanel.tsx
+++ b/frontend/src/components/WriteToBusPanel.tsx
@@ -41,6 +41,50 @@ const newRow = (): Row => ({
   id: `row-${rowSeq++}`, address: '', dpt: '', value: '', delay: '', every: '', busy: false, feedback: null,
 });
 
+// ── Row persistence (#254) ───────────────────────────────────────────────────
+// The panel unmounts when toggled off; without this every configured row would
+// be lost. Only the durable inputs are stored — busy/feedback are transient,
+// and scheduled jobs live server-side (re-attached via the status poll).
+
+const ROWS_STORAGE_KEY = 'spectrumknx-write-panel-rows';
+const MAX_STORED_ROWS = 20;
+
+type StoredRow = Pick<Row, 'address' | 'dpt' | 'value' | 'delay' | 'every'>;
+
+function loadStoredRows(): Row[] | null {
+  try {
+    const raw = localStorage.getItem(ROWS_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed) || parsed.length === 0) return null;
+    const str = (v: unknown) => (typeof v === 'string' ? v : '');
+    return parsed.slice(0, MAX_STORED_ROWS).map(p => {
+      const s = p as Partial<StoredRow> | null;
+      return {
+        ...newRow(),
+        address: str(s?.address),
+        dpt: str(s?.dpt),
+        value: str(s?.value),
+        delay: str(s?.delay),
+        every: str(s?.every),
+      };
+    });
+  } catch {
+    return null;
+  }
+}
+
+function saveRows(rows: Row[]): void {
+  try {
+    const stored: StoredRow[] = rows.map(({ address, dpt, value, delay, every }) => ({
+      address, dpt, value, delay, every,
+    }));
+    localStorage.setItem(ROWS_STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Storage unavailable — the rows just won't survive the next toggle.
+  }
+}
+
 /**
  * "Write to bus" panel: send to several group addresses from stacked rows,
  * each with its own GA/DPT/value/Write/Read and optional delay/cyclic
@@ -49,9 +93,11 @@ const newRow = (): Row => ({
  * The backend runs a single scheduled (delayed/cyclic) job at a time, so at
  * most one row can have an active timer; immediate writes/reads work on any
  * row regardless. Removing the row that owns the active job cancels it first.
+ *
+ * Rows persist to localStorage so toggling the panel keeps its state (#254).
  */
 export function WriteToBusPanel({ targets, onClose }: Props) {
-  const [rows, setRows] = useState<Row[]>(() => [newRow()]);
+  const [rows, setRows] = useState<Row[]>(() => loadStoredRows() ?? [newRow()]);
   const [recentGas, setRecentGas] = useState<string[]>(loadRecentGas);
   const [job, setJob] = useState<ScheduledSendStatus | null>(null);
   const pollRef = useRef<number | null>(null);
@@ -71,6 +117,10 @@ export function WriteToBusPanel({ targets, onClose }: Props) {
     return stopPolling;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    saveRows(rows);
+  }, [rows]);
 
   const updateRow = (id: string, patch: Partial<Row>) =>
     setRows(rs => rs.map(r => (r.id === id ? { ...r, ...patch } : r)));


### PR DESCRIPTION
Fixes the state loss from #254: the write-to-bus panel unmounts when toggled off, so every configured row (GA, DPT, value, delay, interval) was reinitialized empty on reopen.

- Rows persist to `localStorage["spectrumknx-write-panel-rows"]` (matching the existing `spectrumknx-recent-send-gas` naming) on every change and restore on mount, capped at 20 rows with field-by-field sanitization; malformed storage falls back to the single empty row.
- Only the durable inputs are stored — `busy`/`feedback` stay transient.
- Delayed/cyclic timers were never at risk: they run server-side and the panel already re-attaches to a running job via the status poll on mount (TabSel's concern from #214).

As a side effect, rows now also survive full page reloads and HA dashboard switches, consistent with the #211 workspace behavior.

Based directly on main. 3 new tests (restore on mount, persist-edit → unmount/remount round-trip, malformed-storage fallback). Full suite: 179 tests, build + lint clean.

Closes #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)