### PR TITLE
Change default port from 8000 to 8765 (#286)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -65,11 +65,11 @@ POSTGRES_PORT=5432
 # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
 
-# Address and port the web interface listens on. Change BIND_PORT if 8000
+# Address and port the web interface listens on. Change BIND_PORT if 8765
 # clashes with another service on the same host. With docker-compose the
 # published host port follows BIND_PORT automatically.
 # BIND_HOST=0.0.0.0
-# BIND_PORT=8000
+# BIND_PORT=8765
 
 # Allow sending telegrams to the KNX bus (GroupValueWrite/Read from the Group
 # Monitor). Only effective in standalone mode with a live connection. Set to
@@ -92,4 +92,4 @@ APP_IMAGE=ghcr.io/martinhoefling/spectrumknx:latest
 
 # --- Frontend Settings ---
 # API URL used by the frontend (mostly for production/docker builds)
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8765

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,9 +111,9 @@ jobs:
             mkdir -p /var/lib/spectrum-knx && chown spectrum-knx: /var/lib/spectrum-knx
             set -a; . /etc/spectrum-knx/spectrum-knx.env; set +a
             cd /opt/spectrum-knx/app
-            runuser -u spectrum-knx -- /opt/spectrum-knx/venv/bin/uvicorn main:app --port 8000 &
-            for i in \$(seq 1 30); do curl -sf http://localhost:8000/api/version && break; sleep 1; done
-            curl -sf http://localhost:8000/ | grep -q '<title>Spectrum KNX</title>'
+            runuser -u spectrum-knx -- /opt/spectrum-knx/venv/bin/uvicorn main:app --port 8765 &
+            for i in \$(seq 1 30); do curl -sf http://localhost:8765/api/version && break; sleep 1; done
+            curl -sf http://localhost:8765/ | grep -q '<title>Spectrum KNX</title>'
           "
 
       - name: Upload to release
@@ -163,9 +163,9 @@ jobs:
         shell: bash
         run: |
           ./dist/windows/spectrum-knx/spectrum-knx.exe &
-          for i in $(seq 1 60); do curl -sf http://localhost:8000/api/version && break; sleep 1; done
-          curl -sf http://localhost:8000/api/version | grep -q "${GITHUB_REF_NAME#v}"
-          curl -sf http://localhost:8000/ | grep -q '<title>Spectrum KNX</title>'
+          for i in $(seq 1 60); do curl -sf http://localhost:8765/api/version && break; sleep 1; done
+          curl -sf http://localhost:8765/api/version | grep -q "${GITHUB_REF_NAME#v}"
+          curl -sf http://localhost:8765/ | grep -q '<title>Spectrum KNX</title>'
           kill %1
 
       - name: Zip bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ python -m venv .venv
 source .venv/bin/activate  # Or `.\.venv\Scripts\Activate.ps1` on Windows
 pip install -r requirements.txt
 ```
-Run the local uvicorn server in auto-reload mode (runs on port 8000):
+Run the local uvicorn server in auto-reload mode (runs on port 8765):
 ```bash
-uvicorn main:app --reload
+uvicorn main:app --reload --port 8765
 ```
 
 ### 3. Frontend (React / Vite)
@@ -40,7 +40,7 @@ npm run dev
 ```
 
 > [!TIP]
-> **API Proxying:** The Vite dev server is configured (via `vite.config.ts`) to automatically proxy any requests made to `/api` and `/ws` over to `localhost:8000`. This means you can develop the frontend logic at port 5173 and it will transparently communicate with your local python daemon.
+> **API Proxying:** The Vite dev server is configured (via `vite.config.ts`) to automatically proxy any requests made to `/api` and `/ws` over to `localhost:8765`. This means you can develop the frontend logic at port 5173 and it will transparently communicate with your local python daemon.
 
 ## Code Quality Standards
 - **Python Linter:** We use `Ruff`. Run `ruff check .` before committing.

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -180,7 +180,7 @@ automatically) running as its own system user. Locations:
 
 Edit the env file (KNX connection, bind address/port — all variables from
 [Section 5](#5-configuration-variables-docker--kubernetes) apply), then
-`sudo systemctl restart spectrum-knx`. The web UI listens on port 8000 by
+`sudo systemctl restart spectrum-knx`. The web UI listens on port 8765 by
 default. Logs: `journalctl -u spectrum-knx`. `apt purge` removes the database
 and the service user; `apt remove` keeps them.
 
@@ -188,7 +188,7 @@ and the service user; `apt remove` keeps them.
 
 Unzip `spectrum-knx-<version>-windows-x64.zip` anywhere and run
 `spectrum-knx.exe`: a console window shows the logs and the browser opens the
-UI (default `http://localhost:8000`). A `README.txt` with the full setup
+UI (default `http://localhost:8765`). A `README.txt` with the full setup
 guide is included in the zip.
 
 - Configuration lives in the `.env` file created next to the exe on first run

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,7 +44,7 @@ Key variables:
 - `KNX_PROJECT_PATH`: Path to the `.knxproj` file inside the container.
 - `KNX_GATEWAY_IP`: IP of your KNX interface (or `AUTO`). See `DEPLOYMENT.md` for advanced connection settings.
 - `APP_IMAGE`: Docker image to use for production stacks.
-- `VITE_BACKEND_URL`: (Frontend only) The URL of the backend API (default: `http://localhost:8000`).
+- `VITE_BACKEND_URL`: (Frontend only) The URL of the backend API (default: `http://localhost:8765`).
 
 Companion mode (read an external telegram store instead of running the KNX daemon):
 - `STORE_MODE`: `standalone` (default) or `external-readonly` — read a sqlite store owned and written by another process (e.g. Home Assistant's KNX integration). Requires a `sqlite+aiosqlite://` `DATABASE_URL`; the KNX daemon is not started, and purge/optimize are disabled.
@@ -81,9 +81,9 @@ cd backend
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
-uvicorn main:app --reload
+uvicorn main:app --reload --port 8765
 ```
-The API will be available at `http://localhost:8000`.
+The API will be available at `http://localhost:8765`.
 
 #### Via Docker
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,12 @@ COPY backend/ .
 COPY --from=frontend-builder /app/frontend/dist ./static
 
 # Expose port
-EXPOSE 8000
+EXPOSE 8765
 
 # Environment variables
 ENV LOG_LEVEL=INFO
 ENV BIND_HOST=0.0.0.0
-ENV BIND_PORT=8000
+ENV BIND_PORT=8765
 
 # Command to run the application. `exec` keeps uvicorn as PID 1 so it receives
 # signals for graceful shutdown; the shell form lets BIND_HOST/BIND_PORT expand.

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -93,7 +93,7 @@ Steps:
       installed (direct deps from `pyproject.toml`, versions constrained by
       `requirements.txt`) — package size ≈ 13 MB. The unit gets defaults via
       `Environment=` so an old conffile can't break an upgrade; `APP_VERSION`
-      is baked into the unit at build time. The web UI defaults to port 8000.*
+      is baked into the unit at build time. The web UI defaults to port 8765.*
 - [x] Local build inside `debian:trixie` container; verified with
       `dpkg-deb -c`, `lintian` (remaining tags are the expected
       `dir-or-file-in-opt` for venv-bundled software) and an install/run smoke
@@ -108,7 +108,7 @@ Steps:
 - **Launcher**: `packaging/windows/launcher.py` is the PyInstaller entry point.
   It loads `.env` next to the exe (created from a template on first run),
   defaults `DATABASE_URL` and `KNX_PROJECT_PATH` to
-  `%LOCALAPPDATA%\SpectrumKNX\`, starts uvicorn on `127.0.0.1:8000` and opens
+  `%LOCALAPPDATA%\SpectrumKNX\`, starts uvicorn on `127.0.0.1:8765` and opens
   the default browser. Console window stays visible for logs (documented;
   a tray/service wrapper via WinSW is a possible follow-up).
 - **Static frontend**: bundled as PyInstaller data files so `main.py`'s

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ The easiest way to run Spectrum KNX is with Docker Compose. This automatically p
    docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
    ```
 
-4. Access the web interface at `http://localhost:8000` (or `http://localhost:5173` in Dev mode).
+4. Access the web interface at `http://localhost:8765` (or `http://localhost:5173` in Dev mode).
 
-   > The listen port defaults to `8000`. Set `BIND_PORT` (and optionally
+   > The listen port defaults to `8765`. Set `BIND_PORT` (and optionally
    > `BIND_HOST`) in your `.env` if it clashes with another service.
 
 ## 📦 Debian Package & Windows
@@ -58,7 +58,7 @@ No Docker needed — both packages run Spectrum KNX with a local SQLite database
 
 - **Debian 13+ / compatible (amd64, arm64):** `sudo apt install ./spectrum-knx_<version>_<arch>.deb`,
   configure `/etc/spectrum-knx/spectrum-knx.env`, then `sudo systemctl restart spectrum-knx`.
-  Web UI on port 8000.
+  Web UI on port 8765.
 - **Windows (x64):** unzip `spectrum-knx-<version>-windows-x64.zip`, run
   `spectrum-knx.exe` — the browser opens automatically; settings live in the
   `.env` file created next to the exe.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 ENV BIND_HOST=0.0.0.0
-ENV BIND_PORT=8000
+ENV BIND_PORT=8765
 
 # `exec` keeps uvicorn as PID 1 so it receives signals for graceful shutdown;
 # the shell form lets BIND_HOST/BIND_PORT expand.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,7 +15,7 @@ services:
       context: ./frontend
     container_name: knx_frontend
     environment:
-      - VITE_BACKEND_URL=http://backend:8000
+      - VITE_BACKEND_URL=http://backend:8765
       - VITE_APP_VERSION=${APP_VERSION:-dev}
     volumes:
       - ./frontend:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,13 +23,13 @@ services:
       - POSTGRES_PORT=${POSTGRES_PORT:-5432}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - BIND_HOST=${BIND_HOST:-0.0.0.0}
-      - BIND_PORT=${BIND_PORT:-8000}
+      - BIND_PORT=${BIND_PORT:-8765}
     env_file:
       - .env
     volumes:
       - knx_project_data:/project
     ports:
-      - "${BIND_PORT:-8000}:${BIND_PORT:-8000}"
+      - "${BIND_PORT:-8765}:${BIND_PORT:-8765}"
     depends_on:
       - db
     restart: unless-stopped

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   // Set the third parameter to '' to load all env instead of just those starting with `VITE_`.
   const env = loadEnv(mode, process.cwd(), '');
-  const backendUrl = env.VITE_BACKEND_URL || 'http://localhost:8000';
+  const backendUrl = env.VITE_BACKEND_URL || 'http://localhost:8765';
   const wsBackendUrl = backendUrl.replace(/^http/, 'ws');
   const appVersion = process.env.VITE_APP_VERSION || env.VITE_APP_VERSION || gitVersion;
 

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -9,7 +9,7 @@ arch:
   - aarch64
   - amd64
 ingress: true
-ingress_port: 8000
+ingress_port: 8765
 ingress_stream: true
 panel_icon: mdi:database-eye
 panel_title: "Spectrum KNX (HA)"

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -9,7 +9,7 @@ arch:
   - aarch64
   - amd64
 ingress: true
-ingress_port: 8000
+ingress_port: 8765
 ingress_stream: true
 panel_icon: mdi:chart-timeline-variant
 panel_title: "Spectrum KNX"

--- a/ha-addon/rootfs/etc/services.d/spectrum_knx/run
+++ b/ha-addon/rootfs/etc/services.d/spectrum_knx/run
@@ -62,7 +62,7 @@ ln -sfn /data/project /project
 # Ingress support path (provided by Home Assistant)
 if bashio::config.has_value 'ingress_port'; then
     # We serve directly on the port and Home Assistant handles the Ingress proxying
-    export PORT=8000
+    export PORT=8765
 fi
 
 # Set root path if running under HA Ingress
@@ -73,4 +73,4 @@ fi
 
 cd /app/backend
 bashio::log.info "Starting Spectrum KNX Backend..."
-exec /opt/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000
+exec /opt/venv/bin/uvicorn main:app --host 0.0.0.0 --port 8765

--- a/kubernetes/spectrumknx-service.yaml
+++ b/kubernetes/spectrumknx-service.yaml
@@ -8,7 +8,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 80
-      targetPort: 8000
+      targetPort: 8765
       protocol: TCP
       name: http
   selector:

--- a/kubernetes/spectrumknx-sts.yaml
+++ b/kubernetes/spectrumknx-sts.yaml
@@ -39,7 +39,7 @@ spec:
                   name: spectrumknx-secret
                   key: KNX_PASSWORD
           ports:
-            - containerPort: 8000
+            - containerPort: 8765
               name: http
           volumeMounts:
             - name: knxproj

--- a/packaging/debian/spectrum-knx.env
+++ b/packaging/debian/spectrum-knx.env
@@ -5,7 +5,7 @@
 # Address/port the web interface listens on. Use 127.0.0.1 to restrict to
 # localhost (e.g. behind a reverse proxy).
 BIND_HOST=0.0.0.0
-BIND_PORT=8000
+BIND_PORT=8765
 
 # --- Storage (SQLite) -------------------------------------------------------
 DATABASE_URL=sqlite+aiosqlite:////var/lib/spectrum-knx/spectrum-knx.db

--- a/packaging/debian/spectrum-knx.service
+++ b/packaging/debian/spectrum-knx.service
@@ -12,7 +12,7 @@ Group=spectrum-knx
 # at package build time.
 Environment=APP_VERSION=@VERSION@
 Environment=BIND_HOST=0.0.0.0
-Environment=BIND_PORT=8000
+Environment=BIND_PORT=8765
 EnvironmentFile=-/etc/spectrum-knx/spectrum-knx.env
 WorkingDirectory=/opt/spectrum-knx/app
 ExecStart=/opt/spectrum-knx/venv/bin/uvicorn main:app --host ${BIND_HOST} --port ${BIND_PORT}

--- a/packaging/windows/README.txt
+++ b/packaging/windows/README.txt
@@ -16,7 +16,7 @@ GETTING STARTED
    - A console window opens and shows the log output. Keep it open;
      closing it stops Spectrum KNX.
    - Your browser opens the web interface automatically
-     (default: http://localhost:8000).
+     (default: http://localhost:8765).
    - On first start, Windows Firewall asks for network permission.
      Allow it — it is required to discover KNX/IP gateways and to
      receive KNX routing (multicast) traffic.
@@ -45,7 +45,7 @@ The most important settings:
   Web interface
     BIND_HOST=127.0.0.1     only this PC can open the UI (default)
     BIND_HOST=0.0.0.0       other devices on your network can open it
-    BIND_PORT=8000          change if port 8000 is already in use
+    BIND_PORT=8765          change if port 8765 is already in use
 
   KNX connection
     KNX_CONNECTION_TYPE=automatic
@@ -118,7 +118,7 @@ TROUBLESHOOTING
 
 - The browser shows "connection refused":
   Check the console window — the URL and any errors are printed there.
-  If port 8000 is taken by another program, set a different BIND_PORT
+  If port 8765 is taken by another program, set a different BIND_PORT
   in .env and restart.
 
 - No KNX gateway found / no telegrams:

--- a/packaging/windows/env.template
+++ b/packaging/windows/env.template
@@ -5,7 +5,7 @@
 # 127.0.0.1 = only this machine can open the UI. Use 0.0.0.0 to allow other
 # devices on your network.
 BIND_HOST=127.0.0.1
-BIND_PORT=8000
+BIND_PORT=8765
 
 # --- Storage ----------------------------------------------------------------
 # Default: %LOCALAPPDATA%\SpectrumKNX\spectrum-knx.db (SQLite). Uncomment to

--- a/packaging/windows/launcher.py
+++ b/packaging/windows/launcher.py
@@ -67,7 +67,7 @@ def run() -> None:
     prepare_environment()
 
     host = os.environ.get("BIND_HOST", "127.0.0.1")
-    port = int(os.environ.get("BIND_PORT", "8000"))
+    port = int(os.environ.get("BIND_PORT", "8765"))
 
     import uvicorn
     from main import app


### PR DESCRIPTION
## Problem

The default web-UI port `8000` is the **Portainer Edge Agent** default and is commonly already occupied on Docker-based home-automation / Raspberry Pi hosts. A fresh `docker compose up` then fails:

```
Bind for 0.0.0.0:8000 failed: port is already allocated
```

## Fix

Move the default port to **8765** — a quiet 4-digit port with no common home-automation/IoT default, clear of Portainer (8000/9000/9443), Home Assistant (8123), InfluxDB (8086), Grafana (3000) and the usual 8080.

Applied consistently everywhere the default was baked in:

- **Docker / compose** — `Dockerfile` (EXPOSE + `BIND_PORT`), `backend/Dockerfile`, `docker-compose.yml` (env + host mapping), `docker-compose.override.yml` (dev backend URL)
- **Debian package** — `spectrum-knx.env`, `spectrum-knx.service`
- **Windows bundle** — `launcher.py`, `env.template`, `README.txt`
- **Home Assistant add-ons** — `ha-addon` / `ha-addon-companion` `config.yaml` (`ingress_port`) + the s6 `run` script
- **Kubernetes** — service `targetPort` + statefulset `containerPort`
- **Dev** — Vite proxy default + `uvicorn --reload --port 8765` in the dev docs
- **CI** — deb/Windows release smoke tests
- **Docs** — README, DEPLOYMENT, DEVELOPMENT, CONTRIBUTING, PACKAGING, `.env_example`

Users who set `BIND_PORT` explicitly are unaffected.

Left untouched: a KNX telegram hex payload in `test_telegram_import.py` and a timestamp in `TimeBrush.test.tsx` that merely contain the substring `8000`.

Fixes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)