### PR TITLE
Keep the visualization time ruler readable when zoomed out (#314)

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -38,6 +38,9 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
 
   const { unit, isBinary, timestamps, series } = bucket;
 
+  // Show a date alongside times once the visible range crosses midnight (#281).
+  const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
+
   // Prepare data array: [ [x], [y1], [y2] ]
   // We divide timestamps by 1000 since uPlot expects unix seconds by default
   const data: uPlot.AlignedData = [
@@ -70,9 +73,6 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
     const style = getComputedStyle(document.documentElement);
     const gridStroke = style.getPropertyValue('--border-subtle').trim();
     const axisStroke = style.getPropertyValue('--text-dim').trim();
-
-    // Show a date alongside times once the visible range crosses midnight (#281).
-    const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
 
     // Configure Y-Axis scale limits based on smart defaults
     let scaleConfig: uPlot.Scale = {};
@@ -133,7 +133,9 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
       },
       axes: [
         {
-          space: 50,
+          // Wider minimum tick spacing when labels carry a date, so the
+          // "MM-DD HH:mm" ticks don't overlap into an unreadable ruler (#314).
+          space: multiDay ? 95 : 55,
           grid: { stroke: gridStroke, width: 1 },
           stroke: axisStroke,
           values: (_u, splits) => splits.map(v => formatAxisTime(v * 1000, multiDay))
@@ -183,6 +185,14 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
              new telegram doesn't snap the x-axis back to the full range (#281). */}
          <UplotReact options={options} data={data} resetScales={false} />
       </div>
+      {/* Always spell out the visible window's start and end, so the range is
+          readable even when the axis ticks are sparse or zoomed out (#314). */}
+      {minTime != null && maxTime != null && (
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.35rem', fontSize: '0.7rem', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>
+          <span>{formatFullTime(minTime, multiDay)}</span>
+          <span>{formatFullTime(maxTime, multiDay)}</span>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -45,6 +45,12 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
     ...series.map(s => s.data)
   ];
 
+  // Show a date alongside times once the visible range crosses midnight (#281).
+  const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
+  // Series labels are drawn in a fixed gutter on the right (see padding below);
+  // keep the start/end caption aligned to the actual plot area (#314).
+  const LABEL_GUTTER = 180;
+
   const rowHeight = 40;
   const rowGap = 4;
   const chartHeight = series.length * (rowHeight + rowGap) + 60;
@@ -62,9 +68,6 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
     const gridStroke = style.getPropertyValue('--border-subtle').trim();
     const axisStroke = style.getPropertyValue('--text-dim').trim();
     const accentPrimary = style.getPropertyValue('--accent-primary').trim();
-
-    // Show a date alongside times once the visible range crosses midnight (#281).
-    const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
 
     const timelinePlugin = () => ({
       hooks: {
@@ -152,7 +155,7 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
     return {
       width,
       height: chartHeight,
-      padding: [0, 180, 0, 0],
+      padding: [0, LABEL_GUTTER, 0, 0],
       cursor: {
         sync: { key: syncCursor.key },
         drag: { x: true, y: false, setScale: false }
@@ -186,7 +189,9 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
       },
       axes: [
         {
-          space: 50,
+          // Wider tick spacing for the longer "MM-DD HH:mm" labels so the ruler
+          // stays readable instead of overlapping when zoomed out (#314).
+          space: multiDay ? 95 : 55,
           stroke: axisStroke,
           grid: { stroke: gridStroke },
           values: (_u, splits) => splits.map(v => formatAxisTime(v * 1000, multiDay))
@@ -222,6 +227,14 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
              new telegram doesn't snap the x-axis back to the full range (#281). */}
          <UplotReact options={options} data={data} resetScales={false} />
       </div>
+      {/* Always spell out the visible window's start and end (#314). The right
+          gutter holds the series labels, so pad the caption to match the plot. */}
+      {minTime != null && maxTime != null && (
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.35rem', paddingRight: LABEL_GUTTER, fontSize: '0.7rem', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>
+          <span>{formatFullTime(minTime, multiDay)}</span>
+          <span>{formatFullTime(maxTime, multiDay)}</span>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Closes #314.

## Problem

When the visualization is zoomed out across multiple days, the x-axis time ruler became garbled and unreadable (overlapping labels), and the graph's start/end times were not reliably shown.

## Cause

On multi-day ranges the axis labels include a date (`MM-DD HH:mm`, ~11 chars) but the minimum tick spacing stayed at 50px, so uPlot packed the wider labels close enough to overlap.

## Fix

- Widen the minimum tick spacing to 95px on multi-day ranges (55px otherwise) in both `MixedChart` and `TimelineChart`, so date-stamped ticks get the room they need.
- Always render the visible window's **start** (left) and **end** (right) time in a caption beneath each chart, so the range is legible even when ticks are sparse. The timeline chart's caption is padded to match its right-hand series-label gutter so the end time lines up with the plot edge.

## Verification

- `tsc`/eslint/build clean; component test suite green (64 tests).
- Visual change; not unit-testable, but the spacing and caption are derived from the existing `spansMultipleDays`/`formatFullTime` helpers already covered by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)