### PR TITLE
Add update check configuration to .env_example

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -86,6 +86,10 @@ LOG_LEVEL=INFO
 # your container, point this at a larger mounted volume for big imports.
 # TMPDIR=/project/tmp
 
+# Repo to check; overridable for forks. UPDATE_CHECK gates the outbound request.
+UPDATE_CHECK=true
+GITHUB_REPO=martinhoefling/SpectrumKNX
+
 # Full image name for the application (Docker/GHCR)
 # Used by docker-compose.yml
 APP_IMAGE=ghcr.io/martinhoefling/spectrumknx:latest


### PR DESCRIPTION
This commit adds configuration options for the update check feature to the .env_example file:
- UPDATE_CHECK: Enable/disable GitHub update checks
- GITHUB_REPO: Repository to check for updates

This allows users to easily configure these settings when setting up SpectrumKNX.