### PR TITLE
Pan & zoom timeline: double-click a handle to snap to min/max

### DIFF
--- a/frontend/src/components/TimeBrush.test.tsx
+++ b/frontend/src/components/TimeBrush.test.tsx
@@ -56,3 +56,27 @@ test('renders TimeBrush, handles middle click and drags to pan', () => {
   // Release drag
   fireEvent.mouseUp(window);
 });
+
+test('double-clicking a handle snaps that limit to min/max (#267)', () => {
+  const onChangeMock = vi.fn();
+
+  const { container } = render(
+    <TimeBrush
+      minTime={minTime}
+      maxTime={maxTime}
+      value={initialVal}
+      onChange={onChangeMock}
+      telegrams={[]}
+    />
+  );
+
+  const [leftHandle, rightHandle] = container.querySelectorAll('div[style*="ew-resize"]');
+  expect(leftHandle).toBeTruthy();
+  expect(rightHandle).toBeTruthy();
+
+  fireEvent.doubleClick(leftHandle);
+  expect(onChangeMock).toHaveBeenLastCalledWith([minTime, initialVal[1]]);
+
+  fireEvent.doubleClick(rightHandle);
+  expect(onChangeMock).toHaveBeenLastCalledWith([initialVal[0], maxTime]);
+});

--- a/frontend/src/components/TimeBrush.tsx
+++ b/frontend/src/components/TimeBrush.tsx
@@ -186,6 +186,11 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
             e.stopPropagation();
             handleStartDrag('left', e.clientX);
           }}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            onChange([minTime, value[1]]);
+          }}
+          title="Drag to adjust · double-click to extend to the oldest data"
           style={{
             position: 'absolute',
             left: `calc(${leftPct}% - 5px)`,
@@ -217,6 +222,11 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
             e.stopPropagation();
             handleStartDrag('right', e.clientX);
           }}
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            onChange([value[0], maxTime]);
+          }}
+          title="Drag to adjust · double-click to extend to the newest data"
           style={{
             position: 'absolute',
             left: `calc(${rightPct}% - 5px)`,


### PR DESCRIPTION
Closes #267.

Double-clicking the left resize handle of the pan & zoom timeline sets the lower limit to the minimum available time; double-clicking the right handle sets the upper limit to the maximum — much quicker than dragging when "un-limiting" a zoomed view. The handles' tooltips document the gesture.

Covered by a unit test asserting both snaps; lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)