### PR TITLE
Sortable GA last-values table in building view (#268, #269)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1047,6 +1047,7 @@ function App() {
                     onLastSeen={handleQuickLastSeen}
                     onDeviceStatus={setStatusDevice}
                     writeEnabled={serverConfig?.status?.write_enabled}
+                    latestTelegram={latestTelegram}
                   />
                 ) : isDatabaseOpen ? (
                   <DatabaseOverlay onClose={() => setIsDatabaseOpen(false)} />

--- a/frontend/src/components/BuildingOverlay.tsx
+++ b/frontend/src/components/BuildingOverlay.tsx
@@ -5,6 +5,8 @@ import {
 import { apiUrl } from '../utils/basePath';
 import { useExpanded } from '../utils/buildingExpansion';
 import { SendToGaPopover } from './SendToGaPopover';
+import { GaValuesTable } from './GaValuesTable';
+import type { Telegram } from '../hooks/useWebSocket';
 
 // ── Types (mirror /api/building response) ──────────────────────────────────────
 
@@ -19,6 +21,7 @@ export interface Ko {
   text: string;
   function_text: string;
   dpts: { main: number; sub: number | null; name?: string | null }[];
+  flags?: { transmit?: boolean };
   group_addresses: GaRef[];
 }
 
@@ -76,6 +79,8 @@ interface BuildingOverlayProps {
   /** Open the live KO status view for a device (#153). */
   onDeviceStatus: (device: DeviceNode) => void;
   writeEnabled?: boolean;
+  /** Newest telegram from the live websocket feed; keeps expanded GA tables current. */
+  latestTelegram?: Telegram | null;
 }
 
 // ── Group-address collection helpers ─────────────────────────────────────────────
@@ -175,24 +180,32 @@ const Caret: React.FC<{ open: boolean; hasChildren: boolean }> = ({ open, hasChi
 
 const KoRow: React.FC<{
   ko: Ko;
+  koKey: string;
   depth: number;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
   writeEnabled?: boolean;
-}> = ({ ko, depth, onFilterGAs, onLastSeen, writeEnabled }) => {
+  latestTelegram?: Telegram | null;
+}> = ({ ko, koKey, depth, onFilterGAs, onLastSeen, writeEnabled, latestTelegram }) => {
+  const [open, toggle] = useExpanded(`ko:${koKey}`, false);
   const dpt = formatDpt(ko.dpts);
   const gaAddresses = ko.group_addresses.map(g => g.address);
+  const hasGAs = gaAddresses.length > 0;
+  // ETS lists the sending GA first among a transmitting object's links.
+  const sendingGA = ko.flags?.transmit && hasGAs ? ko.group_addresses[0].address : null;
   const nameText = ko.text || ko.name;
   const label = (nameText && ko.function_text && nameText !== ko.function_text)
     ? `${nameText} (${ko.function_text})`
     : (nameText || ko.function_text || `Object ${ko.number ?? ''}`);
   return (
+    <div>
     <div
-      style={{ ...rowStyle(depth) }}
+      style={{ ...rowStyle(depth), cursor: hasGAs ? 'pointer' : 'default' }}
+      onClick={() => hasGAs && toggle()}
       onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
       onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
     >
-      <Caret open={false} hasChildren={false} />
+      <Caret open={open} hasChildren={hasGAs} />
       {ko.number != null && (
         <span style={{
           fontFamily: "'JetBrains Mono', monospace", fontSize: '0.65rem', fontWeight: 600,
@@ -207,14 +220,23 @@ const KoRow: React.FC<{
           overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
         }}>{label}</div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem', marginTop: '0.15rem' }}>
-          {ko.group_addresses.map(ga => (
-            <span key={ga.address} title={ga.name || ga.address} style={{
-              fontFamily: "'JetBrains Mono', monospace", fontSize: '0.65rem',
-              padding: '0.05rem 0.3rem', borderRadius: '3px',
-              background: 'rgba(99,102,241,0.1)', color: 'var(--accent-primary)',
-              border: '1px solid rgba(99,102,241,0.25)',
-            }}>{ga.address}</span>
-          ))}
+          {ko.group_addresses.map(ga => {
+            const sending = ga.address === sendingGA;
+            return (
+              <span
+                key={ga.address}
+                title={`${ga.name || ga.address}${sending ? ' — sending group address' : ''}`}
+                style={{
+                  fontFamily: "'JetBrains Mono', monospace", fontSize: '0.65rem',
+                  padding: '0.05rem 0.3rem', borderRadius: '3px',
+                  background: sending ? 'rgba(99,102,241,0.22)' : 'rgba(99,102,241,0.1)',
+                  color: 'var(--accent-primary)',
+                  border: sending ? '1px solid rgba(99,102,241,0.6)' : '1px solid rgba(99,102,241,0.25)',
+                  fontWeight: sending ? 700 : 400,
+                }}
+              >{ga.address}</span>
+            );
+          })}
         </div>
       </div>
       {dpt && (
@@ -272,6 +294,20 @@ const KoRow: React.FC<{
         </>
       )}
     </div>
+      {open && hasGAs && (
+        <GaValuesTable
+          entries={ko.group_addresses.map(ga => ({
+            address: ga.address,
+            name: ga.name || '',
+            sending: ga.address === sendingGA,
+          }))}
+          depth={depth + 1}
+          latestTelegram={latestTelegram}
+          onFilterGAs={onFilterGAs}
+          onLastSeen={onLastSeen}
+        />
+      )}
+    </div>
   );
 };
 
@@ -286,7 +322,8 @@ const DeviceRow: React.FC<{
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
   onDeviceStatus: (device: DeviceNode) => void;
   writeEnabled?: boolean;
-}> = ({ device, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled }) => {
+  latestTelegram?: Telegram | null;
+}> = ({ device, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`dev:${device.address}`, false);
   const koCount = device.channels.reduce((s, c) => s + c.kos.length, 0) + device.kos.length;
   const hasChildren = koCount > 0;
@@ -366,11 +403,16 @@ const DeviceRow: React.FC<{
               <ChannelRow
                 key={ch.id} channel={ch} deviceAddress={device.address} visibleKos={visibleKos} depth={depth + 1}
                 query={query} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} writeEnabled={writeEnabled}
+                latestTelegram={latestTelegram}
               />
             );
           })}
           {sortKos(query ? device.kos.filter(k => koMatches(k, query)) : device.kos).map((ko, i) => (
-            <KoRow key={`${ko.number}-${i}`} ko={ko} depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} writeEnabled={writeEnabled} />
+            <KoRow
+              key={`${ko.number}-${i}`} ko={ko} koKey={`${device.address}:${ko.number}-${i}`}
+              depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
+            />
           ))}
         </div>
       )}
@@ -387,7 +429,8 @@ const ChannelRow: React.FC<{
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
   writeEnabled?: boolean;
-}> = ({ channel, deviceAddress, visibleKos, depth, query, onFilterGAs, onLastSeen, writeEnabled }) => {
+  latestTelegram?: Telegram | null;
+}> = ({ channel, deviceAddress, visibleKos, depth, query, onFilterGAs, onLastSeen, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`ch:${deviceAddress}:${channel.id}`, false);
   const effectiveOpen = open || !!query;
   const allGAs = useMemo(() => channelGAs(channel), [channel]);
@@ -420,7 +463,11 @@ const ChannelRow: React.FC<{
         )}
       </div>
       {effectiveOpen && visibleKos.map((ko, i) => (
-        <KoRow key={`${ko.number}-${i}`} ko={ko} depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} writeEnabled={writeEnabled} />
+        <KoRow
+          key={`${ko.number}-${i}`} ko={ko} koKey={`${deviceAddress}:${channel.id}:${ko.number}-${i}`}
+          depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+          writeEnabled={writeEnabled} latestTelegram={latestTelegram}
+        />
       ))}
     </div>
   );
@@ -428,72 +475,14 @@ const ChannelRow: React.FC<{
 
 // ── Function nodes ──────────────────────────────────────────────────────────────
 
-const FunctionGaRow: React.FC<{
-  ga: FunctionGA;
-  depth: number;
-  onFilterGAs: (addresses: string[]) => void;
-  onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
-}> = ({ ga, depth, onFilterGAs, onLastSeen }) => {
-  return (
-    <div
-      style={{ ...rowStyle(depth) }}
-      onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
-      onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
-    >
-      <Caret open={false} hasChildren={false} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.4rem' }}>
-          <span style={{
-            fontFamily: "'JetBrains Mono', monospace", fontSize: '0.75rem',
-            padding: '0.05rem 0.3rem', borderRadius: '3px',
-            background: 'rgba(99,102,241,0.1)', color: 'var(--accent-primary)',
-            border: '1px solid rgba(99,102,241,0.25)',
-          }}>{ga.address}</span>
-          {ga.role && (
-            <span style={{
-              fontSize: '0.62rem', fontWeight: 600, color: 'var(--text-dim)',
-              textTransform: 'uppercase', background: 'var(--bg-tag)',
-              padding: '0.05rem 0.25rem', borderRadius: '3px'
-            }}>{ga.role}</span>
-          )}
-        </div>
-        {ga.name && (
-          <div title={ga.name} style={{
-            fontSize: '0.78rem', color: 'var(--text-dim)',
-            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-            marginTop: '0.15rem'
-          }}>{ga.name}</div>
-        )}
-      </div>
-      <button
-        style={iconBtnStyle}
-        title="Filter by this group address"
-        onClick={e => { e.stopPropagation(); onFilterGAs([ga.address]); }}
-        onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
-        onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
-      >
-        <Filter size={12} />
-      </button>
-      <button
-        style={iconBtnStyle}
-        title="Show last seen values"
-        onClick={e => { e.stopPropagation(); onLastSeen([ga.address], 'ga'); }}
-        onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
-        onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
-      >
-        <Clock size={12} />
-      </button>
-    </div>
-  );
-};
-
 const FunctionRow: React.FC<{
   func: FunctionNode;
   depth: number;
   query: string;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
-}> = ({ func, depth, query, onFilterGAs, onLastSeen }) => {
+  latestTelegram?: Telegram | null;
+}> = ({ func, depth, query, onFilterGAs, onLastSeen, latestTelegram }) => {
   const [open, toggle] = useExpanded(`func:${func.id}`, false);
   const effectiveOpen = open || !!query;
   const allGAs = useMemo(() => func.group_addresses.map(g => g.address), [func]);
@@ -545,9 +534,19 @@ const FunctionRow: React.FC<{
           </>
         )}
       </div>
-      {effectiveOpen && func.group_addresses.map((ga, i) => (
-        <FunctionGaRow key={`${ga.address}-${i}`} ga={ga} depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} />
-      ))}
+      {effectiveOpen && func.group_addresses.length > 0 && (
+        <GaValuesTable
+          entries={func.group_addresses.map(ga => ({
+            address: ga.address,
+            name: ga.name || '',
+            role: ga.role || undefined,
+          }))}
+          depth={depth + 1}
+          latestTelegram={latestTelegram}
+          onFilterGAs={onFilterGAs}
+          onLastSeen={onLastSeen}
+        />
+      )}
     </div>
   );
 };
@@ -564,7 +563,8 @@ const SpaceRow: React.FC<{
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
   onDeviceStatus: (device: DeviceNode) => void;
   writeEnabled?: boolean;
-}> = ({ space, path, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled }) => {
+  latestTelegram?: Telegram | null;
+}> = ({ space, path, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`space:${path}`, depth < 2);
   if (query && !spaceMatches(space, query)) return null;
   const effectiveOpen = open || !!query;
@@ -597,20 +597,20 @@ const SpaceRow: React.FC<{
             <SpaceRow
               key={`${sub.name}-${i}`} space={sub} path={`${path}/${sub.type}:${sub.name}#${i}`} depth={depth + 1} query={query}
               onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-              writeEnabled={writeEnabled}
+              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
           {visibleFunctions.map((func, i) => (
             <FunctionRow
               key={`${func.id}-${i}`} func={func} depth={depth + 1} query={query}
-              onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+              onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} latestTelegram={latestTelegram}
             />
           ))}
           {visibleDevices.map(device => (
             <DeviceRow
               key={device.address} device={device} depth={depth + 1} query={query}
               onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-              writeEnabled={writeEnabled}
+              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
         </div>
@@ -622,7 +622,7 @@ const SpaceRow: React.FC<{
 // ── Main overlay ────────────────────────────────────────────────────────────────
 
 export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
-  onClose, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled,
+  onClose, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled, latestTelegram,
 }) => {
   const [data, setData] = useState<BuildingData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -697,7 +697,7 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
             <SpaceRow
               key={`${space.name}-${i}`} space={space} path={`${space.type}:${space.name}#${i}`} depth={0} query={query}
               onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-              writeEnabled={writeEnabled}
+              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
 
@@ -710,7 +710,7 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
                 <DeviceRow
                   key={device.address} device={device} depth={1} query={query}
                   onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-                  writeEnabled={writeEnabled}
+                  writeEnabled={writeEnabled} latestTelegram={latestTelegram}
                 />
               ))}
             </div>

--- a/frontend/src/components/GaValuesTable.test.tsx
+++ b/frontend/src/components/GaValuesTable.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { GaValuesTable, type GaTableEntry } from './GaValuesTable';
+import type { Telegram } from '../hooks/useWebSocket';
+
+const ENTRIES: GaTableEntry[] = [
+  { address: '1/2/3', name: 'Kitchen Light', sending: true },
+  { address: '1/2/10', name: 'Kitchen Status' },
+];
+
+function telegram(target: string, value: string): Telegram {
+  return {
+    timestamp: new Date().toISOString(),
+    source_address: '1.1.9',
+    source_name: 'Push Button',
+    target_address: target,
+    telegram_type: 'GroupValueWrite',
+    dpt: '1.001',
+    dpt_main: 1,
+    dpt_sub: 1,
+    dpt_name: '1.001 - Switch',
+    value_numeric: 1,
+    value_json: null,
+    value_formatted: value,
+    raw_data: '01',
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test('fetches last values for its addresses and marks never-seen GAs', async () => {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    expect(url).toContain('/api/telegrams/last');
+    expect(decodeURIComponent(url)).toContain('1/2/3,1/2/10');
+    return { ok: true, json: async () => ({ telegrams: [telegram('1/2/3', 'On')] }) } as Response;
+  }));
+
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+
+  await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
+  expect(screen.getByText('never seen')).toBeInTheDocument();
+});
+
+test('updates a value live from the websocket feed and ignores unrelated GAs', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => (
+    { ok: true, json: async () => ({ telegrams: [telegram('1/2/3', 'On')] }) } as Response
+  )));
+
+  const { rerender } = render(
+    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />
+  );
+  await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
+  expect(screen.getByText('never seen')).toBeInTheDocument();
+
+  rerender(
+    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('1/2/10', 'Off')} onFilterGAs={() => {}} onLastSeen={() => {}} />
+  );
+  await waitFor(() => expect(screen.getByText('Off')).toBeInTheDocument());
+  expect(screen.queryByText('never seen')).not.toBeInTheDocument();
+
+  rerender(
+    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('9/9/9', 'Ignored')} onFilterGAs={() => {}} onLastSeen={() => {}} />
+  );
+  expect(screen.queryByText('Ignored')).not.toBeInTheDocument();
+});
+
+test('sorts by group address ascending, descending, then back to ETS order', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
+
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+  await waitFor(() => expect(screen.getByText('1/2/3')).toBeInTheDocument());
+
+  const gaCell = (row: HTMLElement) => within(row).getAllByRole('cell')[0].textContent;
+  const dataRows = () => screen.getAllByRole('row').slice(1); // drop header
+
+  // ETS order: 1/2/3 (sending) first as provided
+  expect(gaCell(dataRows()[0])).toContain('1/2/3');
+
+  const gaHeader = screen.getByText('GA');
+  // asc: numeric GA order → 1/2/3 before 1/2/10
+  fireEvent.click(gaHeader);
+  expect(gaCell(dataRows()[0])).toContain('1/2/3');
+  // desc: 1/2/10 before 1/2/3
+  fireEvent.click(gaHeader);
+  expect(gaCell(dataRows()[0])).toContain('1/2/10');
+  // third click restores original ETS order
+  fireEvent.click(gaHeader);
+  expect(gaCell(dataRows()[0])).toContain('1/2/3');
+});
+
+test('highlights the sending group address', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
+
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+  await waitFor(() => expect(screen.getByText('1/2/3')).toBeInTheDocument());
+
+  expect(screen.getByLabelText('sending')).toBeInTheDocument();
+  const sendingRow = screen.getByTitle('Sending group address');
+  expect(within(sendingRow).getByText('1/2/3')).toBeInTheDocument();
+});

--- a/frontend/src/components/GaValuesTable.tsx
+++ b/frontend/src/components/GaValuesTable.tsx
@@ -1,0 +1,244 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { Filter, Clock, ChevronUp, ChevronDown, Send } from 'lucide-react';
+import { apiUrl } from '../utils/basePath';
+import type { Telegram } from '../hooks/useWebSocket';
+
+// Sortable table of group addresses with their last seen values (#269).
+// Used by the building view for a KO's linked GAs and a function's GAs.
+
+export interface GaTableEntry {
+  address: string;
+  name: string;
+  role?: string;
+  /** The GA this KO sends on (first ETS link of a transmitting object). */
+  sending?: boolean;
+}
+
+type SortKey = 'ga' | 'name' | 'role' | 'time';
+
+interface GaValuesTableProps {
+  entries: GaTableEntry[];
+  /** Indentation depth, matching the surrounding tree rows. */
+  depth: number;
+  /** Newest telegram from the live websocket feed; used to update values in place. */
+  latestTelegram?: Telegram | null;
+  onFilterGAs: (addresses: string[]) => void;
+  onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+}
+
+const gaSortValue = (address: string): number => {
+  const parts = address.split('/').map(Number);
+  if (parts.some(Number.isNaN)) return Number.MAX_SAFE_INTEGER;
+  return parts.reduce((acc, p) => acc * 2048 + p, 0);
+};
+
+function ageOf(timestamp: string): string {
+  const diffMs = Date.now() - new Date(timestamp).getTime();
+  if (diffMs < 60_000) return `${Math.max(0, Math.round(diffMs / 1000))}s ago`;
+  if (diffMs < 3_600_000) return `${Math.round(diffMs / 60_000)}m ago`;
+  if (diffMs < 86_400_000) return `${Math.round(diffMs / 3_600_000)}h ago`;
+  return `${Math.round(diffMs / 86_400_000)}d ago`;
+}
+
+const cellStyle: React.CSSProperties = {
+  padding: '0.25rem 0.5rem',
+  fontSize: '0.72rem',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  textAlign: 'left',
+  verticalAlign: 'middle',
+};
+
+const iconBtnStyle: React.CSSProperties = {
+  background: 'transparent', border: 'none', cursor: 'pointer',
+  color: 'var(--text-dim)', padding: '0.15rem', borderRadius: '3px',
+  display: 'inline-flex', alignItems: 'center', verticalAlign: 'middle',
+};
+
+const HeaderCell: React.FC<{
+  label: string;
+  sortKey?: SortKey;
+  sort: { key: SortKey; dir: 'asc' | 'desc' } | null;
+  onSort: (key: SortKey) => void;
+}> = ({ label, sortKey, sort, onSort }) => {
+  const active = sortKey != null && sort?.key === sortKey;
+  return (
+    <th
+      style={{
+        ...cellStyle,
+        fontSize: '0.62rem', fontWeight: 600, textTransform: 'uppercase',
+        letterSpacing: '0.04em', color: 'var(--text-dim)',
+        cursor: sortKey ? 'pointer' : 'default', userSelect: 'none',
+        borderBottom: '1px solid var(--border-subtle)',
+      }}
+      onClick={sortKey ? (e => { e.stopPropagation(); onSort(sortKey); }) : undefined}
+      title={sortKey ? `Sort by ${label.toLowerCase()}` : undefined}
+    >
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.15rem' }}>
+        {label}
+        {active && (sort!.dir === 'asc' ? <ChevronUp size={10} /> : <ChevronDown size={10} />)}
+      </span>
+    </th>
+  );
+};
+
+export const GaValuesTable: React.FC<GaValuesTableProps> = ({
+  entries, depth, latestTelegram, onFilterGAs, onLastSeen,
+}) => {
+  const [valuesByGA, setValuesByGA] = useState<Record<string, Telegram>>({});
+  const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null);
+
+  const addresses = useMemo(() => [...new Set(entries.map(e => e.address))], [entries]);
+  const addressSet = useMemo(() => new Set(addresses), [addresses]);
+
+  const fetchValues = useCallback(async () => {
+    if (addresses.length === 0) return;
+    try {
+      const res = await fetch(
+        apiUrl(`/api/telegrams/last?target_address=${encodeURIComponent(addresses.join(','))}`)
+      );
+      const json = await res.json();
+      const map: Record<string, Telegram> = {};
+      for (const t of (json.telegrams ?? []) as Telegram[]) map[t.target_address] = t;
+      setValuesByGA(map);
+    } catch {
+      // network errors are non-fatal; the table just shows "never seen"
+    }
+  }, [addresses]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchValues();
+  }, [fetchValues]);
+
+  // Keep values current from the live feed without re-fetching.
+  useEffect(() => {
+    if (!latestTelegram || !addressSet.has(latestTelegram.target_address)) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setValuesByGA(prev => ({ ...prev, [latestTelegram.target_address]: latestTelegram }));
+  }, [latestTelegram, addressSet]);
+
+  const handleSort = (key: SortKey) =>
+    setSort(prev => {
+      if (prev?.key !== key) return { key, dir: 'asc' };
+      if (prev.dir === 'asc') return { key, dir: 'desc' };
+      return null; // third click restores ETS order
+    });
+
+  const hasRole = entries.some(e => e.role);
+
+  const sorted = useMemo(() => {
+    if (!sort) return entries;
+    const dir = sort.dir === 'asc' ? 1 : -1;
+    return [...entries].sort((a, b) => {
+      switch (sort.key) {
+        case 'ga':
+          return dir * (gaSortValue(a.address) - gaSortValue(b.address));
+        case 'name':
+          return dir * (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' });
+        case 'role':
+          return dir * (a.role || '').localeCompare(b.role || '', undefined, { sensitivity: 'base' });
+        case 'time': {
+          // Never-seen entries always sort to the end.
+          const ta = valuesByGA[a.address] ? new Date(valuesByGA[a.address].timestamp).getTime() : null;
+          const tb = valuesByGA[b.address] ? new Date(valuesByGA[b.address].timestamp).getTime() : null;
+          if (ta === null && tb === null) return 0;
+          if (ta === null) return 1;
+          if (tb === null) return -1;
+          return dir * (ta - tb);
+        }
+      }
+    });
+  }, [entries, sort, valuesByGA]);
+
+  return (
+    <div style={{ padding: `0.15rem 0.75rem 0.4rem ${0.75 + depth * 1.1}rem` }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', tableLayout: 'auto' }}>
+        <thead>
+          <tr>
+            <HeaderCell label="GA" sortKey="ga" sort={sort} onSort={handleSort} />
+            <HeaderCell label="Name" sortKey="name" sort={sort} onSort={handleSort} />
+            {hasRole && <HeaderCell label="Role" sortKey="role" sort={sort} onSort={handleSort} />}
+            <HeaderCell label="Value" sort={sort} onSort={handleSort} />
+            <HeaderCell label="Time" sortKey="time" sort={sort} onSort={handleSort} />
+            <th style={{ ...cellStyle, borderBottom: '1px solid var(--border-subtle)', width: '1%' }} />
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(entry => {
+            const t = valuesByGA[entry.address];
+            return (
+              <tr
+                key={entry.address}
+                style={entry.sending ? { background: 'rgba(99,102,241,0.08)' } : undefined}
+                title={entry.sending ? 'Sending group address' : undefined}
+              >
+                <td style={{ ...cellStyle, width: '1%' }}>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.3rem' }}>
+                    <span style={{
+                      fontFamily: "'JetBrains Mono', monospace",
+                      color: 'var(--accent-primary)',
+                      fontWeight: entry.sending ? 700 : 400,
+                    }}>{entry.address}</span>
+                    {entry.sending && (
+                      <Send size={10} style={{ color: 'var(--accent-primary)', flexShrink: 0 }} aria-label="sending" />
+                    )}
+                  </span>
+                </td>
+                <td style={{ ...cellStyle, maxWidth: 0, color: 'var(--text-dim)' }} title={entry.name || undefined}>
+                  {entry.name || '—'}
+                </td>
+                {hasRole && (
+                  <td style={{ ...cellStyle, width: '1%' }}>
+                    {entry.role ? (
+                      <span style={{
+                        fontSize: '0.62rem', fontWeight: 600, color: 'var(--text-dim)',
+                        textTransform: 'uppercase', background: 'var(--bg-tag)',
+                        padding: '0.05rem 0.25rem', borderRadius: '3px',
+                      }}>{entry.role}</span>
+                    ) : '—'}
+                  </td>
+                )}
+                <td style={{ ...cellStyle, width: '1%', fontWeight: 600, color: t ? 'var(--text-main)' : 'var(--text-dim)' }}>
+                  {t ? (
+                    <>
+                      {t.value_formatted ?? t.value_numeric ?? '—'}
+                      {t.unit && <span style={{ fontWeight: 400, color: 'var(--text-dim)' }}> {t.unit}</span>}
+                    </>
+                  ) : 'never seen'}
+                </td>
+                <td
+                  style={{ ...cellStyle, width: '1%', color: 'var(--text-dim)' }}
+                  title={t ? `Last updated: ${new Date(t.timestamp).toLocaleString()}\nby ${t.source_address}${t.source_name ? ` (${t.source_name})` : ''}` : 'Never updated'}
+                >
+                  {t ? ageOf(t.timestamp) : '—'}
+                </td>
+                <td style={{ ...cellStyle, width: '1%' }}>
+                  <button
+                    style={iconBtnStyle}
+                    title="Filter by this group address"
+                    onClick={e => { e.stopPropagation(); onFilterGAs([entry.address]); }}
+                    onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                    onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                  >
+                    <Filter size={11} />
+                  </button>
+                  <button
+                    style={iconBtnStyle}
+                    title="Show last seen values"
+                    onClick={e => { e.stopPropagation(); onLastSeen([entry.address], 'ga'); }}
+                    onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                    onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                  >
+                    <Clock size={11} />
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};


### PR DESCRIPTION
## What

Finishes the half-started work on the building view so that expanding a **communication object** or a **function** reveals a **sortable table of its group addresses** with live last-seen values — the core ask of #268 (blue) and #269.

### New: `GaValuesTable`

- One row per linked GA: **GA · name · role · value · age**, plus per-row filter / last-seen actions.
- **Sortable headers** (GA, name, role, time). Third click on a header restores the original ETS order. Numeric GA sort; never-seen entries always sort last.
- Values load from `/api/telegrams/last` (comma-joined targets) and **update live** from the websocket feed without re-fetching.
- The **sending group address** (first ETS link of a KO with the `transmit` flag) is highlighted and marked with a send icon.

### `BuildingOverlay`

- `KoRow` is now expandable; expanding shows the `GaValuesTable` for the KO's GAs. The collapsed chip row also highlights the sending GA.
- `FunctionRow`'s flat GA list is replaced by the same sortable table (roles included).
- `latestTelegram` is threaded from `App.tsx` down through the tree so open tables stay current.

## Verification

- `tsc --noEmit`, ESLint, and `vite build` all clean.
- Full frontend suite green (**183 tests**, incl. 4 new `GaValuesTable` tests covering fetch, live update, never-seen, sorting cycle, and sending highlight).
- Browser/e2e verification deferred to the combined pre-release pass.

Fixes #268
Fixes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)