### PR TITLE
Lower minimum Python to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # 3.13 is the minimum supported version (Debian 13, see PACKAGING.md),
+        # 3.12 is the minimum supported version (FreeBSD port, see issue #274),
+        # 3.13 is what the Debian package targets (Debian 13, see PACKAGING.md),
         # 3.14 is what the Docker image ships.
-        python-version: ['3.13', '3.14']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v7
 

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -33,6 +33,12 @@ unset — **both packages must set `KNX_PROJECT_PATH`** to a writable location.
 - [x] Add Python 3.13 to the CI test matrix so compatibility is enforced
       (`ci.yml` now tests 3.13 and 3.14).
 
+> The baseline was later lowered to 3.12 for the FreeBSD port
+> ([#274](https://github.com/martinhoefling/SpectrumKNX/issues/274)):
+> `requires-python = ">=3.12"`, ruff `target-version = "py312"`, and 3.12 in
+> the CI matrix. The Debian package is unaffected — it is built against
+> trixie's 3.13 and keeps `Depends: python3 (>= 3.13)`.
+
 ## Step 1 — Packaging metadata (`backend/pyproject.toml`)
 
 - [x] Add a `[project]` table: name `spectrum-knx`, `requires-python = ">=3.13"`,

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for installation and configuration of both.
 See [DEVELOPMENT.md](DEVELOPMENT.md) for local setup, [DEPLOYMENT.md](DEPLOYMENT.md) for production configuration, and the [Kubernetes templates](kubernetes/README.md) for cluster deployment.
 
 ## 🛠 Tech Stack
-- **Backend:** Python 3.13+, FastAPI, `xknx`, WebSocket Streaming
+- **Backend:** Python 3.12+, FastAPI, `xknx`, WebSocket Streaming
 - **Database:** PostgreSQL (with optional TimescaleDB acceleration), or SQLite (via `aiosqlite`)
 - **Frontend:** React, TypeScript, Vite, TanStack Table, uPlot
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 description = "A professional KNX bus monitor and analyzer"
 readme = "../README.md"
 license = "MIT"
-requires-python = ">=3.13"
+requires-python = ">=3.12"
 # Direct runtime dependencies. requirements.txt is the pinned lock (including
 # transitive deps) used by the Docker image and the HA add-on — keep both in
 # sync when adding a dependency.
@@ -36,7 +36,7 @@ dev = [
 
 [tool.ruff]
 # Target Python version (minimum supported, see requires-python)
-target-version = "py313"
+target-version = "py312"
 # Max line length for auto-format or other rules
 line-length = 120
 # Exclude common directories


### PR DESCRIPTION
Closes #274.

Requested for a FreeBSD port, where only Python 3.12 is available.

Verified on CPython 3.12.13:

- All pinned dependencies from `requirements.txt` install cleanly (xknx requires >=3.10, xknxproject >=3.9, knx-telegram-store >=3.12).
- The backend uses no 3.13-only syntax or stdlib features.
- The full backend test suite passes (172 tests) and ruff is clean with `target-version = "py312"`.

Changes:

- `backend/pyproject.toml`: `requires-python = ">=3.12"`, ruff target `py312` — this metadata gate was the only actual blocker.
- CI matrix now tests 3.12, 3.13, and 3.14 so the lower bound is enforced.
- README tech-stack line and a note in PACKAGING.md.

The Debian package is unaffected — it is built against trixie's 3.13 and keeps `Depends: python3 (>= 3.13)`. Docker image and HA add-on stay on 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)