### PR TITLE
Filter panel: group the DPT filter by main data types

### DIFF
--- a/frontend/src/components/DptTypeTree.test.tsx
+++ b/frontend/src/components/DptTypeTree.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { DptTypeTree } from './DptTypeTree';
+import type { FilterOption } from '../types/filters';
+
+const ENTRIES: FilterOption[] = [
+  { main: 1, sub: 1, label: 'Switch' },
+  { main: 1, sub: 2, label: 'Boolean' },
+  { main: 9, sub: 1, label: 'Temperature (°C)' },
+  { main: 5, sub: 1, label: 'Percentage (0..100%)' },
+];
+
+const renderTree = (selected: string[], onChange = vi.fn(), searchQuery = '') => {
+  render(
+    <DptTypeTree
+      entries={ENTRIES}
+      selected={selected}
+      onChange={onChange}
+      mode="history"
+      searchQuery={searchQuery}
+    />,
+  );
+  return onChange;
+};
+
+test('groups DPTs by main type with width labels, sorted and collapsed (#273)', () => {
+  renderTree([]);
+
+  const groups = screen.getAllByText(/^DPT \d+$/).map(el => el.textContent);
+  expect(groups).toEqual(['DPT 1', 'DPT 5', 'DPT 9']);
+  expect(screen.getByText('1-bit')).toBeInTheDocument();
+  expect(screen.getByText('8-bit unsigned')).toBeInTheDocument();
+  expect(screen.getByText('2-byte float')).toBeInTheDocument();
+
+  // Collapsed by default: no subtype rows visible.
+  expect(screen.queryByText('Switch')).not.toBeInTheDocument();
+
+  // Expanding a group reveals its subtypes.
+  fireEvent.click(screen.getByText('DPT 1'));
+  expect(screen.getByText('Switch')).toBeInTheDocument();
+  expect(screen.getByText('Boolean')).toBeInTheDocument();
+  expect(screen.queryByText('Temperature (°C)')).not.toBeInTheDocument();
+});
+
+test('an active search expands the groups', () => {
+  renderTree([], vi.fn(), 'switch');
+  expect(screen.getByText('Switch')).toBeInTheDocument();
+});
+
+test('the group checkbox selects the bare main-type key', () => {
+  const onChange = vi.fn();
+  renderTree(['9.001'], onChange);
+
+  fireEvent.click(screen.getByRole('checkbox', { name: 'DPT 1' }));
+  expect(onChange).toHaveBeenCalledWith(['9.001', '1']);
+});
+
+test('a fully selected group shows a checked checkbox, a partial one mixed', () => {
+  renderTree(['1', '9.001']);
+  expect(screen.getByRole('checkbox', { name: 'DPT 1' })).toHaveAttribute('aria-checked', 'true');
+  expect(screen.getByRole('checkbox', { name: 'DPT 9' })).toHaveAttribute('aria-checked', 'true');
+  expect(screen.getByRole('checkbox', { name: 'DPT 5' })).toHaveAttribute('aria-checked', 'false');
+});
+
+test('a partially selected group shows a mixed checkbox', () => {
+  renderTree(['1.001']);
+  expect(screen.getByRole('checkbox', { name: 'DPT 1' })).toHaveAttribute('aria-checked', 'mixed');
+});
+
+test('unchecking a group removes its bare key and subtype keys', () => {
+  const onChange = vi.fn();
+  renderTree(['1', '1.002', '9.001'], onChange);
+  fireEvent.click(screen.getByRole('checkbox', { name: 'DPT 1' }));
+  expect(onChange).toHaveBeenCalledWith(['9.001']);
+});
+
+test('unchecking one subtype of a fully selected main type keeps the others', () => {
+  const onChange = vi.fn();
+  renderTree(['1'], onChange);
+
+  // Group is selected → it renders expanded; uncheck the "Switch" subtype.
+  fireEvent.click(screen.getByText('Switch'));
+  expect(onChange).toHaveBeenCalledWith(['1.002']);
+});
+
+test('toggling a subtype adds and removes its exact key', () => {
+  const onChange = vi.fn();
+  renderTree(['1.001'], onChange);
+
+  fireEvent.click(screen.getByText('Boolean'));
+  expect(onChange).toHaveBeenCalledWith(['1.001', '1.002']);
+});

--- a/frontend/src/components/DptTypeTree.tsx
+++ b/frontend/src/components/DptTypeTree.tsx
@@ -1,0 +1,192 @@
+import React, { useState, useMemo } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { dptKey, type FilterOption } from '../types/filters';
+import { dptWidthLabel } from '../utils/dpt';
+
+interface DptTypeTreeProps {
+  entries: FilterOption[];
+  /** Active DPT filter keys: "1.001" for one subtype, bare "1" for a whole main type. */
+  selected: string[];
+  onChange: (keys: string[]) => void;
+  counts?: Record<string, number>;
+  mode: 'live' | 'history';
+  searchQuery: string;
+}
+
+type CheckState = 'checked' | 'partial' | 'unchecked';
+
+const TriCheckbox: React.FC<{ state: CheckState; onClick: () => void; label: string }> = ({ state, onClick, label }) => (
+  <div
+    role="checkbox"
+    aria-checked={state === 'checked' ? true : state === 'partial' ? 'mixed' : false}
+    aria-label={label}
+    onClick={e => { e.stopPropagation(); onClick(); }}
+    style={{
+      width: 14, height: 14, flexShrink: 0, borderRadius: 3, cursor: 'pointer',
+      border: `1.5px solid ${state !== 'unchecked' ? 'var(--accent-primary)' : 'var(--border-color)'}`,
+      background: state === 'checked' ? 'var(--accent-primary)' : 'transparent',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      transition: 'all 0.15s',
+    }}
+  >
+    {state === 'checked' && (
+      <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+        <path d="M1.5 4L3.5 6L6.5 2" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    )}
+    {state === 'partial' && (
+      <div style={{ width: 6, height: 2, background: 'var(--accent-primary)', borderRadius: 1 }} />
+    )}
+  </div>
+);
+
+const CountBubble: React.FC<{ count: number }> = ({ count }) => (
+  <span style={{
+    fontSize: '0.65rem', fontWeight: 600, minWidth: '1.8rem', textAlign: 'center',
+    padding: '0.1rem 0.4rem', borderRadius: '999px', flexShrink: 0,
+    background: count > 0 ? 'rgba(99,102,241,0.15)' : 'var(--bg-tag)',
+    color: count > 0 ? 'var(--accent-primary)' : 'var(--text-dim)',
+    border: count > 0 ? '1px solid rgba(99,102,241,0.3)' : '1px solid var(--border-color)',
+  }}>
+    {count}
+  </span>
+);
+
+/**
+ * DPT filter as a tree of main data types (grouped by bit/byte width, #273).
+ * The group checkbox toggles the bare main-type key, which the filter logic
+ * (`matchesDpt`) already treats as "every subtype of this main type".
+ */
+export const DptTypeTree: React.FC<DptTypeTreeProps> = ({
+  entries, selected, onChange, counts, mode, searchQuery,
+}) => {
+  // Explicit user choice wins; otherwise groups with a selection (or an active
+  // search, whose matches would be invisible in collapsed groups) start open.
+  const [openState, setOpenState] = useState<Record<number, boolean>>({});
+
+  const groups = useMemo(() => {
+    const byMain = new Map<number, FilterOption[]>();
+    for (const e of entries) {
+      if (e.main == null) continue;
+      const list = byMain.get(e.main) ?? [];
+      list.push(e);
+      byMain.set(e.main, list);
+    }
+    return [...byMain.entries()]
+      .sort(([a], [b]) => a - b)
+      .map(([main, opts]) => ({
+        main,
+        options: opts.sort((a, b) => (a.sub ?? 0) - (b.sub ?? 0)),
+        childKeys: opts.map(o => dptKey(o.main!, o.sub)),
+      }));
+  }, [entries]);
+
+  const inGroup = (main: number, key: string) => key === `${main}` || key.startsWith(`${main}.`);
+
+  const groupState = (main: number, childKeys: string[]): CheckState => {
+    if (selected.includes(`${main}`)) return 'checked';
+    const picked = childKeys.filter(k => selected.includes(k)).length;
+    if (picked === 0) return 'unchecked';
+    return picked === childKeys.length ? 'checked' : 'partial';
+  };
+
+  const toggleGroup = (main: number, childKeys: string[]) => {
+    const rest = selected.filter(k => !inGroup(main, k));
+    onChange(groupState(main, childKeys) === 'checked' ? rest : [...rest, `${main}`]);
+  };
+
+  const toggleChild = (main: number, childKeys: string[], key: string) => {
+    if (selected.includes(`${main}`)) {
+      // The whole main type was selected — keep every other subtype selected.
+      onChange([
+        ...selected.filter(k => k !== `${main}`),
+        ...childKeys.filter(k => k !== key && !selected.includes(k)),
+      ]);
+    } else {
+      onChange(selected.includes(key) ? selected.filter(k => k !== key) : [...selected, key]);
+    }
+  };
+
+  const groupCount = (main: number): number =>
+    Object.entries(counts ?? {})
+      .filter(([k]) => inGroup(main, k))
+      .reduce((sum, [, c]) => sum + c, 0);
+
+  return (
+    <div>
+      {groups.map(({ main, options, childKeys }) => {
+        const state = groupState(main, childKeys);
+        const open = openState[main] ?? (searchQuery !== '' || state !== 'unchecked');
+        const width = dptWidthLabel(main);
+        return (
+          <div key={main}>
+            <div
+              onClick={() => setOpenState(prev => ({ ...prev, [main]: !open }))}
+              style={{
+                display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.3rem 0.25rem',
+                borderRadius: '5px', cursor: 'pointer', userSelect: 'none',
+                transition: 'background 0.15s',
+              }}
+              onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'var(--bg-hover)'; }}
+              onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+            >
+              {open ? (
+                <ChevronDown size={13} style={{ color: 'var(--text-dim)', flexShrink: 0 }} />
+              ) : (
+                <ChevronRight size={13} style={{ color: 'var(--text-dim)', flexShrink: 0 }} />
+              )}
+              <TriCheckbox state={state} onClick={() => toggleGroup(main, childKeys)} label={`DPT ${main}`} />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontSize: '0.8125rem', color: 'var(--text-main)', fontFamily: "'JetBrains Mono', monospace",
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>{`DPT ${main}`}</div>
+                {width && (
+                  <div style={{
+                    fontSize: '0.65rem', color: 'var(--text-dim)',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                  }}>{width}</div>
+                )}
+              </div>
+              {mode === 'live' && counts && <CountBubble count={groupCount(main)} />}
+            </div>
+
+            {open && options.map(o => {
+              const key = dptKey(o.main!, o.sub);
+              const checked = selected.includes(`${main}`) || selected.includes(key);
+              return (
+                <div
+                  key={key}
+                  onClick={() => toggleChild(main, childKeys, key)}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: '0.4rem',
+                    padding: '0.3rem 0.25rem', paddingLeft: '1.55rem',
+                    borderRadius: '5px', cursor: 'pointer', userSelect: 'none',
+                    transition: 'background 0.15s',
+                  }}
+                  onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'var(--bg-hover)'; }}
+                  onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent'; }}
+                >
+                  <TriCheckbox state={checked ? 'checked' : 'unchecked'} onClick={() => toggleChild(main, childKeys, key)} label={key} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div title={key} style={{
+                      fontSize: '0.8125rem', color: 'var(--text-main)', fontFamily: "'JetBrains Mono', monospace",
+                      overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                    }}>{key}</div>
+                    {o.label && o.label !== key && (
+                      <div title={o.label} style={{
+                        fontSize: '0.65rem', color: 'var(--text-dim)',
+                        overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                      }}>{o.label}</div>
+                    )}
+                  </div>
+                  {mode === 'live' && counts && <CountBubble count={counts[key] ?? 0} />}
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -10,6 +10,8 @@ import {
 } from '../types/filters';
 import { compareKnxAddress } from '../utils/knxAddress';
 import { KnxAddressTree } from './KnxAddressTree';
+import { DptTypeTree } from './DptTypeTree';
+import { dptWidthLabel, bareDptLabel } from '../utils/dpt';
 import { SendToGaPopover } from './SendToGaPopover';
 
 const rowActionBtnStyle: React.CSSProperties = {
@@ -227,11 +229,24 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
 
   const filteredDpts = useMemo(() =>
     options.dpts.filter(d =>
-      !q || d.label?.toLowerCase().includes(q)
+      !q
+      || d.label?.toLowerCase().includes(q)
+      || dptKey(d.main!, d.sub).includes(q)
+      || (d.main != null && dptWidthLabel(d.main).toLowerCase().includes(q))
     ), [options.dpts, q]);
 
   const toggle = <T extends string | number>(list: T[], value: T): T[] =>
     list.includes(value) ? list.filter(v => v !== value) : [...list, value];
+
+  // Live count for a DPT filter key; a bare main-type key ("1") aggregates
+  // every subtype count of that main type (#273).
+  const dptCount = (key: string): number => {
+    const c = counts?.dpts ?? {};
+    if (!/^\d+$/.test(key)) return c[key] ?? 0;
+    return Object.entries(c)
+      .filter(([k]) => k === key || k.startsWith(`${key}.`))
+      .reduce((sum, [, v]) => sum + v, 0);
+  };
 
   const update = (patch: Partial<ActiveFilters>) =>
     onFiltersChange({ ...activeFilters, ...patch });
@@ -375,13 +390,14 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
             />
           ))}
           {activeFilters.dpts.map(d => {
-            const label = options.dpts.find(opt => dptKey(opt.main!, opt.sub) === d)?.label;
+            const label = options.dpts.find(opt => dptKey(opt.main!, opt.sub) === d)?.label
+              ?? (/^\d+$/.test(d) ? bareDptLabel(Number(d)) : undefined);
             return (
               <OptionRow
                 key={`active-dpt-${d}`}
                 label={label || `DPT ${d}`}
                 checked={true}
-                count={mode === 'live' ? (counts?.dpts[d] ?? 0) : undefined}
+                count={mode === 'live' ? dptCount(d) : undefined}
                 onToggle={() => update({ dpts: activeFilters.dpts.filter(v => v !== d) })}
                 onRemove={() => update({ dpts: activeFilters.dpts.filter(v => v !== d) })}
               />
@@ -551,21 +567,17 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           </Section>
         )}
 
-        {/* DPT */}
+        {/* DPT — grouped by main data type / bit-byte width (#273) */}
         {filteredDpts.length > 0 && (
           <Section title="DPT" defaultOpen={false}>
-            {filteredDpts.map(d => {
-              const key = dptKey(d.main!, d.sub);
-              return (
-                <OptionRow
-                  key={key}
-                  label={d.label!}
-                  checked={activeFilters.dpts.includes(key)}
-                  count={mode === 'live' ? (counts?.dpts[key] ?? 0) : undefined}
-                  onToggle={() => update({ dpts: toggle(activeFilters.dpts, key) })}
-                />
-              );
-            })}
+            <DptTypeTree
+              entries={filteredDpts}
+              selected={activeFilters.dpts}
+              onChange={dpts => update({ dpts })}
+              counts={counts?.dpts}
+              mode={mode}
+              searchQuery={q}
+            />
           </Section>
         )}
 

--- a/frontend/src/utils/dpt.ts
+++ b/frontend/src/utils/dpt.ts
@@ -1,0 +1,47 @@
+/**
+ * Data width / kind of each DPT main type, following the KNX System
+ * Specification "Datapoint Types" main-type table (#273).
+ */
+const DPT_MAIN_WIDTHS: Record<number, string> = {
+  1: '1-bit',
+  2: '2-bit · 1-bit controlled',
+  3: '4-bit · 3-bit controlled',
+  4: '8-bit character',
+  5: '8-bit unsigned',
+  6: '8-bit signed',
+  7: '2-byte unsigned',
+  8: '2-byte signed',
+  9: '2-byte float',
+  10: '3-byte time',
+  11: '3-byte date',
+  12: '4-byte unsigned',
+  13: '4-byte signed',
+  14: '4-byte float',
+  15: '4-byte access data',
+  16: '14-byte string',
+  17: '8-bit scene number',
+  18: '8-bit scene control',
+  19: '8-byte date & time',
+  20: '8-bit enumeration',
+  21: '8-bit bit set',
+  22: '2-byte bit set',
+  23: '2-bit enumeration',
+  25: '2-nibble',
+  26: '8-bit scene info',
+  27: '4-byte bit set',
+  28: 'UTF-8 string',
+  29: '8-byte signed',
+  232: '3-byte RGB colour',
+  235: 'tariff & energy',
+  238: '8-bit scene',
+  251: '6-byte RGBW colour',
+};
+
+/** "1-bit" for main 1, '' for mains not in the spec table. */
+export const dptWidthLabel = (main: number): string => DPT_MAIN_WIDTHS[main] ?? '';
+
+/** Label for a bare main-type filter key ("1" = every 1.x subtype). */
+export const bareDptLabel = (main: number): string => {
+  const width = dptWidthLabel(main);
+  return `DPT ${main} · all${width ? ` ${width}` : ''} subtypes`;
+};


### PR DESCRIPTION
Closes #273.

The DPT filter is now a two-level tree instead of a flat list: main types — labelled with their bit/byte width per the KNX Datapoint Types specification (1-bit, 2-bit, 4-bit, 8-bit unsigned, 2-byte float, …) — containing the subtypes present in the project.

- The group checkbox selects the **bare main-type key** (`"1"`), which `matchesDpt` and the backend's `dpt_main` grammar already treat as "every 1.x subtype"; the active-filters list renders it as e.g. "DPT 1 · all 1-bit subtypes" with an aggregated live count.
- Unchecking one subtype of a fully selected main type expands the selection to the remaining subtypes.
- Tri-state group checkboxes (checked / mixed / unchecked) with proper ARIA roles, matching the KnxAddressTree look.
- Groups start collapsed; they open when they contain a selection or while a search is active. The options search also matches width labels ("2-byte") and numeric keys ("9.001").

Covered by new unit tests for grouping, expansion, and all selection semantics. Full suite: 188 passed; lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)