### PR TITLE
Building structure: resolve function GA names + readable value table (#295)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -602,10 +602,21 @@ def _build_space(space: dict, devices: dict, cos: dict, gas: dict, functions_dic
         if func:
             group_addresses = []
             for ga_addr, ga_ref in func.get("group_addresses", {}).items():
+                ga_master = gas.get(ga_addr) or {}
+                dpt = ga_master.get("dpt")
+                # The function ref's own name is empty and its "role" is an opaque
+                # UUID; resolve the real GA name + DPT from the project (#295).
                 group_addresses.append({
                     "address": ga_addr,
-                    "name": ga_ref.get("name", ""),
-                    "role": ga_ref.get("role", "")
+                    "name": ga_master.get("name") or ga_ref.get("name", ""),
+                    "dpts": (
+                        [{
+                            "main": dpt.get("main"),
+                            "sub": dpt.get("sub"),
+                            "name": format_dpt_name(dpt.get("main"), dpt.get("sub"))[0],
+                        }]
+                        if dpt else []
+                    ),
                 })
             space_functions.append({
                 "id": func_id,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -108,7 +108,9 @@ def test_get_building_with_project():
                 "name": "Dimming Light",
                 "function_type": "Dimming",
                 "group_addresses": {
-                    "1/2/3": {"name": "Light On/Off", "role": "Switch"}
+                    # As in real projects: the function ref carries no name and an
+                    # opaque UUID role — the real name/DPT come from the project (#295).
+                    "1/2/3": {"name": "", "role": "98139557-C86A-4134-AB91-325CF8ECFC2A"}
                 }
             }
         },
@@ -145,7 +147,7 @@ def test_get_building_with_project():
             "O-3": {"number": 3, "name": "Status", "text": "State", "group_address_links": ["1/2/4"]},
         },
         "group_addresses": {
-            "1/2/3": {"name": "Light On/Off"},
+            "1/2/3": {"name": "Light On/Off", "dpt": {"main": 1, "sub": 1}},
             "1/2/4": {"name": "Light Status"},
         },
     }
@@ -165,7 +167,12 @@ def test_get_building_with_project():
     assert func["id"] == "Func-1"
     assert func["name"] == "Dimming Light"
     assert func["type"] == "Dimming"
-    assert func["group_addresses"] == [{"address": "1/2/3", "name": "Light On/Off", "role": "Switch"}]
+    ga = func["group_addresses"][0]
+    assert ga["address"] == "1/2/3"
+    assert ga["name"] == "Light On/Off"  # resolved from the project, not the empty ref (#295)
+    assert "role" not in ga  # opaque UUID no longer surfaced
+    assert ga["dpts"][0]["main"] == 1 and ga["dpts"][0]["sub"] == 1
+    assert ga["dpts"][0]["name"].startswith("1.001")
 
     device = floor["devices"][0]
     assert device["address"] == "1.1.1"

--- a/frontend/src/components/BuildingOverlay.tsx
+++ b/frontend/src/components/BuildingOverlay.tsx
@@ -43,7 +43,7 @@ export interface DeviceNode {
 export interface FunctionGA {
   address: string;
   name: string;
-  role: string;
+  dpts?: { main: number; sub: number | null; name?: string | null }[];
 }
 
 export interface FunctionNode {
@@ -299,10 +299,12 @@ const KoRow: React.FC<{
           entries={ko.group_addresses.map(ga => ({
             address: ga.address,
             name: ga.name || '',
+            dpt: ko.dpts?.[0],
             sending: ga.address === sendingGA,
           }))}
           depth={depth + 1}
           latestTelegram={latestTelegram}
+          writeEnabled={writeEnabled}
           onFilterGAs={onFilterGAs}
           onLastSeen={onLastSeen}
         />
@@ -481,8 +483,9 @@ const FunctionRow: React.FC<{
   query: string;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  writeEnabled?: boolean;
   latestTelegram?: Telegram | null;
-}> = ({ func, depth, query, onFilterGAs, onLastSeen, latestTelegram }) => {
+}> = ({ func, depth, query, onFilterGAs, onLastSeen, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`func:${func.id}`, false);
   const effectiveOpen = open || !!query;
   const allGAs = useMemo(() => func.group_addresses.map(g => g.address), [func]);
@@ -539,10 +542,11 @@ const FunctionRow: React.FC<{
           entries={func.group_addresses.map(ga => ({
             address: ga.address,
             name: ga.name || '',
-            role: ga.role || undefined,
+            dpt: ga.dpts?.[0],
           }))}
           depth={depth + 1}
           latestTelegram={latestTelegram}
+          writeEnabled={writeEnabled}
           onFilterGAs={onFilterGAs}
           onLastSeen={onLastSeen}
         />
@@ -603,7 +607,7 @@ const SpaceRow: React.FC<{
           {visibleFunctions.map((func, i) => (
             <FunctionRow
               key={`${func.id}-${i}`} func={func} depth={depth + 1} query={query}
-              onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} latestTelegram={latestTelegram}
+              onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
           {visibleDevices.map(device => (

--- a/frontend/src/components/GaValuesTable.tsx
+++ b/frontend/src/components/GaValuesTable.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { Filter, Clock, ChevronUp, ChevronDown, Send } from 'lucide-react';
+import { format } from 'date-fns';
+import { Filter, Clock, ChevronUp, ChevronDown } from 'lucide-react';
 import { apiUrl } from '../utils/basePath';
+import { SendToGaPopover } from './SendToGaPopover';
 import type { Telegram } from '../hooks/useWebSocket';
 
 // Sortable table of group addresses with their last seen values (#269).
@@ -9,12 +11,13 @@ import type { Telegram } from '../hooks/useWebSocket';
 export interface GaTableEntry {
   address: string;
   name: string;
-  role?: string;
+  /** DPT of the address, resolved from the project (#295). */
+  dpt?: { main: number; sub: number | null; name?: string | null };
   /** The GA this KO sends on (first ETS link of a transmitting object). */
   sending?: boolean;
 }
 
-type SortKey = 'ga' | 'name' | 'role' | 'time';
+type SortKey = 'ga' | 'name' | 'time';
 
 interface GaValuesTableProps {
   entries: GaTableEntry[];
@@ -22,6 +25,8 @@ interface GaValuesTableProps {
   depth: number;
   /** Newest telegram from the live websocket feed; used to update values in place. */
   latestTelegram?: Telegram | null;
+  /** Show the per-row "send to this GA" action when the bus is writable. */
+  writeEnabled?: boolean;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
 }
@@ -32,13 +37,17 @@ const gaSortValue = (address: string): number => {
   return parts.reduce((acc, p) => acc * 2048 + p, 0);
 };
 
-function ageOf(timestamp: string): string {
-  const diffMs = Date.now() - new Date(timestamp).getTime();
-  if (diffMs < 60_000) return `${Math.max(0, Math.round(diffMs / 1000))}s ago`;
-  if (diffMs < 3_600_000) return `${Math.round(diffMs / 60_000)}m ago`;
-  if (diffMs < 86_400_000) return `${Math.round(diffMs / 3_600_000)}h ago`;
-  return `${Math.round(diffMs / 86_400_000)}d ago`;
-}
+// "1.011 - Switch" → "1.011 Switch"; falls back to the bare "main.sub" number (#295).
+const formatDptLabel = (dpt?: GaTableEntry['dpt']): string | null => {
+  if (!dpt || dpt.main == null) return null;
+  const num = dpt.sub != null ? `${dpt.main}.${String(dpt.sub).padStart(3, '0')}` : String(dpt.main);
+  let desc = '';
+  if (dpt.name) {
+    const sep = dpt.name.indexOf(' - ');
+    desc = sep >= 0 ? dpt.name.slice(sep + 3) : dpt.name === num ? '' : dpt.name;
+  }
+  return desc ? `${num} ${desc}` : num;
+};
 
 const cellStyle: React.CSSProperties = {
   padding: '0.25rem 0.5rem',
@@ -84,7 +93,7 @@ const HeaderCell: React.FC<{
 };
 
 export const GaValuesTable: React.FC<GaValuesTableProps> = ({
-  entries, depth, latestTelegram, onFilterGAs, onLastSeen,
+  entries, depth, latestTelegram, writeEnabled, onFilterGAs, onLastSeen,
 }) => {
   const [valuesByGA, setValuesByGA] = useState<Record<string, Telegram>>({});
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null);
@@ -126,8 +135,6 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
       return null; // third click restores ETS order
     });
 
-  const hasRole = entries.some(e => e.role);
-
   const sorted = useMemo(() => {
     if (!sort) return entries;
     const dir = sort.dir === 'asc' ? 1 : -1;
@@ -137,8 +144,6 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
           return dir * (gaSortValue(a.address) - gaSortValue(b.address));
         case 'name':
           return dir * (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' });
-        case 'role':
-          return dir * (a.role || '').localeCompare(b.role || '', undefined, { sensitivity: 'base' });
         case 'time': {
           // Never-seen entries always sort to the end.
           const ta = valuesByGA[a.address] ? new Date(valuesByGA[a.address].timestamp).getTime() : null;
@@ -159,15 +164,16 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
           <tr>
             <HeaderCell label="GA" sortKey="ga" sort={sort} onSort={handleSort} />
             <HeaderCell label="Name" sortKey="name" sort={sort} onSort={handleSort} />
-            {hasRole && <HeaderCell label="Role" sortKey="role" sort={sort} onSort={handleSort} />}
-            <HeaderCell label="Value" sort={sort} onSort={handleSort} />
+            <HeaderCell label="DPT" sort={sort} onSort={handleSort} />
             <HeaderCell label="Time" sortKey="time" sort={sort} onSort={handleSort} />
+            <HeaderCell label="Value" sort={sort} onSort={handleSort} />
             <th style={{ ...cellStyle, borderBottom: '1px solid var(--border-subtle)', width: '1%' }} />
           </tr>
         </thead>
         <tbody>
           {sorted.map(entry => {
             const t = valuesByGA[entry.address];
+            const dptLabel = formatDptLabel(entry.dpt);
             return (
               <tr
                 key={entry.address}
@@ -175,32 +181,37 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
                 title={entry.sending ? 'Sending group address' : undefined}
               >
                 <td style={{ ...cellStyle, width: '1%' }}>
-                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.3rem' }}>
-                    <span style={{
+                  {/* The sending GA is framed rather than icon-tagged (#295). */}
+                  <span
+                    aria-label={entry.sending ? 'sending' : undefined}
+                    style={{
                       fontFamily: "'JetBrains Mono', monospace",
                       color: 'var(--accent-primary)',
                       fontWeight: entry.sending ? 700 : 400,
-                    }}>{entry.address}</span>
-                    {entry.sending && (
-                      <Send size={10} style={{ color: 'var(--accent-primary)', flexShrink: 0 }} aria-label="sending" />
-                    )}
-                  </span>
+                      ...(entry.sending
+                        ? {
+                            display: 'inline-block',
+                            border: '1px solid var(--accent-primary)',
+                            borderRadius: '4px',
+                            padding: '0.02rem 0.3rem',
+                          }
+                        : {}),
+                    }}
+                  >{entry.address}</span>
                 </td>
-                <td style={{ ...cellStyle, maxWidth: 0, color: 'var(--text-dim)' }} title={entry.name || undefined}>
+                <td style={{ ...cellStyle, maxWidth: 300, color: 'var(--text-dim)' }} title={entry.name || undefined}>
                   {entry.name || '—'}
                 </td>
-                {hasRole && (
-                  <td style={{ ...cellStyle, width: '1%' }}>
-                    {entry.role ? (
-                      <span style={{
-                        fontSize: '0.62rem', fontWeight: 600, color: 'var(--text-dim)',
-                        textTransform: 'uppercase', background: 'var(--bg-tag)',
-                        padding: '0.05rem 0.25rem', borderRadius: '3px',
-                      }}>{entry.role}</span>
-                    ) : '—'}
-                  </td>
-                )}
-                <td style={{ ...cellStyle, width: '1%', fontWeight: 600, color: t ? 'var(--text-main)' : 'var(--text-dim)' }}>
+                <td style={{ ...cellStyle, width: '1%', color: 'var(--text-dim)' }} title={dptLabel || undefined}>
+                  {dptLabel || '—'}
+                </td>
+                <td
+                  style={{ ...cellStyle, width: '1%', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}
+                  title={t ? `by ${t.source_address}${t.source_name ? ` (${t.source_name})` : ''}` : 'Never updated'}
+                >
+                  {t ? format(new Date(t.timestamp), 'yyyy-MM-dd HH:mm:ss.SS') : '—'}
+                </td>
+                <td style={{ ...cellStyle, fontWeight: 600, color: t ? 'var(--text-main)' : 'var(--text-dim)' }}>
                   {t ? (
                     <>
                       {t.value_formatted ?? t.value_numeric ?? '—'}
@@ -208,31 +219,36 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
                     </>
                   ) : 'never seen'}
                 </td>
-                <td
-                  style={{ ...cellStyle, width: '1%', color: 'var(--text-dim)' }}
-                  title={t ? `Last updated: ${new Date(t.timestamp).toLocaleString()}\nby ${t.source_address}${t.source_name ? ` (${t.source_name})` : ''}` : 'Never updated'}
-                >
-                  {t ? ageOf(t.timestamp) : '—'}
-                </td>
                 <td style={{ ...cellStyle, width: '1%' }}>
-                  <button
-                    style={iconBtnStyle}
-                    title="Filter by this group address"
-                    onClick={e => { e.stopPropagation(); onFilterGAs([entry.address]); }}
-                    onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
-                    onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
-                  >
-                    <Filter size={11} />
-                  </button>
-                  <button
-                    style={iconBtnStyle}
-                    title="Show last seen values"
-                    onClick={e => { e.stopPropagation(); onLastSeen([entry.address], 'ga'); }}
-                    onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
-                    onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
-                  >
-                    <Clock size={11} />
-                  </button>
+                  <span style={{ display: 'inline-flex', alignItems: 'center' }}>
+                    {writeEnabled && entry.dpt?.main != null && (
+                      <SendToGaPopover
+                        address={entry.address}
+                        name={entry.name}
+                        dptMain={entry.dpt.main}
+                        dptSub={entry.dpt.sub}
+                        buttonStyle={iconBtnStyle}
+                      />
+                    )}
+                    <button
+                      style={iconBtnStyle}
+                      title="Filter by this group address"
+                      onClick={e => { e.stopPropagation(); onFilterGAs([entry.address]); }}
+                      onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                      onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                    >
+                      <Filter size={11} />
+                    </button>
+                    <button
+                      style={iconBtnStyle}
+                      title="Show last seen values"
+                      onClick={e => { e.stopPropagation(); onLastSeen([entry.address], 'ga'); }}
+                      onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                      onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                    >
+                      <Clock size={11} />
+                    </button>
+                  </span>
                 </td>
               </tr>
             );


### PR DESCRIPTION
Fixes #295.

The **Building → functions → associated GAs** table showed each GA with an empty **Name** and an opaque **Role** UUID, in a layout wide enough to be unreadable. Root cause: a function's GA ref carries no name and only a GUID role — the real name and DPT live in the project's group-address table.

### Backend (`/api/building`)
For each function GA, resolve the **name** and **DPT** from the project's `group_addresses` instead of the ref, and drop the role UUID from the response.

### Frontend (`GaValuesTable`, shared by the KO and function tables)
- Reordered columns to **GA · Name · DPT · Time · Value**, with Value taking the remaining width.
- Replaced the Role column with a **DPT** column (e.g. `1.011 Status`).
- **Absolute timestamp** (`2026-07-21 08:07:03.38`) instead of relative `5 min ago`.
- The sending GA is now **framed** rather than tagged with a send icon; the send icon is repurposed as the per-row **"send to bus"** popover (shown when the bus is writable).

### Result (headless-browser capture of the stubbed function)

```
GA         NAME                              DPT           TIME                     VALUE
19/4/144   MTR_Lastueberschreitung_M2E       1.011 Status  2026-07-21 08:07:03.38   active
4/6/17     EGW_JALB1UP_Automatikposition_3   1.008 Up/Down  —                       never seen
18/2/6     DIM_Sperren_D1G                   1.011 Status   —                       never seen
```

Matches the layout requested in the issue.

### Notes / scope
- The GA **framing** for the *sending* address works for KO tables (driven by the transmit flag). For **functions** we can't reliably identify the sending GA — that information is encoded in the role GUID, which references the application's function-type role definitions and isn't decoded by our project parser — so function rows aren't framed. Happy to add it if we later decode that mapping.
- `#296` (nested channel folders) is a separate, deeper parser limitation blocked on upstream `xknxproject` support — documented in a comment there.

### Tests
- Backend `test_api.py` updated to assert name/DPT resolution and absence of the role field (37 pass).
- Frontend suite green (213 pass), `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)