### PR TITLE
Group monitor: stable zebra stripes, pause live-follow on row click

### DIFF
--- a/frontend/src/components/TelegramTable.test.tsx
+++ b/frontend/src/components/TelegramTable.test.tsx
@@ -1,0 +1,132 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import { expect, test, vi, beforeAll } from 'vitest';
+import { TelegramTable, type SortConfig } from './TelegramTable';
+import { makeTelegram } from '../test/telegramFactory';
+import type { Telegram } from '../hooks/useWebSocket';
+import { DEFAULT_FILTERS } from '../types/filters';
+
+// jsdom has no layout: give the virtualizer a viewport and rows a rect so it
+// renders items and the anchor logic finds rows.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    private cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe(el: Element) {
+      const size = { inlineSize: 1000, blockSize: el.classList.contains('log-row') ? 85 : 800 };
+      this.cb(
+        [{ target: el, contentRect: el.getBoundingClientRect(), borderBoxSize: [size], contentBoxSize: [size] } as unknown as ResizeObserverEntry],
+        this as unknown as ResizeObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  Element.prototype.getBoundingClientRect = () =>
+    ({ width: 1000, height: 800, top: 0, bottom: 800, left: 0, right: 1000, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+});
+
+const visibleColumns = {
+  time: true, delta: true, source: true, sourceName: true,
+  target: true, targetName: true, type: true, dpt: true, data: true, value: true,
+};
+
+const sortConfig: SortConfig = { key: 'timestamp', direction: 'desc' };
+
+/** `count` telegrams sorted newest-first, 1 s apart, ending at `newestOffsetS`. */
+const makeList = (count: number, newestOffsetS: number): Telegram[] => {
+  const base = new Date('2024-01-01T10:00:00.000Z').getTime();
+  return Array.from({ length: count }, (_, i) => {
+    const t = base + (newestOffsetS - i) * 1000;
+    return makeTelegram({ timestamp: new Date(t).toISOString(), raw_hex: `0x${newestOffsetS - i}` });
+  });
+};
+
+const renderTable = (telegrams: Telegram[]) =>
+  render(
+    <TelegramTable
+      telegrams={telegrams}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+const stripesByKey = (container: HTMLElement): Map<string, string> => {
+  const map = new Map<string, string>();
+  for (const row of container.querySelectorAll<HTMLElement>('.log-row')) {
+    map.set(row.getAttribute('data-akey')!, row.style.background);
+  }
+  return map;
+};
+
+test('zebra stripes stay with their telegram when new ones are prepended (#266)', () => {
+  const { container, rerender } = renderTable(makeList(6, 5));
+  const before = stripesByKey(container);
+  expect(before.size).toBeGreaterThan(2);
+
+  // One new telegram arrives at the live edge (top, newest-first).
+  rerender(
+    <TelegramTable
+      telegrams={makeList(7, 6)}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+  const after = stripesByKey(container);
+  for (const [key, background] of before) {
+    expect(after.get(key), `stripe of row ${key} must not change`).toBe(background);
+  }
+
+  // Adjacent rows still alternate.
+  const rows = [...container.querySelectorAll<HTMLElement>('.log-row')];
+  for (let i = 1; i < rows.length; i++) {
+    expect(rows[i].style.background).not.toBe(rows[i - 1].style.background);
+  }
+});
+
+test('clicking a row pauses live-following (#266)', () => {
+  const { container, rerender } = renderTable(makeList(6, 5));
+  fireEvent.click(container.querySelectorAll('.log-row')[2]);
+
+  rerender(
+    <TelegramTable
+      telegrams={makeList(7, 6)}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+  // Anchored away from the live edge: the jump-to-live pill appears.
+  expect(screen.getByText(/1 new telegram/)).toBeInTheDocument();
+});
+
+test('without a click the table keeps following the live edge', () => {
+  renderTable(makeList(6, 5));
+  const { rerender } = renderTable(makeList(6, 5));
+  rerender(
+    <TelegramTable
+      telegrams={makeList(7, 6)}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+  expect(screen.queryByText(/new telegram/)).not.toBeInTheDocument();
+});

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -194,6 +194,10 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   // from the scroll-container top. Captured from user scrolls only.
   const anchorRef = useRef<{ key: string; offset: number } | null>(null);
   const programmaticScrollRef = useRef(false);
+  // Zebra stripes must stay with a telegram, not with a row index (#266):
+  // prepends at the live edge shift every index by the number of new rows, so
+  // this offset accumulates those shifts and is added back to the index parity.
+  const [stripeOffset, setStripeOffset] = useState(0);
 
   // Suppress edge/anchor tracking for scrolls we cause ourselves. Auto-clears on
   // the next frame so a no-op programmatic scroll can't swallow a later real one.
@@ -247,6 +251,14 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     }
   };
 
+  // Clicking a row pauses live-following just like scrolling away (#266) — the
+  // row being read must not move. The jump-to-live pill is the way back.
+  const handleRowClick = () => {
+    if (!isTimeSort || !atEdgeRef.current) return;
+    atEdgeRef.current = false;
+    captureAnchor();
+  };
+
   const scrollToEdge = () => {
     markProgrammatic();
     virtualizer.scrollToOffset(liveEdge === 'top' ? 0 : virtualizer.getTotalSize());
@@ -278,6 +290,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   // Changing sort moves (or removes) the live edge — drop the anchor state.
   useEffect(() => {
     setNewSinceAnchor(0);
+    setStripeOffset(0);
     anchorRef.current = null;
     atEdgeRef.current = checkAtEdge();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -295,6 +308,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     const lastKey = rows.length > 0 ? anchorKey(rows[rows.length - 1]) : null;
     prevRowsRef.current = { firstKey, lastKey, len: rows.length };
 
+    if (rows.length === 0) setStripeOffset(0);
     if (!isTimeSort || prev.len === 0 || rows.length === 0) return;
 
     const edgeKey = liveEdge === 'top' ? firstKey : lastKey;
@@ -313,8 +327,16 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
       // Previous edge vanished: list replaced (clear / filter / history load).
       anchorRef.current = null;
       setNewSinceAnchor(0);
+      setStripeOffset(0);
       return;
     }
+
+    // Keep each row's stripe color across the update (#266). Existing rows
+    // shift down by `added` on top-prepends; with the buffer at capacity the
+    // asc view instead drops rows from the head, shifting indexes up.
+    const dropped = prev.len + added - rows.length;
+    const indexShift = liveEdge === 'top' ? added : -dropped;
+    setStripeOffset(o => (((o + indexShift) % 2) + 2) % 2);
 
     if (atEdgeRef.current) {
       scrollToEdge();
@@ -618,6 +640,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                   key={virtualRow.key}
                   data-index={virtualRow.index}
                   data-akey={anchorKey(t)}
+                  onClick={handleRowClick}
                   ref={virtualizer.measureElement}
                   style={{
                     position: 'absolute',
@@ -629,7 +652,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                     gridTemplateColumns: gridTemplate,
                     borderBottom: '1px solid var(--border-color)',
                     fontSize: '0.8125rem',
-                    background: virtualRow.index % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
+                    background: (virtualRow.index + stripeOffset) % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
                     alignItems: 'start',
                     minHeight: '60px' // Ensure a minimum touch/visual target
                   }}


### PR DESCRIPTION
Closes #266.

Two fixes to the group-monitor telegram list:

- **Stable zebra striping** — stripes were keyed to `virtualRow.index % 2`, so each telegram prepended at the live edge flipped every existing row between grey and white. The table now accumulates the index shift caused by live-edge prepends (and head-drops when the capped buffer is full in ascending sort) into a stripe offset, so a row keeps its color for as long as it is in the list. Sort changes and list replacements (clear, filter, history load) reset the offset.
- **Pause on row click** — clicking a row now stops live-following, the same as scrolling away: the clicked row is captured as the scroll anchor and stays put while new telegrams accumulate behind the existing jump-to-live pill.

Covered by new unit tests (stripe stability across prepends, pause-on-click, live-follow unaffected without a click). Full suite: 182 passed; lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)