### PR TITLE
Build multi-arch Docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Set up QEMU (arm64 emulation)
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -40,6 +46,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

The GHCR image published by the release workflow was single-arch (linux/amd64). Running it on ARM64 hosts (Raspberry Pi 4/5) fails with:

```
The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8)
exec /usr/bin/sh: exec format error
```

`docker buildx imagetools inspect ghcr.io/martinhoefling/spectrumknx:latest` returns a single manifest rather than a manifest list.

## Root cause

The `build-and-push` job ran `docker/build-push-action` with no QEMU/Buildx setup and no `platforms:`, so it only built the runner's native platform (amd64). The `build-deb` job already emulates arm64 via QEMU — which is why the Debian packages are multi-arch but the Docker image was not.

## Fix

- Add `docker/setup-qemu-action` (arm64 emulation) and `docker/setup-buildx-action`.
- Set `platforms: linux/amd64,linux/arm64` on the build-push step.

Both base images (`node:26-alpine`, `python:3.14-slim`) are multi-arch, and every compiled Python dependency (cryptography, pydantic-core, asyncpg, greenlet, cffi, pyzipper) ships arm64 manylinux wheels, so the arm64 build uses prebuilt wheels rather than compiling under emulation.

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)