### PR TITLE
Add setting to load cached telegrams on startup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -203,6 +203,10 @@ function App() {
     };
   });
   const [rateMode, setRateMode] = useState<'s' | 'm' | 'h'>((getPref('rateMode') as 's' | 'm' | 'h') || 's');
+  // Restore the browser telegram cache (and fill the gap from the backend) on
+  // startup. On by default; when off the view starts empty and shows only live
+  // telegrams and manual history loads (#246).
+  const [restoreOnStartup, setRestoreOnStartup] = useState(() => getPref('restoreOnStartup') !== 'false');
 
   const [isHistoryLoaderOpen, setIsHistoryLoaderOpen] = useState(false);
   const [selectedVisualizationTargets, setSelectedVisualizationTargets] = useState<string[]>(
@@ -222,7 +226,7 @@ function App() {
     isLoading: isHistoryLoading,
     loadError: historyLoadError,
     clear: clearTelegrams,
-  } = useTelegramCache(loadLimit);
+  } = useTelegramCache(loadLimit, restoreOnStartup);
   const [isPaused, setIsPaused] = useState(false);
 
   // ── Rate Estimation ─────────────────────────────────────────────────────────
@@ -374,7 +378,8 @@ function App() {
     setPref('loadLimit', loadLimit.toString());
     setPref('visibleColumns', JSON.stringify(visibleColumns));
     setPref('rateMode', rateMode);
-  }, [loadLimit, visibleColumns, rateMode]);
+    setPref('restoreOnStartup', String(restoreOnStartup));
+  }, [loadLimit, visibleColumns, rateMode, restoreOnStartup]);
 
   // ── Persist workspace (#211) ────────────────────────────────────────────────
   const workspaceView: WorkspaceView = isVisualizerOpen
@@ -833,6 +838,21 @@ function App() {
                   onChange={e => setLoadLimit(Number(e.target.value))}
                 />
               </div>
+
+              <h3 style={{ fontSize: '0.75rem', color: 'var(--text-dim)', textTransform: 'uppercase', marginBottom: '0.75rem', letterSpacing: '0.05em', marginTop: '1.5rem' }}>
+                Startup
+              </h3>
+              <button
+                className="setting-item"
+                onClick={() => setRestoreOnStartup(v => !v)}
+                title="Restore recent telegrams from the browser cache and fill the gap from the server on load. When off, the view starts empty and shows only live telegrams and manual history loads."
+                style={{ padding: '0.5rem', background: 'var(--bg-subtle)', borderRadius: 6, marginBottom: '2rem' }}
+              >
+                <div className={`checkbox ${restoreOnStartup ? 'checked' : ''}`} style={{ width: 14, height: 14, border: '1px solid var(--border-color)', borderRadius: 3, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                  {restoreOnStartup && <div style={{ width: 8, height: 8, background: 'white', borderRadius: 2 }} />}
+                </div>
+                <span style={{ fontSize: '0.85rem' }}>Load cached telegrams on startup</span>
+              </button>
 
               <>
                 <h3 style={{ fontSize: '0.75rem', color: 'var(--text-dim)', textTransform: 'uppercase', marginBottom: '0.75rem', letterSpacing: '0.05em', marginTop: '1.5rem' }}>

--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -111,6 +111,34 @@ describe('useTelegramCache', () => {
     expect(Date.parse(params.get('start_time')!)).toBe(2001);
   });
 
+  it('skips the startup restore when restoreFromCache is off, keeping live and manual loads', async () => {
+    seedIdb([tg(1000, 'a'), tg(2000, 'b')]);
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1000, 2000]]));
+
+    const { result } = renderHook(() => useTelegramCache(1000, false));
+    await settle(result);
+
+    // Nothing restored and nothing fetched from the backend on startup.
+    expect(result.current.telegrams).toEqual([]);
+    expect(fetchCalls.filter(u => u.includes('/api/telegrams'))).toEqual([]);
+
+    // Live telegrams still flow into the view.
+    act(() => {
+      result.current.addLive(tg(3000, 'live'));
+    });
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.live']);
+
+    // A manual history load still serves cache hits.
+    await act(async () => {
+      await result.current.loadRange(1000, 2000);
+    });
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual([
+      '1.2.live',
+      '1.2.b',
+      '1.2.a',
+    ]);
+  });
+
   it('hydrates only the newest slice of a large cache on startup, keeping the rest loadable (#284)', async () => {
     // Seed more than the 5000 initial-load budget, all already covered so no
     // gap fetch masks the cap.

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -85,8 +85,13 @@ async function fetchRange(startMs: number, endMs: number, limit: number): Promis
  *
  * The persistent cache is advisory: every IDB/backend failure degrades to
  * live-only behavior identical to the pre-cache app.
+ *
+ * `restoreFromCache` (default on) controls the startup restore only: when off,
+ * the buffer starts empty and only live telegrams and explicit `loadRange`
+ * calls (the history loader) populate it. Live telegrams are still flushed to
+ * the cache, so re-enabling the setting restores them on the next reload.
  */
-export function useTelegramCache(maxSize: number): TelegramCache {
+export function useTelegramCache(maxSize: number, restoreFromCache = true): TelegramCache {
   const bufferRef = useRef<TelegramBufferService | null>(null);
   bufferRef.current ??= new TelegramBufferService(maxSize);
   const cacheRef = useRef<TelegramCacheService | null>(null);
@@ -223,6 +228,9 @@ export function useTelegramCache(maxSize: number): TelegramCache {
 
   // ── Startup: restore cache + coverage, then fill gaps up to now ─────────────
   useEffect(() => {
+    // When restore is disabled the view starts empty; only live telegrams and
+    // manual history loads populate it (the setting is read once, at mount).
+    if (!restoreFromCache) return;
     let cancelled = false;
     void runLoad(async () => {
       const coverage = coverageRef.current!;


### PR DESCRIPTION
## Summary

Adds a **"Load cached telegrams on startup"** toggle (Settings → Startup), **on by default**, that controls whether the browser telegram cache is restored when the app loads.

- **On (default):** unchanged behavior — cached telegrams (IndexedDB) repaint instantly and the gap up to now is fetched from the backend (#246).
- **Off:** the view starts empty and shows only live telegrams and manual history loads. Live telegrams are still flushed to the cache, so re-enabling restores them on the next reload.

## Changes

- `useTelegramCache`: new `restoreFromCache = true` param; the startup restore effect returns early when off.
- `App.tsx`: `restoreOnStartup` preference (persisted), wired into the hook, plus the settings toggle.
- Test covering the disabled path (no restore, no backend fetch; live + manual `loadRange` still work).

## Verification

- `tsc --noEmit` clean, eslint clean
- Full frontend suite: 214 tests pass (incl. new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)