### PR TITLE
Order visualization charts by metric, not telegram time (#312)

### DIFF
--- a/frontend/src/hooks/useChartData.test.ts
+++ b/frontend/src/hooks/useChartData.test.ts
@@ -43,6 +43,28 @@ describe('useChartData — DPT backfill / duplicate graphs (#206)', () => {
   });
 });
 
+describe('useChartData — stable bucket order (#312)', () => {
+  test('orders buckets by metric regardless of which telegram is earliest', () => {
+    // '%' arrives first here, 'W' arrives first when reordered — the vertical
+    // order of the charts must not depend on telegram timing.
+    const early = [
+      at(1, { target_address: '1/1/1', dpt_main: 5, dpt_sub: 1, unit: '%', value_numeric: 50 }),
+      at(2, { target_address: '2/2/2', dpt_main: 14, unit: 'W', value_numeric: 1200 }),
+    ];
+    const swapped = [
+      at(1, { target_address: '2/2/2', dpt_main: 14, unit: 'W', value_numeric: 1200 }),
+      at(2, { target_address: '1/1/1', dpt_main: 5, dpt_sub: 1, unit: '%', value_numeric: 50 }),
+    ];
+    const targets = ['1/1/1', '2/2/2'];
+
+    const a = renderHook(() => useChartData(early, targets)).result.current.buckets.map(b => b.unit);
+    const b = renderHook(() => useChartData(swapped, targets)).result.current.buckets.map(b => b.unit);
+
+    expect(a).toEqual(['%', 'W']);
+    expect(b).toEqual(['%', 'W']);
+  });
+});
+
 describe('useChartData — extend last segment to newest telegram (#208)', () => {
   test("a binary series' held state extends to the newest telegram of another GA", () => {
     const telegrams = [

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -135,6 +135,12 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
       });
     }
 
+    // Order buckets by metric (unit), not by which telegram arrived first. The
+    // grouping Map above preserves insertion order, so without this the vertical
+    // order of the charts flipped whenever a new telegram or history chunk made
+    // a different metric the earliest one plotted (#312).
+    buckets.sort((a, b) => a.unit.localeCompare(b.unit));
+
     return { buckets, minTime, maxTime };
   }, [telegrams, selectedTargets]);
 }


### PR DESCRIPTION
Closes #312.

## Problem

In the visualization pane, the vertical order of the per-metric charts changed unexpectedly — e.g. two graphs swapping places while watching live data.

## Cause

`useChartData` groups telegrams into per-unit buckets with a `Map`, then emits buckets in the Map's **insertion order**. Insertion order is decided by whichever metric's telegram is *earliest* in the plotted set, so a new live telegram or an incoming history chunk could make a different metric the earliest one and flip the chart order.

## Fix

Sort the buckets by `unit` before returning, so the order is deterministic and independent of telegram timing.

## Tests

- New test: the same two metrics yield the same order (`['%', 'W']`) regardless of which telegram is earliest.
- `useChartData` suite green; `tsc`/eslint/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)