### PR TITLE
Only mark a range covered after its rows are cached (#317)

### DIFF
--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -8,10 +8,13 @@ import type { Telegram } from './useWebSocket';
 
 // In-memory IDB stand-in shared with the cache service.
 const _idb = new Map<string, { ts: number; telegram: Telegram }>();
+// Flip on to make cache writes reject (simulates IndexedDB quota failures).
+let storeShouldFail = false;
 
 vi.mock('idb-keyval', () => ({
   createStore: () => 'mock-store',
   setMany: async (pairs: [string, { ts: number; telegram: Telegram }][]) => {
+    if (storeShouldFail) throw new Error('QuotaExceededError');
     for (const [k, v] of pairs) _idb.set(k, v);
   },
   entries: async () => Array.from(_idb.entries()),
@@ -48,6 +51,7 @@ const jsonRes = (body: unknown) =>
 
 beforeEach(() => {
   _idb.clear();
+  storeShouldFail = false;
   localStorage.clear();
   telegramResponses = [];
   fetchCalls = [];
@@ -309,6 +313,26 @@ describe('useTelegramCache', () => {
 
     expect(loadFetches).toBe(0);
     expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.live2', '1.2.live1']);
+  });
+
+  it('does not mark a range covered when the cache write fails (#317)', async () => {
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[10_000, 10_000]]));
+    telegramResponses.push({ telegrams: [] }); // startup gap fill
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    // The load fetches a row, but persisting it to the cache fails.
+    storeShouldFail = true;
+    telegramResponses.push({ telegrams: [tg(5000, 'x')] });
+    await act(async () => {
+      await result.current.loadRange(0, 6000);
+    });
+
+    // The row is painted, but coverage must not claim its range — otherwise a
+    // reload would trust coverage and never refetch the (uncached) row.
+    expect(result.current.telegrams.map(t => t.source_address)).toContain('1.2.x');
+    const saved = JSON.parse(localStorage.getItem(COVERAGE_STORAGE_KEY)!) as [number, number][];
+    expect(saved.some(([s, e]) => s <= 5000 && 5000 <= e)).toBe(false);
   });
 
   it('records a load failure without breaking the buffer', async () => {

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -164,13 +164,19 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
           break;
         }
         if (mergeIntoBuffer(entries)) publish();
-        cacheRef.current!.store(entries).catch(() => {});
+        // Mark the range covered only once its rows are actually persisted. If
+        // the cache write fails (e.g. IndexedDB quota), leaving coverage claiming
+        // a range the cache can't serve surfaces later as a permanent gap (#317).
+        const stored = await cacheRef.current!.store(entries).then(
+          () => true,
+          () => false,
+        );
         fetched += entries.length;
         const oldestTs = entries[entries.length - 1].ts;
-        coverageRef.current!.addCovered(oldestTs, cursor);
+        if (stored) coverageRef.current!.addCovered(oldestTs, cursor);
         if (!limitReached) {
           // The whole remaining window came back — the gap is fully covered.
-          coverageRef.current!.addCovered(gapStart, cursor);
+          if (stored) coverageRef.current!.addCovered(gapStart, cursor);
           break;
         }
         // Page further back. Re-including `oldestTs` (dedup handles the repeat)


### PR DESCRIPTION
Addresses #317.

## Background

The Group Monitor tracks loaded time ranges in a **coverage** index (localStorage) so already-loaded windows are never refetched, and stores the telegrams themselves in an **IndexedDB cache**. History loads (`fetchGapProgressive`) page backward in chunks, recording each chunk's range as covered.

## The bug

The cache write was fire-and-forget:

```ts
cacheRef.current!.store(entries).catch(() => {});
coverageRef.current!.addCovered(oldestTs, cursor);   // marked covered regardless
```

If the IndexedDB write failed — e.g. a **quota error during a large multi-day load**, which is exactly the situation described in #317 (loading 7 days into a ~100k buffer) — coverage still claimed the range while the cache held nothing for it. A later load or a reload then trusts coverage, skips the backend, and the un-cached rows appear as a **permanent gap** in the timeline, even though the backend database has them (the reporter confirmed the DB was fine and a full reload after clearing recovered the data).

## Fix

Await the cache write and only extend coverage when it actually succeeded. On failure the range stays uncovered, so it reloads from the backend on demand instead of becoming a silent hole.

## Tests

- New test: when the cache write fails, the fetched row is still painted but its range is **not** recorded as covered.
- Full frontend suite green (216 tests); `tsc`/eslint clean.

## Scope / follow-ups

This closes the divergence on the **history-load path** (the one in the report). Two related divergence sources remain and are worth a separate look if gaps resurface:

- **Live path**: `addLive`/flush writes are also fire-and-forget while `extendLive` marks time covered; a failed live write can't currently be un-covered because the coverage service only trims from the start.
- **Cross-session**: the browser can evict IndexedDB independently of localStorage. Detecting that cleanly needs coverage and cache to share a storage/versioning signal (a naive "cache empty ⇒ clear coverage" guard wrongly discards valid covered-but-empty ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)