### PR TITLE
Visualization: date-aware times, visible drag-select, no reset on telegram (#281)

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -6,6 +6,7 @@ import type { ChartBucket } from '../hooks/useChartData';
 import { useThemeTick } from '../hooks/useTheme';
 import { seriesColor } from '../utils/seriesColors';
 import { isSeriesHidden, setSeriesHidden } from '../utils/legendVisibility';
+import { spansMultipleDays, formatAxisTime, formatFullTime } from '../utils/timeFormat';
 
 interface MixedChartProps {
   bucket: ChartBucket;
@@ -70,6 +71,9 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
     const gridStroke = style.getPropertyValue('--border-subtle').trim();
     const axisStroke = style.getPropertyValue('--text-dim').trim();
 
+    // Show a date alongside times once the visible range crosses midnight (#281).
+    const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
+
     // Configure Y-Axis scale limits based on smart defaults
     let scaleConfig: uPlot.Scale = {};
     if (!isBinary && (unit === '%' || unit === 'Hz' || unit === 'W')) {
@@ -132,9 +136,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
           space: 50,
           grid: { stroke: gridStroke, width: 1 },
           stroke: axisStroke,
-          values: (_u, splits) => splits.map(v =>
-            new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
-          )
+          values: (_u, splits) => splits.map(v => formatAxisTime(v * 1000, multiDay))
         },
         {
           space: 30,
@@ -147,7 +149,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
       ],
       series: [
         {
-          value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+          value: (_u, v) => v == null ? '-' : formatFullTime(v * 1000, multiDay)
         },
         ...series.map((s, sIdx) => ({
           label: s.name,
@@ -177,7 +179,9 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
         {isBinary ? 'Binary States (Ein/Aus)' : `Metrics (${unit})`}
       </h4>
       <div ref={containerRef} style={{ width: '100%', overflow: 'hidden' }}>
-         <UplotReact options={options} data={data} />
+         {/* resetScales=false: keep the app-controlled zoom on live updates so a
+             new telegram doesn't snap the x-axis back to the full range (#281). */}
+         <UplotReact options={options} data={data} resetScales={false} />
       </div>
     </div>
   );

--- a/frontend/src/components/TimeBrush.tsx
+++ b/frontend/src/components/TimeBrush.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useMemo, useEffect, useState } from 'react';
 import type { Telegram } from '../hooks/useWebSocket';
+import { spansMultipleDays, formatFullTime } from '../utils/timeFormat';
 
 interface TimeBrushProps {
   minTime: number;
@@ -114,9 +115,10 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
     };
   }, [dragMode, minTime, maxTime, range, value, onChange]);
 
-  const formatTime = (ms: number) => {
-    return new Date(ms).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
-  };
+  // Date-aware edge labels: show the date too once the data spans days (#281),
+  // so the selected window's bounds aren't ambiguous across midnight.
+  const multiDay = spansMultipleDays(minTime, maxTime);
+  const formatTime = (ms: number) => formatFullTime(ms, multiDay);
 
   return (
     <div style={{ padding: '0.75rem 1.5rem', borderTop: '1px solid var(--border-color)', background: 'var(--bg-panel)', flexShrink: 0 }}>

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -4,6 +4,7 @@ import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';
 import type { ChartBucket } from '../hooks/useChartData';
 import { useThemeTick } from '../hooks/useTheme';
+import { spansMultipleDays, formatAxisTime, formatFullTime } from '../utils/timeFormat';
 
 interface TimelineChartProps {
   bucket: ChartBucket;
@@ -61,6 +62,9 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
     const gridStroke = style.getPropertyValue('--border-subtle').trim();
     const axisStroke = style.getPropertyValue('--text-dim').trim();
     const accentPrimary = style.getPropertyValue('--accent-primary').trim();
+
+    // Show a date alongside times once the visible range crosses midnight (#281).
+    const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
 
     const timelinePlugin = () => ({
       hooks: {
@@ -185,9 +189,7 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
           space: 50,
           stroke: axisStroke,
           grid: { stroke: gridStroke },
-          values: (_u, splits) => splits.map(v =>
-            new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false })
-          )
+          values: (_u, splits) => splits.map(v => formatAxisTime(v * 1000, multiDay))
         },
         {
           show: true,
@@ -199,7 +201,7 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
       ],
       series: [
         {
-          value: (_u, v) => v == null ? '-' : new Date(v * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+          value: (_u, v) => v == null ? '-' : formatFullTime(v * 1000, multiDay)
         },
         ...series.map((s) => ({
           label: s.name,
@@ -216,7 +218,9 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
         Binary States Timeline
       </h4>
       <div ref={containerRef} style={{ width: '100%', overflow: 'visible' }}>
-         <UplotReact options={options} data={data} />
+         {/* resetScales=false: keep the app-controlled zoom on live updates so a
+             new telegram doesn't snap the x-axis back to the full range (#281). */}
+         <UplotReact options={options} data={data} resetScales={false} />
       </div>
     </div>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -220,6 +220,14 @@ code, pre {
   color: var(--text-main) !important;
 }
 
+/* Make the drag-to-zoom selection visible while dragging (#281). uPlot's
+   default .u-select tint is near-invisible on the dark chart background. */
+.u-select {
+  background: rgba(99, 102, 241, 0.18);
+  border: 1px solid var(--accent-primary);
+  box-sizing: border-box;
+}
+
 /* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 8px;

--- a/frontend/src/utils/timeFormat.test.ts
+++ b/frontend/src/utils/timeFormat.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { spansMultipleDays, formatAxisTime, formatFullTime } from './timeFormat';
+
+// Use fixed local-time instants so assertions don't depend on the runner's tz
+// beyond what the formatters themselves use.
+const t = (s: string) => new Date(s).getTime();
+
+describe('spansMultipleDays', () => {
+  test('false within a single calendar day', () => {
+    expect(spansMultipleDays(t('2026-07-18T00:05:00'), t('2026-07-18T23:55:00'))).toBe(false);
+  });
+
+  test('true across a midnight boundary', () => {
+    expect(spansMultipleDays(t('2026-07-18T23:00:00'), t('2026-07-19T01:00:00'))).toBe(true);
+  });
+});
+
+describe('formatAxisTime', () => {
+  test('time only on single-day ranges', () => {
+    const s = formatAxisTime(t('2026-07-18T14:30:00'), false);
+    expect(s).toBe('14:30');
+  });
+
+  test('prefixes a MM-DD date on multi-day ranges', () => {
+    const s = formatAxisTime(t('2026-07-18T14:30:00'), true);
+    // Locale can vary, but the time part and both date fields must be present.
+    expect(s).toContain('14:30');
+    expect(s).toMatch(/\b07\b/);
+    expect(s).toMatch(/\b18\b/);
+    expect(s.length).toBeGreaterThan('14:30'.length);
+  });
+});
+
+describe('formatFullTime', () => {
+  test('HH:mm:ss on single-day ranges', () => {
+    expect(formatFullTime(t('2026-07-18T14:30:15'), false)).toBe('14:30:15');
+  });
+
+  test('includes year and seconds on multi-day ranges', () => {
+    const s = formatFullTime(t('2026-07-18T14:30:15'), true);
+    expect(s).toContain('14:30:15');
+    expect(s).toContain('2026');
+  });
+});

--- a/frontend/src/utils/timeFormat.ts
+++ b/frontend/src/utils/timeFormat.ts
@@ -1,0 +1,31 @@
+// Date-aware time formatting for the visualization (#281). When the plotted
+// range spans more than one calendar day, time-only labels ("14:30") are
+// ambiguous, so axis ticks, tooltips and the pan/zoom timeline show a date too.
+
+/** True when the two instants fall on different calendar days (local time). */
+export const spansMultipleDays = (minMs: number, maxMs: number): boolean =>
+  new Date(minMs).toDateString() !== new Date(maxMs).toDateString();
+
+/**
+ * Axis tick label: `HH:mm`, prefixed with a short `MM-DD` date on multi-day
+ * ranges so ticks that cross midnight stay unambiguous.
+ */
+export const formatAxisTime = (ms: number, multiDay: boolean): string => {
+  const d = new Date(ms);
+  const time = d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', hour12: false });
+  if (!multiDay) return time;
+  const date = d.toLocaleDateString(undefined, { month: '2-digit', day: '2-digit' });
+  return `${date} ${time}`;
+};
+
+/**
+ * Full timestamp for tooltips and the pan/zoom timeline edges: `HH:mm:ss`,
+ * with a `YYYY-MM-DD` date prefix on multi-day ranges.
+ */
+export const formatFullTime = (ms: number, multiDay: boolean): string => {
+  const d = new Date(ms);
+  const time = d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
+  if (!multiDay) return time;
+  const date = d.toLocaleDateString(undefined, { year: 'numeric', month: '2-digit', day: '2-digit' });
+  return `${date} ${time}`;
+};


### PR DESCRIPTION
Addresses three of the four parts of #281. The fourth — **replacing the x-axis with the pan/zoom timeline (green)** — is a larger, subjective visual redesign and is deferred to a separate PR.

## 🐞 Bug: chart no longer resets to the full range on each telegram

`uplot-react` defaults `resetScales=true`, so every live update called `setData(data, true)`, which re-ranged the x-scale to the **full data extent** — while the app-controlled zoom (React state) stayed put and kept driving the pan/zoom timeline. That mismatch is exactly the reported discrepancy.

Fix: pass **`resetScales={false}`** to both charts. Live telegrams then keep the current (app-controlled) range; an *options* change still recreates the chart at the correct range, so:
- **Zoomed:** options stable → `setData(data, false)` keeps the zoom. ✅
- **Not zoomed:** the range grows → options change → `optionsUpdateState === 'create'` recreates at the new full range. ✅

## 🟡 Date-aware time labels

Axis ticks, tooltips and the pan/zoom timeline edge labels now include a date once the visible range crosses midnight (time-only labels are ambiguous across days). Centralized in `utils/timeFormat.ts` (`spansMultipleDays` / `formatAxisTime` / `formatFullTime`).

## 🔵 Drag selection visible while dragging

uPlot draws a `.u-select` rectangle during a drag-to-zoom, but its default tint is near-invisible on the dark chart background. Added an accent fill + border so the selection shows while dragging.

## Verification

- `tsc`, ESLint, `vite build` clean.
- Full suite green (**210 tests**, incl. 6 new `timeFormat` unit tests); existing `TimeBrush` tests still pass.
- The uPlot rendering, live-reset behavior and the drag-select visual are layout/canvas-dependent, so those are left for the combined in-browser pre-release pass.

Part of #281 (green/x-axis replacement to follow separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)