### PR TITLE
release: prepare v1.16.0

### DIFF
--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.16.0
+
+### Added
+
+- **Quick filter bar in the telegram table**: a per-column regex/literal filter row on top of the main filter, for fast ad-hoc narrowing without opening the filter panel (#271).
+- **Group addresses as a sortable last-values table in the building view**: expanding a communication object or a function now shows its group addresses with name, role, last value and age, sortable by any column; the transmitting object's sending GA is highlighted (#268, #269).
+- **"Quick goto time" in the telegram list**: a clock button opens a time-entry popover that jumps the list to the telegram nearest that time and pauses live-follow — the jump-to-live pill brings you back (#282).
+- **Date-aware visualization labels**: axis ticks, tooltips and the pan/zoom timeline now show a date alongside the time once the visible range spans more than one day, and the drag-to-zoom selection is now visible while dragging (#281).
+- **DPT filter grouped by main data type** for easier browsing of large project DPT lists (#273).
+- **Double-click a pan/zoom timeline handle** to snap that edge to the earliest / newest data (#267).
+
+### Changed
+
+- **Zebra stripes stay with their telegram**, and clicking a row pauses live-follow so the row you are reading no longer shifts as new telegrams arrive (#266).
+
+### Fixed
+
+- **Visualization no longer resets to the full time range** when a new telegram arrives — the zoom and the pan/zoom timeline now stay in sync (#281).
+
 ## 1.15.1
 
 ### Fixed

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "1.15.1"
+version: "1.16.0"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.16.0
+
+### Added
+
+- **Quick filter bar in the telegram table**: a per-column regex/literal filter row on top of the main filter, for fast ad-hoc narrowing without opening the filter panel (#271).
+- **Group addresses as a sortable last-values table in the building view**: expanding a communication object or a function now shows its group addresses with name, role, last value and age, sortable by any column; the transmitting object's sending GA is highlighted (#268, #269).
+- **"Quick goto time" in the telegram list**: a clock button opens a time-entry popover that jumps the list to the telegram nearest that time and pauses live-follow — the jump-to-live pill brings you back (#282).
+- **Date-aware visualization labels**: axis ticks, tooltips and the pan/zoom timeline now show a date alongside the time once the visible range spans more than one day, and the drag-to-zoom selection is now visible while dragging (#281).
+- **DPT filter grouped by main data type** for easier browsing of large project DPT lists (#273).
+- **Double-click a pan/zoom timeline handle** to snap that edge to the earliest / newest data (#267).
+
+### Changed
+
+- **Zebra stripes stay with their telegram**, and clicking a row pauses live-follow so the row you are reading no longer shifts as new telegrams arrive (#266).
+
+### Fixed
+
+- **Visualization no longer resets to the full time range** when a new telegram arrives — the zoom and the pan/zoom timeline now stay in sync (#281).
+
 ## 1.15.1
 
 ### Fixed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.15.1"
+version: "1.16.0"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Release prep for **v1.16.0** — bumps both Home Assistant add-ons to 1.16.0 and adds their changelog entries.

## Highlights since v1.15.1

**Added**
- Quick filter bar in the telegram table (#271)
- Group addresses as a sortable last-values table in the building view (#268, #269)
- "Quick goto time" in the telegram list (#282)
- Date-aware visualization labels + visible drag-to-zoom selection (#281)
- DPT filter grouped by main data type (#273)
- Double-click a pan/zoom timeline handle to snap to min/max (#267)
- **Multi-architecture Docker image (amd64 + arm64)** — runs natively on Raspberry Pi (#285/#288)

**Changed**
- **Default web-UI port changed 8000 → 8765** to avoid the common Portainer conflict; `BIND_PORT` overrides are unaffected (#286)
- Zebra stripes stay with their telegram; clicking a row pauses live-follow (#266)
- Minimum Python lowered to 3.12 (#274)

**Fixed**
- Visualization no longer resets to the full time range when a new telegram arrives (#281)

## Verification
- Full unit suite green across the merged PRs; `tsc` / ESLint / `vite build` clean.
- E2E smoke pass on this candidate: app boot, live telegrams, goto-time popover + jump, quick filter bar, history view, and the visualization (date-aware axis `07/19–07/20`, pan/zoom timeline, survives live telegrams). Only console noise was a pre-existing, gracefully-handled `/api/database` 404 (unrelated to this release).

Tag `v1.16.0` will be pushed after merge to trigger the Docker (multi-arch), Debian, Windows and GitHub-release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)