### PR TITLE
release: prepare v1.15.1 — bump knx-telegram-store to 0.10.2

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "asyncpg",
     "fastapi",
     "httpx",
-    "knx-telegram-store>=0.10.1",
+    "knx-telegram-store>=0.10.2",
     "pydantic",
     "python-dotenv",
     "python-multipart",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.10.1
+knx-telegram-store==0.10.2
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0

--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.1
+
+### Fixed
+
+- Bump knx-telegram-store to 0.10.2: the legacy-data probe run at startup no longer scans the whole telegrams table once recovery is recorded — store initialization time no longer grows with database size.
+
 ## 1.15.0
 
 ### Added

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "1.15.0"
+version: "1.15.1"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.15.1
+
+### Fixed
+
+- Bump knx-telegram-store to 0.10.2: the legacy-data probe run at startup no longer scans the whole telegrams table once recovery is recorded — store initialization time no longer grows with database size.
+
 ## 1.15.0
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.15.0"
+version: "1.15.1"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Patch release picking up knx-telegram-store 0.10.2: the legacy-data probe and backfill at startup no longer scan the whole telegrams table once recovery is recorded in `store_metadata`, so store initialization time no longer grows with database size.

- Bump `knx-telegram-store` to `>=0.10.2` (pyproject) / `==0.10.2` (requirements)
- Bump both add-on versions to 1.15.1 with changelog entries

Backend unit tests pass locally against 0.10.2 (172 passed, sqlite `DATABASE_URL` as in CI).

Library diff: https://github.com/XKNX/knx-telegram-store/compare/v0.10.1...v0.10.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)