### PR TITLE
Add "quick goto time" to the telegram list (#282)

### DIFF
--- a/frontend/src/components/GotoTimeControl.test.tsx
+++ b/frontend/src/components/GotoTimeControl.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { afterEach, expect, test, vi } from 'vitest';
+import { format } from 'date-fns';
+import { GotoTimeControl } from './GotoTimeControl';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const seed = new Date('2026-07-20T14:30:15').getTime();
+
+test('opens a popover seeded with the newest telegram time', () => {
+  render(<GotoTimeControl seedMs={seed} onGoto={() => {}} />);
+
+  // Popover is closed initially.
+  expect(screen.queryByRole('button', { name: 'Go' })).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Go to time' }));
+
+  const input = screen.getByLabelText('Target time') as HTMLInputElement;
+  // Seeded to the newest telegram time (jsdom normalizes to ms precision).
+  expect(input.value.startsWith(format(seed, "yyyy-MM-dd'T'HH:mm:ss"))).toBe(true);
+  expect(new Date(input.value).getTime()).toBe(seed);
+});
+
+test('submits the entered time as epoch ms via the Go button', () => {
+  const onGoto = vi.fn();
+  render(<GotoTimeControl seedMs={seed} onGoto={onGoto} />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Go to time' }));
+  const input = screen.getByLabelText('Target time');
+  fireEvent.change(input, { target: { value: '2026-07-20T09:05:00' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+
+  expect(onGoto).toHaveBeenCalledTimes(1);
+  expect(onGoto).toHaveBeenCalledWith(new Date('2026-07-20T09:05:00').getTime());
+  // Popover closes after submit.
+  expect(screen.queryByRole('button', { name: 'Go' })).not.toBeInTheDocument();
+});
+
+test('Enter in the input submits the time', () => {
+  const onGoto = vi.fn();
+  render(<GotoTimeControl seedMs={seed} onGoto={onGoto} />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Go to time' }));
+  const input = screen.getByLabelText('Target time');
+  fireEvent.change(input, { target: { value: '2026-07-20T10:00:00' } });
+  fireEvent.keyDown(input, { key: 'Enter' });
+
+  expect(onGoto).toHaveBeenCalledWith(new Date('2026-07-20T10:00:00').getTime());
+});
+
+test('Escape closes the popover without submitting', () => {
+  const onGoto = vi.fn();
+  render(<GotoTimeControl seedMs={seed} onGoto={onGoto} />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Go to time' }));
+  expect(screen.getByRole('button', { name: 'Go' })).toBeInTheDocument();
+
+  fireEvent.keyDown(document, { key: 'Escape' });
+  expect(screen.queryByRole('button', { name: 'Go' })).not.toBeInTheDocument();
+  expect(onGoto).not.toHaveBeenCalled();
+});
+
+test('Go is disabled when there is no seed time', () => {
+  render(<GotoTimeControl seedMs={null} onGoto={() => {}} />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Go to time' }));
+  expect(screen.getByRole('button', { name: 'Go' })).toBeDisabled();
+});

--- a/frontend/src/components/GotoTimeControl.tsx
+++ b/frontend/src/components/GotoTimeControl.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { format } from 'date-fns';
+import { Clock } from 'lucide-react';
+
+// "Quick goto time" control for the telegram list (#282): a clock button that
+// opens a small time-entry popover. Submitting jumps the list to the telegram
+// nearest that time and (via the parent) stops live-following.
+
+interface GotoTimeControlProps {
+  /** Newest telegram time (epoch ms) used to seed the input, or null when empty. */
+  seedMs: number | null;
+  /** Called with the chosen time (epoch ms) when the user submits. */
+  onGoto: (targetMs: number) => void;
+}
+
+/** date-fns pattern for an <input type="datetime-local" step="1"> value (local time). */
+const INPUT_FMT = "yyyy-MM-dd'T'HH:mm:ss";
+
+export const GotoTimeControl: React.FC<GotoTimeControlProps> = ({ seedMs, onGoto }) => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState('');
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  const toggle = () => {
+    if (open) { setOpen(false); return; }
+    // Reseed to the newest telegram each time the popover opens.
+    setValue(seedMs != null ? format(new Date(seedMs), INPUT_FMT) : '');
+    const r = btnRef.current?.getBoundingClientRect();
+    if (r) setPos({ top: r.bottom + 4, left: r.left });
+    setOpen(true);
+  };
+
+  // Close on Escape or an outside click, mirroring SendToGaPopover.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    const onDown = (e: MouseEvent) => {
+      const n = e.target as Node;
+      if (!cardRef.current?.contains(n) && !btnRef.current?.contains(n)) setOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onDown);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onDown);
+    };
+  }, [open]);
+
+  const submit = () => {
+    const ms = new Date(value).getTime();
+    if (!Number.isNaN(ms)) onGoto(ms);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        className={`quick-filter-bar-toggle ${open ? 'open' : ''}`}
+        onClick={toggle}
+        title="Go to time"
+        aria-label="Go to time"
+      >
+        <Clock size={13} />
+      </button>
+      {open && pos && createPortal(
+        <div
+          ref={cardRef}
+          className="goto-time-popover"
+          style={{ position: 'fixed', top: pos.top, left: pos.left, zIndex: 1000 }}
+        >
+          <input
+            type="datetime-local"
+            step="1"
+            className="goto-time-input"
+            value={value}
+            autoFocus
+            aria-label="Target time"
+            onChange={e => setValue(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') submit(); }}
+          />
+          <button className="goto-time-go" onClick={submit} disabled={!value}>Go</button>
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -5,6 +5,7 @@ import type { Telegram } from '../hooks/useWebSocket';
 import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock } from 'lucide-react';
 import { dptKey, type ActiveFilters } from '../types/filters';
 import { SendToGaPopover } from './SendToGaPopover';
+import { GotoTimeControl } from './GotoTimeControl';
 import { getPref, setPref } from '../utils/prefs';
 
 export type SortKey = 'timestamp' | 'source_address' | 'target_address' | 'simplified_type' | 'dpt_name' | 'value_numeric';
@@ -320,6 +321,36 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     scrollToEdge();
   };
 
+  // "Quick goto time" (#282): scroll to the telegram nearest a given time and
+  // stop live-following, so the viewed rows stay put while new ones accumulate.
+  // The jump-to-live pill is the way back. Only meaningful for the timestamp
+  // sort, where rows are ordered by time.
+  const gotoTime = (targetMs: number) => {
+    const rows = telegramRows;
+    if (!isTimeSort || rows.length === 0) return;
+    let bestIdx = 0;
+    let bestDiff = Infinity;
+    for (let i = 0; i < rows.length; i++) {
+      const diff = Math.abs(new Date(rows[i].timestamp).getTime() - targetMs);
+      if (diff < bestDiff) { bestDiff = diff; bestIdx = i; }
+    }
+    atEdgeRef.current = false;
+    setNewSinceAnchor(0);
+    markProgrammatic();
+    virtualizer.scrollToIndex(bestIdx, { align: 'center' });
+    // Pin the row we land on once the virtualizer has settled the scroll (rows
+    // are dynamically measured, so give it two frames before capturing).
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      captureAnchor();
+      atEdgeRef.current = false;
+    }));
+  };
+
+  // Newest telegram time, used to seed the goto-time input.
+  const newestMs = telegramRows.length > 0
+    ? new Date(telegramRows[liveEdge === 'top' ? 0 : telegramRows.length - 1].timestamp).getTime()
+    : null;
+
   // Correct scrollTop so the anchored row keeps its recorded viewport offset.
   // Only the top (newest-first) edge needs this — bottom-appends don't move the
   // content above the viewport.
@@ -631,6 +662,9 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                 <ListFilter size={13} />
               </button>
             )}
+            {c.id === 'time' && isTimeSort && (
+              <GotoTimeControl seedMs={newestMs} onGoto={gotoTime} />
+            )}
             {c.sortKey ? (
               <button className="sort-header" onClick={() => onSort(c.sortKey!)}>
                 {c.label} {renderSortArrow(c.sortKey)}
@@ -887,6 +921,54 @@ style.textContent = `
 
   .quick-filter-bar-input:focus {
     border-color: var(--accent-primary);
+  }
+
+  .goto-time-popover {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem;
+    background: var(--bg-panel);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: var(--shadow-lg);
+  }
+
+  .goto-time-input {
+    background: var(--bg-tag);
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    padding: 0.25rem 0.45rem;
+    color: var(--text-main);
+    font-size: 0.75rem;
+    font-family: var(--font-mono, monospace);
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  .goto-time-input:focus {
+    border-color: var(--accent-primary);
+  }
+
+  .goto-time-go {
+    background: var(--accent-primary);
+    border: none;
+    border-radius: 5px;
+    padding: 0.3rem 0.7rem;
+    color: white;
+    font-size: 0.72rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: filter 0.15s;
+  }
+
+  .goto-time-go:hover:not(:disabled) {
+    filter: brightness(1.08);
+  }
+
+  .goto-time-go:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .col-resize-handle {


### PR DESCRIPTION
## What

Adds a **quick goto time** control to the group-monitor telegram list, so you can jump to a moment instead of hunting with the scrollbar.

- A **clock button** in the `TIME` column header opens a small time-entry popover (`datetime-local`, second precision), seeded with the newest telegram's time.
- Submitting (**Go** or **Enter**) scrolls the list to the telegram **nearest** that time and **stops live-following** — the viewed rows stay put while new telegrams accumulate. The existing **jump-to-live pill** brings you back.
- Escape / outside-click closes the popover.

## How

- New standalone `GotoTimeControl` component — a portaled popover (mirrors `SendToGaPopover`'s portal + fixed-position + outside-close pattern, so the header's `overflow: hidden` can't clip it).
- The jump reuses `TelegramTable`'s existing ETS-style anchor/pin machinery (#202): it finds the nearest row, `scrollToIndex(..., { align: 'center' })`, drops out of edge-follow, and pins the landed row so it's held across incoming updates.
- Shown only for the timestamp sort, where rows are ordered by time.

## Verification

- `tsc`, ESLint, `vite build` clean.
- Full suite green (**204 tests**, incl. 5 new `GotoTimeControl` tests: popover open/seed, Go-button submit → epoch ms, Enter submit, Escape close, disabled Go with no data).
- The scroll/anchor interaction itself depends on real layout + the virtualizer (not exercisable in jsdom), so that part is left for the combined in-browser pre-release pass.

Fixes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)