### PR TITLE
Let users pick a datatype to plot untyped group addresses (#315)

### DIFF
--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -26,7 +26,42 @@ export const Visualizer: React.FC<VisualizerProps> = ({
 }) => {
 
   const chartWrapperRef = useRef<HTMLDivElement>(null);
-  const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets);
+
+  // Datatype chosen per group address for GAs with no DPT in the project, so
+  // their raw payloads can be decoded and plotted (#315). Persisted so the
+  // choice survives reloads.
+  const [dptOverrides, setDptOverrides] = useState<Record<string, string>>(() => {
+    try {
+      return JSON.parse(getPref('vizDptOverrides') || '{}') as Record<string, string>;
+    } catch {
+      return {};
+    }
+  });
+
+  const setDptOverride = (address: string, key: string) => {
+    setDptOverrides(prev => {
+      const next = { ...prev };
+      if (key) next[address] = key;
+      else delete next[address];
+      setPref('vizDptOverrides', JSON.stringify(next));
+      return next;
+    });
+  };
+
+  // GAs whose telegrams never carry a decoded DPT but do carry raw byte
+  // payloads — the ones that need a manual datatype to be plottable (#315).
+  const untypedTargets = useMemo(() => {
+    const decoded = new Set<string>();
+    const rawArray = new Set<string>();
+    for (const t of telegrams) {
+      if (!t.target_address) continue;
+      if (t.dpt_main != null) decoded.add(t.target_address);
+      else if (Array.isArray(t.value_json)) rawArray.add(t.target_address);
+    }
+    return new Set([...rawArray].filter(a => !decoded.has(a)));
+  }, [telegrams]);
+
+  const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets, dptOverrides);
   const [stepped, setStepped] = useState(() => getPref('chartStepped') !== 'false');
   const [showDots, setShowDots] = useState(() => getPref('chartDots') !== 'false');
   const [linkCopied, setLinkCopied] = useState(false);
@@ -130,6 +165,9 @@ export const Visualizer: React.FC<VisualizerProps> = ({
           selectedTargets={selectedTargets}
           onTargetsChange={handleTargetsChange}
           onClose={onClose}
+          untypedTargets={untypedTargets}
+          dptOverrides={dptOverrides}
+          onDptOverrideChange={setDptOverride}
         />
 
         {/* Chart Area */}

--- a/frontend/src/components/VisualizerSidebar.tsx
+++ b/frontend/src/components/VisualizerSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { LineChart, X, Search } from 'lucide-react';
 import type { Telegram } from '../hooks/useWebSocket';
 import { OptionRow } from './FilterPanel';
+import { RAW_DPT_OPTIONS } from '../utils/rawDpt';
 
 interface TargetCount {
   address: string;
@@ -14,9 +15,18 @@ interface VisualizerSidebarProps {
   selectedTargets: string[];
   onTargetsChange: (targets: string[]) => void;
   onClose: () => void;
+  /** Selected GAs with no project DPT that need a manual datatype to plot (#315). */
+  untypedTargets?: Set<string>;
+  /** Chosen datatype key per address. */
+  dptOverrides?: Record<string, string>;
+  /** Assign (or clear, with '') the datatype for a GA. */
+  onDptOverrideChange?: (address: string, key: string) => void;
 }
 
-export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({ telegrams, selectedTargets, onTargetsChange, onClose }) => {
+export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
+  telegrams, selectedTargets, onTargetsChange, onClose,
+  untypedTargets, dptOverrides = {}, onDptOverrideChange,
+}) => {
   const [search, setSearch] = useState('');
 
   // Extract unique targets and their counts from the currently plotted dataset
@@ -88,16 +98,42 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({ telegrams,
           Select targets from the currently active {telegrams.length.toLocaleString()} telegrams to plot their metrics over time.
         </div>
 
-        {filteredTargets.map(t => (
-          <OptionRow
-            key={t.address}
-            label={t.address}
-            sublabel={t.name}
-            checked={selectedTargets.includes(t.address)}
-            count={t.count}
-            onToggle={() => toggle(t.address)}
-          />
-        ))}
+        {filteredTargets.map(t => {
+          const selected = selectedTargets.includes(t.address);
+          // Offer a datatype picker for a selected GA that has no project DPT,
+          // so its raw payload can be decoded into a plottable value (#315).
+          const needsDpt = selected && untypedTargets?.has(t.address) && onDptOverrideChange;
+          return (
+            <React.Fragment key={t.address}>
+              <OptionRow
+                label={t.address}
+                sublabel={t.name}
+                checked={selected}
+                count={t.count}
+                onToggle={() => toggle(t.address)}
+              />
+              {needsDpt && (
+                <div style={{ padding: '0 0.25rem 0.5rem 1.75rem', marginTop: '-0.25rem' }}>
+                  <select
+                    value={dptOverrides[t.address] ?? ''}
+                    onChange={e => onDptOverrideChange(t.address, e.target.value)}
+                    title="This group address has no datatype in the project. Pick one to decode and plot its raw payload."
+                    style={{
+                      width: '100%', background: 'var(--bg-tag)', color: 'var(--text-main)',
+                      border: '1px solid var(--border-color)', borderRadius: '6px',
+                      padding: '0.35rem 0.5rem', fontSize: '0.75rem',
+                    }}
+                  >
+                    <option value="">No datatype — pick to plot…</option>
+                    {RAW_DPT_OPTIONS.map(o => (
+                      <option key={o.key} value={o.key}>{o.label}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+            </React.Fragment>
+          );
+        })}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useChartData.test.ts
+++ b/frontend/src/hooks/useChartData.test.ts
@@ -43,6 +43,42 @@ describe('useChartData — DPT backfill / duplicate graphs (#206)', () => {
   });
 });
 
+describe('useChartData — datatype override for untyped GAs (#315)', () => {
+  test('untyped raw-byte telegrams do not plot without a chosen datatype', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', value_json: [0x0c, 0x1a] as unknown as Record<string, unknown> }),
+      at(2, { target_address: '1/1/1', value_json: [0x0c, 0x1b] as unknown as Record<string, unknown> }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1']));
+    // A bucket exists but the raw byte arrays decode to nothing plottable.
+    const series = result.current.buckets[0]?.series[0];
+    expect(series?.data.every(v => v === null)).toBe(true);
+  });
+
+  test('a chosen datatype decodes raw payloads and groups by its unit', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', value_json: [0x0c, 0x1a] as unknown as Record<string, unknown> }),
+      at(2, { target_address: '1/1/1', value_json: [0x00, 0x00] as unknown as Record<string, unknown> }),
+    ];
+    // DPT 9 (2-byte float): 0x0C1A ≈ 21.0, 0x0000 = 0.
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1'], { '1/1/1': '9' }));
+    const bucket = result.current.buckets[0];
+    expect(bucket.unit).toBe('DPT 9');
+    const series = bucket.series.find(s => s.address === '1/1/1')!;
+    expect(series.data[0]).toBeCloseTo(21.0, 4);
+    expect(series.data[series.data.length - 1]).toBeCloseTo(0, 6);
+  });
+
+  test('a percent datatype buckets under its unit', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', value_json: [0xff] as unknown as Record<string, unknown> }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1'], { '1/1/1': '5.001' }));
+    expect(result.current.buckets[0].unit).toBe('%');
+    expect(result.current.buckets[0].series[0].data[0]).toBeCloseTo(100, 6);
+  });
+});
+
 describe('useChartData — stable bucket order (#312)', () => {
   test('orders buckets by metric regardless of which telegram is earliest', () => {
     // '%' arrives first here, 'W' arrives first when reordered — the vertical

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { Telegram } from '../hooks/useWebSocket';
+import { decodeRawDpt, rawDptUnit } from '../utils/rawDpt';
 
 export interface ChartSeries {
   address: string;
@@ -24,11 +25,24 @@ export interface ChartDataResult {
   maxTime: number | null;
 }
 
-export function useChartData(telegrams: Telegram[], selectedTargets: string[]): ChartDataResult {
+export function useChartData(
+  telegrams: Telegram[],
+  selectedTargets: string[],
+  // Per-GA datatype chosen for group addresses with no DPT in the project, so
+  // their raw payloads can be decoded and plotted (#315). Keyed by address.
+  dptOverrides: Record<string, string> = {},
+): ChartDataResult {
   return useMemo(() => {
     if (selectedTargets.length === 0 || telegrams.length === 0) {
       return { buckets: [], minTime: null, maxTime: null };
     }
+
+    // Decode an untyped GA's raw payload with its chosen datatype, if any.
+    const overrideValue = (t: Telegram): number | null => {
+      const key = t.dpt_main == null ? dptOverrides[t.target_address] : undefined;
+      if (!key || !Array.isArray(t.value_json)) return null;
+      return decodeRawDpt(t.value_json as number[], key);
+    };
 
     // A GA whose DPT is known from the project produces decoded telegrams
     // (dpt_main set). Telegrams received *before* a project import stay
@@ -69,7 +83,13 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
     const grouped = new Map<string, typeof relevant>();
 
     for (const t of relevant) {
+      const overrideKey = t.dpt_main == null ? dptOverrides[t.target_address] : undefined;
       let bucketKey = t.unit || 'unknown';
+      if (overrideKey) {
+        // Group decoded-untyped GAs by their chosen unit (or the datatype key
+        // when dimensionless) so they don't fall into the 'unknown' bucket (#315).
+        bucketKey = rawDptUnit(overrideKey) || `DPT ${overrideKey}`;
+      }
       if (t.dpt_main === 1) bucketKey = 'binary';
       // Also catch anything with a boolean value_json if type is unknown
       if (typeof t.value_json === 'boolean') bucketKey = 'binary';
@@ -118,6 +138,9 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
               val = match.value_json ? 1 : 0;
             } else if (val === null && typeof match.value_json === 'number') {
               val = match.value_json;
+            } else if (val === null) {
+              // Untyped GA: decode the raw payload with the user-chosen DPT (#315).
+              val = overrideValue(match);
             }
             if (val !== null) lastVal = Number(val);
           }
@@ -142,5 +165,5 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
     buckets.sort((a, b) => a.unit.localeCompare(b.unit));
 
     return { buckets, minTime, maxTime };
-  }, [telegrams, selectedTargets]);
+  }, [telegrams, selectedTargets, dptOverrides]);
 }

--- a/frontend/src/utils/rawDpt.test.ts
+++ b/frontend/src/utils/rawDpt.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest';
+import { decodeRawDpt, rawDptUnit, RAW_DPT_OPTIONS } from './rawDpt';
+
+describe('decodeRawDpt (#315)', () => {
+  test('8-bit unsigned / signed', () => {
+    expect(decodeRawDpt([0xff], '5')).toBe(255);
+    expect(decodeRawDpt([0x00], '5')).toBe(0);
+    expect(decodeRawDpt([0xff], '6')).toBe(-1);
+    expect(decodeRawDpt([0x80], '6')).toBe(-128);
+    expect(decodeRawDpt([0x7f], '6')).toBe(127);
+  });
+
+  test('8-bit percent scalings', () => {
+    expect(decodeRawDpt([0xff], '5.001')).toBeCloseTo(100, 6);
+    expect(decodeRawDpt([0x80], '5.001')).toBeCloseTo((128 * 100) / 255, 6);
+    expect(decodeRawDpt([0xff], '5.004')).toBe(255);
+  });
+
+  test('2-byte unsigned / signed (big-endian)', () => {
+    expect(decodeRawDpt([0x12, 0x34], '7')).toBe(0x1234);
+    expect(decodeRawDpt([0xff, 0xff], '7')).toBe(65535);
+    expect(decodeRawDpt([0xff, 0xff], '8')).toBe(-1);
+    expect(decodeRawDpt([0x80, 0x00], '8')).toBe(-32768);
+  });
+
+  test('DPT 9 KNX 2-byte float', () => {
+    // 0x0000 → 0
+    expect(decodeRawDpt([0x00, 0x00], '9')).toBeCloseTo(0, 6);
+    // 21.0 °C encodes as 0x0C1A in the KNX 16-bit float format.
+    expect(decodeRawDpt([0x0c, 0x1a], '9')).toBeCloseTo(21.0, 4);
+    // 0.01 * 1 * 2^0 = 0.01 (mantissa 1, exponent 0)
+    expect(decodeRawDpt([0x00, 0x01], '9')).toBeCloseTo(0.01, 6);
+    // Negative: sign set, mantissa -1 → -0.01
+    expect(decodeRawDpt([0x87, 0xff], '9')).toBeCloseTo(-0.01, 6);
+  });
+
+  test('4-byte unsigned / signed / float (big-endian)', () => {
+    expect(decodeRawDpt([0x00, 0x00, 0x00, 0x01], '12')).toBe(1);
+    expect(decodeRawDpt([0xff, 0xff, 0xff, 0xff], '13')).toBe(-1);
+    // IEEE-754 float 1.0 = 0x3F800000
+    expect(decodeRawDpt([0x3f, 0x80, 0x00, 0x00], '14')).toBeCloseTo(1.0, 6);
+  });
+
+  test('rejects width mismatches and invalid bytes', () => {
+    expect(decodeRawDpt([0x12], '7')).toBeNull(); // needs 2 bytes
+    expect(decodeRawDpt([0x12, 0x34, 0x56], '7')).toBeNull();
+    expect(decodeRawDpt([], '5')).toBeNull();
+    expect(decodeRawDpt([300], '5')).toBeNull(); // not a byte
+    expect(decodeRawDpt([0x12], 'nonsense')).toBeNull();
+  });
+
+  test('rawDptUnit exposes the option unit', () => {
+    expect(rawDptUnit('5.001')).toBe('%');
+    expect(rawDptUnit('7')).toBe('');
+    expect(rawDptUnit('missing')).toBe('');
+  });
+
+  test('every option round-trips a payload of its declared width', () => {
+    for (const opt of RAW_DPT_OPTIONS) {
+      const bytes = Array.from({ length: opt.bytes }, () => 0x01);
+      expect(decodeRawDpt(bytes, opt.key)).not.toBeNull();
+    }
+  });
+});

--- a/frontend/src/utils/rawDpt.ts
+++ b/frontend/src/utils/rawDpt.ts
@@ -1,0 +1,87 @@
+/**
+ * Client-side decoding of raw KNX payload bytes for group addresses that have
+ * no datatype in the ETS project (#315).
+ *
+ * Such telegrams reach the frontend as an array of payload bytes in
+ * `value_json` (e.g. `[0x0c, 0x1a]`) with no decoded numeric value, so the
+ * visualization can't plot them. Letting the user pick a datatype lets us
+ * interpret those bytes into a number here, without a project re-import.
+ *
+ * Only the datatypes that decode to a single plottable number are offered.
+ */
+
+export interface RawDptOption {
+  /** Stable key persisted per group address. */
+  key: string;
+  /** Dropdown label. */
+  label: string;
+  /** Physical unit for bucketing/axis, or '' when dimensionless. */
+  unit: string;
+  /** Expected payload width in bytes; a mismatch decodes to null. */
+  bytes: number;
+}
+
+/** Datatypes offered for an untyped GA, in menu order. */
+export const RAW_DPT_OPTIONS: RawDptOption[] = [
+  { key: '5', label: '5 · 8-bit unsigned (0–255)', unit: '', bytes: 1 },
+  { key: '5.001', label: '5.001 · Percent (0–100%)', unit: '%', bytes: 1 },
+  { key: '5.004', label: '5.004 · Percent (0–255%)', unit: '%', bytes: 1 },
+  { key: '6', label: '6 · 8-bit signed (−128–127)', unit: '', bytes: 1 },
+  { key: '7', label: '7 · 2-byte unsigned', unit: '', bytes: 2 },
+  { key: '8', label: '8 · 2-byte signed', unit: '', bytes: 2 },
+  { key: '9', label: '9 · 2-byte float', unit: '', bytes: 2 },
+  { key: '12', label: '12 · 4-byte unsigned', unit: '', bytes: 4 },
+  { key: '13', label: '13 · 4-byte signed', unit: '', bytes: 4 },
+  { key: '14', label: '14 · 4-byte float', unit: '', bytes: 4 },
+];
+
+const OPTION_BY_KEY = new Map(RAW_DPT_OPTIONS.map(o => [o.key, o]));
+
+/** The physical unit a decoded value should be bucketed/labelled under. */
+export const rawDptUnit = (key: string): string => OPTION_BY_KEY.get(key)?.unit ?? '';
+
+/** Decodes the KNX 2-byte float (DPT 9) format from two bytes. */
+const decodeKnxFloat16 = (b0: number, b1: number): number => {
+  const data = ((b0 << 8) | b1) & 0xffff;
+  const exponent = (data & 0x7800) >> 11;
+  // 11-bit mantissa in two's complement (the high bit is the sign).
+  let mantissa = data & 0x07ff;
+  if (data & 0x8000) mantissa -= 2048;
+  return 0.01 * mantissa * Math.pow(2, exponent);
+};
+
+/**
+ * Decodes raw payload bytes into a plottable number for the chosen datatype,
+ * or null when the datatype is unknown or the width does not match.
+ */
+export function decodeRawDpt(bytes: readonly number[], key: string): number | null {
+  const opt = OPTION_BY_KEY.get(key);
+  if (!opt || bytes.length !== opt.bytes) return null;
+  if (bytes.some(b => !Number.isInteger(b) || b < 0 || b > 255)) return null;
+
+  const view = new DataView(new Uint8Array(bytes).buffer);
+  switch (key) {
+    case '5':
+      return view.getUint8(0);
+    case '5.001':
+      return (view.getUint8(0) * 100) / 255;
+    case '5.004':
+      return view.getUint8(0); // percent on a 0–255 scale: the raw byte is the value
+    case '6':
+      return view.getInt8(0);
+    case '7':
+      return view.getUint16(0, false);
+    case '8':
+      return view.getInt16(0, false);
+    case '9':
+      return decodeKnxFloat16(bytes[0], bytes[1]);
+    case '12':
+      return view.getUint32(0, false);
+    case '13':
+      return view.getInt32(0, false);
+    case '14':
+      return view.getFloat32(0, false);
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Closes #315.

## Problem

A group address that has **no datatype in the ETS project** can't be plotted in the visualization. Its telegrams arrive as a raw byte array (`value_json`, e.g. `[0x0c, 0x1a]`) with no decoded numeric value, so `useChartData` produces only null points and the chart is empty.

## Solution

Let the user assign a datatype to such a GA and decode its raw payload client-side.

- **`utils/rawDpt.ts`** — a small decoder for the common plottable datatypes: 8/16/32-bit unsigned & signed, the KNX 2-byte float (DPT 9), IEEE 4-byte float (DPT 14), and the DPT 5 percent scalings. Big-endian, width-checked (a wrong-width payload decodes to `null`).
- **`VisualizerSidebar`** — for a *selected* target that has no project DPT (and does carry raw bytes), a datatype dropdown appears under its row.
- **`Visualizer`** — holds the per-GA override map, persists it to prefs (`vizDptOverrides`), and passes it to `useChartData`.
- **`useChartData`** — decodes overridden GAs' raw payloads and buckets them under the chosen unit (e.g. `%`) instead of the catch-all `unknown` group.

Typed GAs are completely unaffected — the override path only runs when `dpt_main` is null.

## Tests

- `rawDpt` decoder: unsigned/signed widths, percent scalings, the KNX float (21.0 °C = `0x0C1A`), IEEE float, and width/validity rejection.
- `useChartData`: untyped bytes don't plot without a datatype; choosing DPT 9 decodes to ~21.0 and buckets correctly; a percent type buckets under `%`.
- Full frontend suite green (228 tests); `tsc`/eslint/build clean.

## Scope

Covers the datatypes that map to a single plottable number. Multi-field types (date/time, strings, colours) are intentionally not offered since they aren't line-plottable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)