### PR TITLE
Freeze live view at capacity; progressive, capped history loads (#297, #284)

### DIFF
--- a/frontend/src/components/TelegramTable.test.tsx
+++ b/frontend/src/components/TelegramTable.test.tsx
@@ -114,6 +114,43 @@ test('clicking a row pauses live-following (#266)', () => {
   expect(screen.getByText(/1 new telegram/)).toBeInTheDocument();
 });
 
+test('newest-on-bottom: clicking a row stays anchored while the full buffer evicts (#297)', () => {
+  const asc: SortConfig = { key: 'timestamp', direction: 'asc' };
+  // In asc view the parent hands rows oldest-first, newest at the bottom edge.
+  const oldestFirst = (count: number, newestOffsetS: number) => makeList(count, newestOffsetS).slice().reverse();
+  const renderAsc = (telegrams: Telegram[]) =>
+    render(
+      <TelegramTable
+        telegrams={telegrams}
+        visibleColumns={visibleColumns}
+        sortConfig={asc}
+        onSort={vi.fn()}
+        activeFilters={DEFAULT_FILTERS}
+        onQuickFilter={vi.fn()}
+        onQuickVisualize={vi.fn()}
+      />,
+    );
+
+  const { container, rerender } = renderAsc(oldestFirst(6, 5));
+  // Click a row that is neither the oldest nor the newest, then simulate a
+  // capacity eviction: one new telegram at the bottom, one dropped from the top.
+  fireEvent.click(container.querySelectorAll('.log-row')[2]);
+  rerender(
+    <TelegramTable
+      telegrams={oldestFirst(6, 6)}
+      visibleColumns={visibleColumns}
+      sortConfig={asc}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+  // The list stayed anchored rather than snapping to the (bottom) live edge.
+  expect(screen.getByText(/1 new telegram/)).toBeInTheDocument();
+});
+
 test('without a click the table keeps following the live edge', () => {
   renderTable(makeList(6, 5));
   const { rerender } = renderTable(makeList(6, 5));

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -352,14 +352,24 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     : null;
 
   // Correct scrollTop so the anchored row keeps its recorded viewport offset.
-  // Only the top (newest-first) edge needs this — bottom-appends don't move the
-  // content above the viewport.
+  // Both edges need this. Newest-first (top edge) prepends live rows above the
+  // viewport; oldest-first (bottom edge) looks safe — bottom-appends don't move
+  // content above the viewport — until the buffer hits capacity, when each new
+  // telegram also evicts the oldest from the head, i.e. the top of the asc view,
+  // shifting everything above the viewport up and drifting the read row (#297).
+  // Progressive history chunks (#284) prepend older rows at the top of the asc
+  // view the same way; the measured pixel delta absorbs all of these uniformly.
   const pinAnchor = () => {
     const el = parentRef.current;
     const anchor = anchorRef.current;
-    if (!el || !anchor || atEdgeRef.current || liveEdge !== 'top') return;
+    if (!el || !anchor || atEdgeRef.current) return;
     const now = rowOffset(anchor.key);
-    if (now == null) return;
+    if (now == null) {
+      // The anchored row was evicted out from under us (#297): re-pin to the
+      // current top-most visible row so freezing continues from where we are.
+      captureAnchor();
+      return;
+    }
     const delta = now - anchor.offset;
     if (Math.abs(delta) > 0.5) {
       markProgrammatic();

--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -111,6 +111,31 @@ describe('useTelegramCache', () => {
     expect(Date.parse(params.get('start_time')!)).toBe(2001);
   });
 
+  it('hydrates only the newest slice of a large cache on startup, keeping the rest loadable (#284)', async () => {
+    // Seed more than the 5000 initial-load budget, all already covered so no
+    // gap fetch masks the cap.
+    const count = 5100;
+    seedIdb(Array.from({ length: count }, (_, i) => tg(i + 1, `c${i + 1}`)));
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1, count]]));
+    telegramResponses.push({ telegrams: [] }); // trailing [covered…now] gap is empty
+
+    const { result } = renderHook(() => useTelegramCache(100_000));
+    await settle(result);
+
+    // Only the newest 5000 paint; the older remainder stays in IDB untouched.
+    expect(result.current.telegrams).toHaveLength(5000);
+    expect(result.current.telegrams[0].source_address).toBe(`1.2.c${count}`);
+    expect(_idb.size).toBe(count);
+
+    // The older cached rows are still reachable on demand, from cache alone.
+    const before = fetchCalls.filter(u => u.includes('/api/telegrams')).length;
+    await act(async () => {
+      await result.current.loadRange(1, 100);
+    });
+    expect(result.current.telegrams).toHaveLength(count);
+    expect(fetchCalls.filter(u => u.includes('/api/telegrams')).length).toBe(before);
+  });
+
   it('publishes live telegrams newest first', async () => {
     const { result } = renderHook(() => useTelegramCache(1000));
     await settle(result);
@@ -189,14 +214,42 @@ describe('useTelegramCache', () => {
     expect(Date.parse(params.get('end_time')!)).toBe(999);
   });
 
-  it('keeps the unfetched remainder uncovered when the limit is reached', async () => {
-    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[10_000, 10_000]]));
-    telegramResponses.push({ telegrams: [] }); // startup gap fill
+  it('loads a gap in newest-first chunks, painting after each (#284)', async () => {
+    // Coverage forces a single gap [0, 6000]; the backend serves it in two chunks.
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[6001, 6001]]));
+    telegramResponses.push({ telegrams: [] }); // startup gap [6002, now]
+    telegramResponses.push({ telegrams: [tg(5000, 'a'), tg(4000, 'b')], limitReached: true }); // chunk 1 (newest)
+    telegramResponses.push({ telegrams: [tg(3000, 'c'), tg(2000, 'd')] }); // chunk 2 (older, final)
 
     const { result } = renderHook(() => useTelegramCache(1000));
     await settle(result);
 
-    // Only the newest row of [0, 9999] arrives.
+    const before = fetchCalls.filter(u => u.includes('/api/telegrams')).length;
+    await act(async () => {
+      await result.current.loadRange(0, 6000);
+    });
+    const loadFetches = fetchCalls.filter(u => u.includes('/api/telegrams')).length - before;
+
+    // Two chunk requests, all four telegrams merged newest-first.
+    expect(loadFetches).toBe(2);
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual([
+      '1.2.a', '1.2.b', '1.2.c', '1.2.d',
+    ]);
+    // The second chunk paged back to just the older remainder (up to chunk 1's oldest ts).
+    const chunk2 = fetchCalls.filter(u => u.includes('/api/telegrams')).at(-1)!;
+    const chunk2Params = new URLSearchParams(chunk2.split('?')[1]);
+    expect(Date.parse(chunk2Params.get('end_time')!)).toBe(4000);
+  });
+
+  it('stops at the load budget and leaves the older remainder uncovered (#284)', async () => {
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[10_000, 10_000]]));
+    telegramResponses.push({ telegrams: [] }); // startup gap fill
+
+    // Buffer size 1 → the load budget is a single telegram: the first chunk
+    // exhausts it and paging stops, deferring the rest.
+    const { result } = renderHook(() => useTelegramCache(1));
+    await settle(result);
+
     telegramResponses.push({ telegrams: [tg(9000, 'partial')], limitReached: true });
     await act(async () => {
       await result.current.loadRange(0, 10_000);

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -16,6 +16,20 @@ const FLUSH_INTERVAL_MS = 2000;
 const FLUSH_BATCH_SIZE = 200;
 /** Cache size enforcement cadence (in flush ticks: 30 × 2 s = every minute). */
 const EVICT_EVERY_TICKS = 30;
+/**
+ * Telegrams pulled in for the first paint on startup (#284). We hydrate only
+ * the newest slice from cache and fetch at most this many from the backend,
+ * newest-first; older history stays in IDB and is loaded on demand via the
+ * history loader. Keeps startup cheap on low-power hosts (e.g. RasPi4) and the
+ * buffer off its capacity ceiling, where eviction churn lives (#297).
+ */
+const INITIAL_LOAD_LIMIT = 5000;
+/**
+ * Rows fetched per backend request while filling a gap (#284). History loads
+ * page backward in chunks of this size and paint after every chunk, so the list
+ * and charts build progressively instead of blocking on one large fetch.
+ */
+const HISTORY_CHUNK_SIZE = 2000;
 
 export interface TelegramCache {
   /** Current buffer contents, newest first. Frozen while paused. */
@@ -117,26 +131,67 @@ export function useTelegramCache(maxSize: number): TelegramCache {
     saveCoverageIntervals(coverageRef.current!.covered);
   }, []);
 
-  /** Fetches every uncovered sub-range of [startMs, endMs] from the backend. */
-  const fillGaps = useCallback(
-    async (startMs: number, endMs: number) => {
-      const coverage = coverageRef.current!;
-      for (const [gapStart, gapEnd] of coverage.gaps(startMs, endMs)) {
-        const { entries, limitReached } = await fetchRange(gapStart, gapEnd, maxSize);
+  /**
+   * Progressively fills one uncovered sub-range, newest-first, publishing after
+   * every chunk so the UI builds as data streams in (#284). Pages backward in
+   * `HISTORY_CHUNK_SIZE` requests until the gap is exhausted or `budget` rows
+   * have been fetched; a budget cut-off leaves the older remainder uncovered for
+   * a later load. Returns how many telegrams were fetched (for cross-gap budgeting).
+   */
+  const fetchGapProgressive = useCallback(
+    async (gapStart: number, gapEnd: number, budget: number): Promise<number> => {
+      let cursor = gapEnd;
+      let fetched = 0;
+      while (cursor >= gapStart && fetched < budget) {
+        const limit = Math.min(HISTORY_CHUNK_SIZE, budget - fetched);
+        const { entries, limitReached } = await fetchRange(gapStart, cursor, limit);
+        if (entries.length === 0) {
+          // Nothing left in this window — the rest is covered-but-empty.
+          coverageRef.current!.addCovered(gapStart, cursor);
+          break;
+        }
         if (mergeIntoBuffer(entries)) publish();
         cacheRef.current!.store(entries).catch(() => {});
-        if (limitReached && entries.length > 0) {
-          // Only the newest `limit` rows arrived — the older remainder of the
-          // gap stays uncovered so a later load can still fetch it.
-          const oldestTs = entries[entries.length - 1].ts;
-          coverage.addCovered(oldestTs, gapEnd);
-        } else {
-          coverage.addCovered(gapStart, gapEnd);
+        fetched += entries.length;
+        const oldestTs = entries[entries.length - 1].ts;
+        coverageRef.current!.addCovered(oldestTs, cursor);
+        if (!limitReached) {
+          // The whole remaining window came back — the gap is fully covered.
+          coverageRef.current!.addCovered(gapStart, cursor);
+          break;
         }
+        // Page further back. Re-including `oldestTs` (dedup handles the repeat)
+        // avoids dropping siblings that share that millisecond; step past it only
+        // when a whole chunk sat on one timestamp, to guarantee progress.
+        cursor = oldestTs < cursor ? oldestTs : cursor - 1;
+      }
+      return fetched;
+    },
+    [mergeIntoBuffer, publish],
+  );
+
+  /**
+   * Fills the uncovered sub-ranges of [startMs, endMs] newest-first, chunk by
+   * chunk, up to `budget` telegrams total. Older gaps (and the remainder of the
+   * gap where the budget runs out) stay uncovered for on-demand loading, so a
+   * load never blocks on more history than asked for (#284).
+   */
+  const fillGapsBudgeted = useCallback(
+    async (startMs: number, endMs: number, budget: number) => {
+      const gaps = coverageRef.current!.gaps(startMs, endMs);
+      let remaining = budget;
+      for (let i = gaps.length - 1; i >= 0 && remaining > 0; i--) {
+        remaining -= await fetchGapProgressive(gaps[i][0], gaps[i][1], remaining);
       }
       saveCoverage();
     },
-    [maxSize, mergeIntoBuffer, publish, saveCoverage],
+    [fetchGapProgressive, saveCoverage],
+  );
+
+  /** Fills every uncovered sub-range of [startMs, endMs], bounded by the buffer size. */
+  const fillGaps = useCallback(
+    (startMs: number, endMs: number) => fillGapsBudgeted(startMs, endMs, maxSize),
+    [fillGapsBudgeted, maxSize],
   );
 
   /** Wraps a background load with the shared loading/error state. */
@@ -189,15 +244,21 @@ export function useTelegramCache(maxSize: number): TelegramCache {
 
       const cached = await cacheRef.current!.loadAll().catch(() => [] as TelegramEntry[]);
       if (cancelled) return;
-      if (cached.length > 0 && mergeIntoBuffer(cached)) publish();
+      // Hydrate only the newest slice for a fast first paint; the older cached
+      // remainder stays in IDB and is pulled in on demand via the history
+      // loader / lazy loads (#284). Never exceed the configured buffer size.
+      const budget = Math.min(INITIAL_LOAD_LIMIT, maxSize);
+      const initialCached = cached.slice(0, budget);
+      if (initialCached.length > 0 && mergeIntoBuffer(initialCached)) publish();
 
-      // Fill everything between the oldest known data and now (#211): the
-      // dashboard-switch / closed-tab window arrives without user action.
+      // Fill the most recent gaps up to the budget (#211): the dashboard-switch
+      // / closed-tab window arrives without user action, but older history is
+      // deferred so startup stays cheap on low-power hosts.
       const coveredStart = coverage.covered[0]?.[0];
       const oldestCached = cached.length > 0 ? cached[cached.length - 1].ts : undefined;
       const start = Math.min(coveredStart ?? Infinity, oldestCached ?? Infinity);
       if (Number.isFinite(start)) {
-        await fillGaps(start, Date.now());
+        await fillGapsBudgeted(start, Date.now(), budget);
       }
     });
     return () => {


### PR DESCRIPTION
Fixes #297, and implements the functional part of #284 — two Group Monitor issues surfaced by the telegram caching work. (The cosmetic status-bar tweak that completes #284 is in #301.)

## #297 — freeze-on-click didn't hold newest-on-bottom with a full buffer

Clicking a telegram is supposed to freeze the live view so you can read it. It worked in the default (newest-first) sort but not with newest-on-bottom once the 100k buffer filled.

**Cause:** `pinAnchor` only compensated scroll for the top edge, on the assumption that bottom-appends never move content above the viewport. That holds until the buffer hits capacity — then every new telegram also evicts the oldest from the head, which in the ascending view is the *top* of the list. Content above the viewport shifts up, and with native scroll-anchoring disabled the "frozen" row drifts.

**Fix:** the key-based anchor correction was always direction-agnostic (it corrects `scrollTop` by the measured pixel delta of a concrete row), so the edge guard is dropped. It now also re-pins to the top-most visible row when the anchored row is itself evicted (TabSel's "click the oldest row and it vanishes" case).

## #284 — progressive history loading + capped startup

History used to be considered only after the *entire* range finished fetching — loading 7 days meant a long blank wait. Now:

- **Progressive chunks:** each gap is fetched newest-first in `HISTORY_CHUNK_SIZE` requests, painting after every chunk, so the list and charts build as data streams in.
- **Capped startup:** on load we hydrate only the newest slice from the IndexedDB cache and fetch at most an initial budget (5000) from the backend, newest-first. Older history stays cached in IndexedDB and loads on demand via the history loader — no backend round-trip. This keeps first paint cheap on low-power hosts (RasPi4) and, as a bonus, keeps the buffer off the capacity ceiling where the #297 eviction churn lives.

Older cached telegrams are **not** deleted (that would conflate the display limit with cache retention and force re-fetches); cache size stays bounded independently by the existing `MAX_CACHE_SIZE`.

## Verification

- Unit tests (213 pass, tsc clean): edge-agnostic anchoring in ascending order; startup hydration cap with older rows still cache-loadable; newest-first chunked paging; budget cut-off deferring the remainder.
- Headless browser (Playwright, injected telegram stream / stubbed chunked backend):
  - **#297:** selected row holds at **0px drift** across eviction churn (reverting the fix reproduces a 584px drift).
  - **#284:** a large startup gap builds the buffer incrementally over 3 chunk requests (2000 → 3999 → 4998; the ~2-row shortfall is the per-chunk dedup boundary, deferred not lost).

## Not included

The issue's secondary suggestion to relocate the buffer icons into a status bar is a cosmetic reshuffle and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)