### PR TITLE
Fix telegram-cache retention probe hitting a 404 endpoint

### DIFF
--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -56,7 +56,7 @@ beforeEach(() => {
     vi.fn(async (url: RequestInfo | URL) => {
       const u = String(url);
       fetchCalls.push(u);
-      if (u.includes('/api/database')) {
+      if (u.includes('/api/database/info')) {
         return jsonRes({ retention_days: null });
       }
       const next = telegramResponses.shift() ?? { telegrams: [] };

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -175,7 +175,7 @@ export function useTelegramCache(maxSize: number): TelegramCache {
 
       // Clamp everything to the backend's retention window when known.
       try {
-        const res = await fetch(apiUrl('/api/database'));
+        const res = await fetch(apiUrl('/api/database/info'));
         const info = await res.json();
         if (info.retention_days != null) {
           const minMs = Date.now() - (info.retention_days + 1) * 86_400_000;


### PR DESCRIPTION
## Problem

`useTelegramCache` clamps its cached coverage to the backend's retention window by fetching database info on every load — but it called **`/api/database`**, which doesn't exist. The route is **`/api/database/info`**. Result: a 404 on every load (surfaced during the v1.16.0 e2e pass) and retention clamping silently skipped (it's inside a `try/catch`, so it degraded quietly).

Pre-existing (unrelated to v1.16.0).

## Fix

- Point the fetch at `/api/database/info` (which returns `retention_days`).
- Tighten the test mock from `includes('/api/database')` to `includes('/api/database/info')` so the test actually guards the correct endpoint — the loose match is why this slipped through.

## Verification
- `useTelegramCache` suite green (10 tests); ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)