### PR TITLE
release: prepare v1.16.1

### DIFF
--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.16.1
+
+### Added
+
+- **Progressive history loading**: history now loads in newest-first chunks and paints after each chunk, and startup restores only the most recent telegrams (older history is fetched on demand). The telegram list and charts build quickly even on low-power hosts like a Raspberry Pi, instead of waiting for the whole history read to finish (#284).
+
+### Changed
+
+- **Buffer controls moved into the status bar**: the clear and load-history actions now sit next to the buffer count, with an inline marker when the buffer is full (#284).
+
+### Fixed
+
+- **Freeze-on-click in the group monitor** now holds with newest-on-bottom sorting even when the buffer is full: selecting a telegram keeps it in place instead of drifting upward as older rows are evicted (#297).
+- Telegram-cache retention probe no longer requests a missing endpoint (#294).
+
 ## 1.16.0
 
 ### Added

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "1.16.0"
+version: "1.16.1"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.16.1
+
+### Added
+
+- **Progressive history loading**: history now loads in newest-first chunks and paints after each chunk, and startup restores only the most recent telegrams (older history is fetched on demand). The telegram list and charts build quickly even on low-power hosts like a Raspberry Pi, instead of waiting for the whole history read to finish (#284).
+
+### Changed
+
+- **Buffer controls moved into the status bar**: the clear and load-history actions now sit next to the buffer count, with an inline marker when the buffer is full (#284).
+
+### Fixed
+
+- **Freeze-on-click in the group monitor** now holds with newest-on-bottom sorting even when the buffer is full: selecting a telegram keeps it in place instead of drifting upward as older rows are evicted (#297).
+- Telegram-cache retention probe no longer requests a missing endpoint (#294).
+
 ## 1.16.0
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.16.0"
+version: "1.16.1"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Patch release since **v1.16.0**, focused on the Group Monitor telegram cache. Bumps both Home Assistant add-ons to **1.16.1**.

### Fixed
- **Freeze-on-click in the group monitor** now holds with newest-on-bottom sorting even when the buffer is full — a selected telegram stays put instead of drifting upward as older rows are evicted (#297, PR #300).
- **Telegram-cache retention probe** no longer requests a missing endpoint (#294).

### Added
- **Progressive history loading**: history loads in newest-first chunks and paints after each chunk; startup restores only the most recent telegrams and fetches older history on demand, so the list and charts build quickly on low-power hosts like a Raspberry Pi (#284, PR #300).

### Changed
- **Buffer controls moved into the status bar**: clear and load-history now sit next to the buffer count, with an inline "buffer full" marker (#284, PR #301).

### Release mechanics
Only the two add-on `config.yaml` versions and CHANGELOGs change, per the tag-driven flow (`frontend/package.json` stays `0.0.0`; version is surfaced at runtime from the git tag). Merging this and pushing the **`v1.16.1`** tag triggers `release.yml` (Docker image + GitHub Release).

Not included: #302 (building-structure function GA names, #295) is still open and will land in a later release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)