### PR TITLE
release: prepare v1.16.2

### DIFF
--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.16.2
+
+### Added
+
+- **Plot group addresses without a project datatype**: the visualization now offers a datatype picker for a selected group address that has no DPT in the ETS project, decoding its raw payload (8/16/32-bit integers, the KNX 2-byte float, IEEE 4-byte float, percent scalings) so it can be graphed (#315).
+- **"Load cached telegrams on startup" setting**: the group monitor restores its browser cache on load by default; turning the new setting off starts the view empty, showing only live telegrams and manual history loads (#246).
+
+### Changed
+
+- **History loading stops when the buffer is full**: paging older history no longer churns through chunks that are immediately evicted, and "Load history" is disabled while the buffer is full (#313).
+- **Readable visualization time ruler when zoomed out**: wider tick spacing on multi-day ranges, plus an always-visible start/end time under each chart (#314).
+
+### Fixed
+
+- **Stable visualization chart order**: the per-metric charts no longer change vertical order as live telegrams or history chunks arrive (#312).
+- **Fewer group-monitor gaps**: a time range is only marked loaded once its telegrams are actually cached, so a failed cache write no longer leaves a permanent gap in the timeline (#317).
+
 ## 1.16.1
 
 ### Added

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "1.16.1"
+version: "1.16.2"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 1.16.2
+
+### Added
+
+- **Plot group addresses without a project datatype**: the visualization now offers a datatype picker for a selected group address that has no DPT in the ETS project, decoding its raw payload (8/16/32-bit integers, the KNX 2-byte float, IEEE 4-byte float, percent scalings) so it can be graphed (#315).
+- **"Load cached telegrams on startup" setting**: the group monitor restores its browser cache on load by default; turning the new setting off starts the view empty, showing only live telegrams and manual history loads (#246).
+
+### Changed
+
+- **History loading stops when the buffer is full**: paging older history no longer churns through chunks that are immediately evicted, and "Load history" is disabled while the buffer is full (#313).
+- **Readable visualization time ruler when zoomed out**: wider tick spacing on multi-day ranges, plus an always-visible start/end time under each chart (#314).
+
+### Fixed
+
+- **Stable visualization chart order**: the per-metric charts no longer change vertical order as live telegrams or history chunks arrive (#312).
+- **Fewer group-monitor gaps**: a time range is only marked loaded once its telegrams are actually cached, so a failed cache write no longer leaves a permanent gap in the timeline (#317).
+
 ## 1.16.1
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.16.1"
+version: "1.16.2"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Patch release since v1.16.1. Bumps both Home Assistant add-ons to **1.16.2** and adds the changelog entries.

### Added
- Datatype picker to plot group addresses without a project DPT (#315)
- "Load cached telegrams on startup" setting (#246)

### Changed
- History loading stops when the buffer is full; "Load history" disabled while full (#313)
- Readable visualization time ruler when zoomed out, always-visible start/end times (#314)

### Fixed
- Stable visualization chart order regardless of telegram timing (#312)
- A time range is only marked loaded once its telegrams are cached, avoiding permanent gaps (#317)

After merge, tag `v1.16.2` to trigger the Docker/GHCR + add-on publish and the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)