### PR TITLE
Stop history loading once the buffer is full (#313)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -585,6 +585,10 @@ function App() {
     ? activeFilters.sources.length + activeFilters.targets.length + activeFilters.types.length + activeFilters.directions.length + activeFilters.dpts.length
     : 0;
 
+  // The buffer holds at most `loadLimit` (newest) telegrams; once it is at
+  // capacity there is no room to load older history (#313).
+  const bufferFull = liveTelegrams.length >= loadLimit;
+
   // Inline "buffer full" marker shown next to the count in the stats pill (#284).
   const bufferLimitWarning = filteredLiveTelegrams.length >= loadLimit ? (
     <span
@@ -662,8 +666,20 @@ function App() {
                     <button
                       className="icon-button"
                       onClick={() => setIsHistoryLoaderOpen(true)}
-                      title={isHistoryLoading ? 'History read in progress…' : 'Load history'}
-                      style={{ color: isHistoryLoading ? 'var(--accent-primary)' : 'var(--text-dim)', padding: '0.15rem' }}
+                      disabled={bufferFull}
+                      title={
+                        bufferFull
+                          ? `Buffer full (${loadLimit.toLocaleString()}); clear it or raise the limit to load more history`
+                          : isHistoryLoading
+                            ? 'History read in progress…'
+                            : 'Load history'
+                      }
+                      style={{
+                        color: isHistoryLoading ? 'var(--accent-primary)' : 'var(--text-dim)',
+                        padding: '0.15rem',
+                        opacity: bufferFull ? 0.4 : 1,
+                        cursor: bufferFull ? 'not-allowed' : 'pointer',
+                      }}
                     >
                       <Download size={15} />
                     </button>

--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -289,6 +289,28 @@ describe('useTelegramCache', () => {
     expect(saved.some(([s]) => s === 0)).toBe(false);
   });
 
+  it('stops backing off older history once the buffer is full (#313)', async () => {
+    // Buffer size 2, filled with the two newest (live) telegrams.
+    const { result } = renderHook(() => useTelegramCache(2));
+    await settle(result);
+    act(() => {
+      result.current.addLive(tg(8000, 'live1'));
+      result.current.addLive(tg(9000, 'live2'));
+    });
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.live2', '1.2.live1']);
+
+    // Requesting older history: every fetched row would be older than the
+    // buffer's oldest entry and evicted on arrival, so no backend request is made.
+    const before = fetchCalls.filter(u => u.includes('/api/telegrams')).length;
+    await act(async () => {
+      await result.current.loadRange(1000, 5000);
+    });
+    const loadFetches = fetchCalls.filter(u => u.includes('/api/telegrams')).length - before;
+
+    expect(loadFetches).toBe(0);
+    expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.live2', '1.2.live1']);
+  });
+
   it('records a load failure without breaking the buffer', async () => {
     const { result } = renderHook(() => useTelegramCache(1000));
     await settle(result);

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -148,6 +148,14 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
       let cursor = gapEnd;
       let fetched = 0;
       while (cursor >= gapStart && fetched < budget) {
+        // Once the buffer is full, anything older than its oldest entry is
+        // evicted the instant it arrives. Stop paging backward instead of
+        // fetching chunks only to discard them (#313). The skipped remainder
+        // stays uncovered so it loads on demand once there is room.
+        const buf = bufferRef.current!;
+        if (buf.length >= maxSize && buf.oldestTs !== null && cursor < buf.oldestTs) {
+          break;
+        }
         const limit = Math.min(HISTORY_CHUNK_SIZE, budget - fetched);
         const { entries, limitReached } = await fetchRange(gapStart, cursor, limit);
         if (entries.length === 0) {
@@ -172,7 +180,7 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
       }
       return fetched;
     },
-    [mergeIntoBuffer, publish],
+    [mergeIntoBuffer, publish, maxSize],
   );
 
   /**

--- a/frontend/src/services/telegram-buffer-service.ts
+++ b/frontend/src/services/telegram-buffer-service.ts
@@ -73,6 +73,11 @@ export class TelegramBufferService {
     return this._buffer.length;
   }
 
+  /** Timestamp of the oldest buffered entry, or null when empty. */
+  get oldestTs(): number | null {
+    return this._buffer.length > 0 ? this._buffer[0].ts : null;
+  }
+
   get isEmpty(): boolean {
     return this._buffer.length === 0;
   }


### PR DESCRIPTION
Closes #313.

## Problem

With a large buffer (e.g. 100 000), clicking **Load history → 7 d** fills the buffer backward in chunks. Once the buffer is at capacity, every additional older chunk fetched is evicted the instant it arrives — but the "History: loading" spinner kept spinning, hammering the backend only to discard the results. There was also no signal that "Load history" is pointless when the buffer is already full.

## Fix

- **`useTelegramCache`**: while paging a gap backward, stop as soon as the buffer is full **and** the next window is entirely older than the buffer's oldest entry (everything from there back would be evicted). The skipped remainder stays *uncovered*, so it loads on demand later once there's room (e.g. after clearing or raising the limit). Adds an `oldestTs` getter to `TelegramBufferService`.
- **`App`**: disable the "Load history" button when the buffer is full, with a tooltip explaining to clear the buffer or raise the limit.

## Tests

- New test: with a full buffer, an older-history `loadRange` issues **zero** backend requests and leaves the buffer intact.
- Full frontend suite green (215 tests); `tsc`/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)