### PR TITLE
Telegram table: quick filter bar with per-column regex/literal filters

### DIFF
--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useEffect, useLayoutEffect, useState, useCallba
 import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
-import { ChevronUp, ChevronDown, Filter, LineChart, X, Clock } from 'lucide-react';
+import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock } from 'lucide-react';
 import { dptKey, type ActiveFilters } from '../types/filters';
 import { SendToGaPopover } from './SendToGaPopover';
 import { getPref, setPref } from '../utils/prefs';
@@ -88,6 +88,32 @@ const ROW_ESTIMATE = 85; // matches the virtualizer's estimateSize
 const anchorKey = (t: Telegram) =>
   `${t.timestamp}-${t.source_address}-${t.target_address}-${t.raw_hex ?? ''}`;
 
+// ── Quick filter bar (#271) ──────────────────────────────────────────────────
+
+/** Per-column text the quick filter matches against (addresses and names alike). */
+const quickFilterHaystack = (id: ColId, t: Telegram): string => {
+  switch (id) {
+    case 'time': return format(new Date(t.timestamp), 'yyyy-MM-dd HH:mm:ss.SS');
+    case 'delta': return ''; // derived from visible row order — nothing to filter
+    case 'source': return `${t.source_address} ${t.source_name ?? ''}`;
+    case 'target': return `${t.target_address} ${t.target_name ?? ''}`;
+    case 'type': return `${t.simplified_type || t.telegram_type} ${t.direction ?? ''}`;
+    case 'dpt': return `${t.dpt_name ?? ''} ${t.dpt_main != null ? dptKey(t.dpt_main, t.dpt_sub) : ''}`;
+    case 'value': return `${t.value_formatted ?? t.value_numeric ?? ''} ${t.unit ?? ''} ${t.raw_hex ?? ''}`;
+  }
+};
+
+/** Case-insensitive regex matcher; an invalid pattern degrades to a literal substring match. */
+const makeQuickMatcher = (pattern: string): ((s: string) => boolean) => {
+  try {
+    const re = new RegExp(pattern, 'i');
+    return s => re.test(s);
+  } catch {
+    const lower = pattern.toLowerCase();
+    return s => s.toLowerCase().includes(lower);
+  }
+};
+
 export const TelegramTable: React.FC<TelegramTableProps> = ({
   telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend
 }) => {
@@ -146,13 +172,36 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     });
   }, [persistWidths]);
 
+  // ── Quick filter bar (#271): per-column regex/literal filter on top of the
+  // complex filter. Expanding enables it, collapsing disables it; the toggle
+  // in the bar switches it without losing the patterns.
+  const [quickOpen, setQuickOpen] = useState(false);
+  const [quickEnabled, setQuickEnabled] = useState(false);
+  const [quickPatterns, setQuickPatterns] = useState<Partial<Record<ColId, string>>>({});
+
+  const toggleQuickOpen = () => {
+    setQuickOpen(open => {
+      setQuickEnabled(!open);
+      return !open;
+    });
+  };
+
+  const quickFiltered = useMemo(() => {
+    if (!quickOpen || !quickEnabled) return telegrams;
+    const matchers = Object.entries(quickPatterns)
+      .filter(([, p]) => p && p.trim() !== '')
+      .map(([id, p]) => [id, makeQuickMatcher(p!.trim())] as const);
+    if (matchers.length === 0) return telegrams;
+    return telegrams.filter(t => matchers.every(([id, m]) => m(quickFilterHaystack(id as ColId, t))));
+  }, [telegrams, quickOpen, quickEnabled, quickPatterns]);
+
   // Compute time deltas between consecutive rows (by visual order)
   const telegramRows = useMemo<TelegramRow[]>(() => {
-    return telegrams.map((t, idx) => {
+    return quickFiltered.map((t, idx) => {
       let deltaStr: string | null = null;
       if (idx > 0) {
         const curr = new Date(t.timestamp).getTime();
-        const prev = new Date(telegrams[idx - 1].timestamp).getTime();
+        const prev = new Date(quickFiltered[idx - 1].timestamp).getTime();
         const diffMs = Math.abs(curr - prev);
         const mm = String(Math.floor(diffMs / 60000)).padStart(2, '0');
         const ss = String(Math.floor((diffMs % 60000) / 1000)).padStart(2, '0');
@@ -161,7 +210,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
       }
       return { ...t, deltaStr };
     });
-  }, [telegrams]);
+  }, [quickFiltered]);
 
   const virtualizer = useVirtualizer({
     count: telegramRows.length,
@@ -550,7 +599,16 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
         }}
       >
         {visibleCols.map((c, i) => (
-          <div key={c.id} style={{ padding: cellPadding, position: 'relative' }}>
+          <div key={c.id} style={{ padding: cellPadding, position: 'relative', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+            {c.id === 'time' && (
+              <button
+                className={`quick-filter-bar-toggle ${quickOpen ? 'open' : ''}`}
+                onClick={toggleQuickOpen}
+                title={quickOpen ? 'Hide quick filter bar' : 'Show quick filter bar'}
+              >
+                <ListFilter size={13} />
+              </button>
+            )}
             {c.sortKey ? (
               <button className="sort-header" onClick={() => onSort(c.sortKey!)}>
                 {c.label} {renderSortArrow(c.sortKey)}
@@ -569,6 +627,45 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
           </div>
         ))}
       </div>
+
+      {/* Quick filter bar (#271) — one regex/literal input per visible column */}
+      {quickOpen && (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: gridTemplate,
+            background: 'var(--bg-subtle)',
+            borderBottom: '1px solid var(--border-color)',
+            flexShrink: 0,
+            paddingRight: '8px', // align with the header's scrollbar compensation
+            opacity: quickEnabled ? 1 : 0.5,
+          }}
+        >
+          {visibleCols.map(c => (
+            <div key={c.id} style={{ padding: '0.35rem 0.5rem', display: 'flex', alignItems: 'center', gap: '0.35rem', minWidth: 0 }}>
+              {c.id === 'time' && (
+                <button
+                  className={`quick-filter-bar-toggle ${quickEnabled ? 'open' : ''}`}
+                  onClick={() => setQuickEnabled(e => !e)}
+                  title={quickEnabled ? 'Disable quick filter (keeps patterns)' : 'Enable quick filter'}
+                >
+                  <Filter size={12} />
+                </button>
+              )}
+              {c.id !== 'delta' && (
+                <input
+                  className="quick-filter-bar-input"
+                  type="text"
+                  value={quickPatterns[c.id] ?? ''}
+                  placeholder="regex…"
+                  aria-label={`Quick filter ${c.label}`}
+                  onChange={e => setQuickPatterns(prev => ({ ...prev, [c.id]: e.target.value }))}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Body area — relative wrapper so the jump-to-live pill (#202) anchors
           below the header, not over it. */}
@@ -726,6 +823,47 @@ style.textContent = `
   .jump-to-live-pill:hover {
     filter: brightness(1.08);
     transform: translateX(-50%) scale(1.03);
+  }
+
+  .quick-filter-bar-toggle {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--text-dim);
+    padding: 0.15rem;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition: all 0.15s;
+  }
+
+  .quick-filter-bar-toggle:hover {
+    background: var(--bg-hover);
+    color: var(--accent-primary);
+  }
+
+  .quick-filter-bar-toggle.open {
+    color: var(--accent-primary);
+  }
+
+  .quick-filter-bar-input {
+    width: 100%;
+    min-width: 0;
+    background: var(--bg-tag);
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    padding: 0.25rem 0.45rem;
+    color: var(--text-main);
+    font-size: 0.72rem;
+    font-family: var(--font-mono, monospace);
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  .quick-filter-bar-input:focus {
+    border-color: var(--accent-primary);
   }
 
   .col-resize-handle {

--- a/frontend/src/components/TelegramTableQuickFilter.test.tsx
+++ b/frontend/src/components/TelegramTableQuickFilter.test.tsx
@@ -1,0 +1,113 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import { expect, test, vi, beforeAll } from 'vitest';
+import { TelegramTable, type SortConfig } from './TelegramTable';
+import { makeTelegram } from '../test/telegramFactory';
+import type { Telegram } from '../hooks/useWebSocket';
+import { DEFAULT_FILTERS } from '../types/filters';
+
+// jsdom has no layout: give the virtualizer a viewport so it renders rows.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    private cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe(el: Element) {
+      const size = { inlineSize: 1000, blockSize: el.classList.contains('log-row') ? 85 : 800 };
+      this.cb(
+        [{ target: el, contentRect: el.getBoundingClientRect(), borderBoxSize: [size], contentBoxSize: [size] } as unknown as ResizeObserverEntry],
+        this as unknown as ResizeObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  Element.prototype.getBoundingClientRect = () =>
+    ({ width: 1000, height: 800, top: 0, bottom: 800, left: 0, right: 1000, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+});
+
+const visibleColumns = {
+  time: true, delta: true, source: true, sourceName: true,
+  target: true, targetName: true, type: true, dpt: true, data: true, value: true,
+};
+
+const sortConfig: SortConfig = { key: 'timestamp', direction: 'desc' };
+
+const TELEGRAMS: Telegram[] = [
+  makeTelegram({ timestamp: '2024-01-01T10:00:03.000Z', target_address: '1/2/3', target_name: 'Licht Küche', raw_hex: '0x03' }),
+  makeTelegram({ timestamp: '2024-01-01T10:00:02.000Z', target_address: '1/2/4', target_name: 'Licht Flur', raw_hex: '0x02' }),
+  makeTelegram({ timestamp: '2024-01-01T10:00:01.000Z', target_address: '2/0/1', target_name: 'Jalousie Bad', raw_hex: '0x01' }),
+];
+
+const renderTable = () =>
+  render(
+    <TelegramTable
+      telegrams={TELEGRAMS}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+const rowCount = (container: HTMLElement) => container.querySelectorAll('.log-row').length;
+
+test('expanding the quick filter bar and typing filters the rows (#271)', () => {
+  const { container } = renderTable();
+  expect(rowCount(container)).toBe(3);
+  expect(screen.queryByLabelText('Quick filter TARGET')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  const input = screen.getByLabelText('Quick filter TARGET');
+
+  fireEvent.change(input, { target: { value: 'küche' } });
+  expect(rowCount(container)).toBe(1);
+
+  // Regex alternation across address and name.
+  fireEvent.change(input, { target: { value: '1/2/(3|4)' } });
+  expect(rowCount(container)).toBe(2);
+});
+
+test('an invalid regex falls back to a literal substring match', () => {
+  const { container } = renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+
+  // "(" alone is an invalid regex — must not crash, matches nothing literally…
+  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: '(' } });
+  expect(rowCount(container)).toBe(0);
+
+  // …and a literal fragment of a name still matches.
+  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: 'jalousie' } });
+  expect(rowCount(container)).toBe(1);
+});
+
+test('the toggle disables filtering without losing patterns; collapsing restores all rows', () => {
+  const { container } = renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: 'küche' } });
+  expect(rowCount(container)).toBe(1);
+
+  // Disable via the bar's toggle — patterns stay, rows come back.
+  fireEvent.click(screen.getByTitle('Disable quick filter (keeps patterns)'));
+  expect(rowCount(container)).toBe(3);
+  expect(screen.getByLabelText('Quick filter TARGET')).toHaveValue('küche');
+
+  // Re-enable — filtering resumes with the kept pattern.
+  fireEvent.click(screen.getByTitle('Enable quick filter'));
+  expect(rowCount(container)).toBe(1);
+
+  // Collapse — bar gone, all rows visible again.
+  fireEvent.click(screen.getByTitle('Hide quick filter bar'));
+  expect(screen.queryByLabelText('Quick filter TARGET')).not.toBeInTheDocument();
+  expect(rowCount(container)).toBe(3);
+});
+
+test('filters combine across columns (AND)', () => {
+  const { container } = renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: 'licht' } });
+  fireEvent.change(screen.getByLabelText('Quick filter VALUE'), { target: { value: '0x02' } });
+  expect(rowCount(container)).toBe(1);
+});


### PR DESCRIPTION
Closes #271.

An expand/collapse icon at the left of the table header toggles a quick filter row beneath the header — one text input per visible column, applied on top of any complex filter:

- Patterns are **case-insensitive regexes**; an invalid pattern (e.g. a lone `(`) degrades to a literal substring match instead of erroring.
- Each column matches its displayed values: source/target match address *and* name, DPT matches name and numeric key, value matches formatted value, unit and raw hex, time matches `yyyy-MM-dd HH:mm:ss.SS`. Multiple columns combine with AND. The Δt column has no input (it is derived from the visible row order and recomputes after filtering).
- **Expanding auto-enables** the filter and **collapsing disables it**, per the issue; the funnel toggle inside the bar disables/re-enables without losing the typed patterns (the bar dims while disabled).
- Implemented inside `TelegramTable`, so the live group monitor and the history view both get it.

Note: this touches the same file as #277 but disjoint regions; whichever merges second may need a trivial rebase.

Covered by new unit tests (filtering, regex + literal fallback, enable/disable/collapse semantics, AND across columns). Full suite: 186 passed; lint and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)