### PR TITLE
Add MCP server endpoint (read-only tools)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -76,6 +76,12 @@ LOG_LEVEL=INFO
 # false to keep SpectrumKNX strictly read-only.
 # KNX_ALLOW_WRITE=true
 
+# MCP (Model Context Protocol) server for AI agents, mounted at /mcp.
+#   off        — endpoint disabled
+#   read-only  — query/introspection tools only (default)
+#   read-write — additionally exposes bus/write tools
+# MCP_MODE=read-only
+
 # Check GitHub for new releases and show a "what's changed" popup when an update
 # is available. Makes an outbound request to api.github.com (cached ~6h). Set to
 # false to disable all update checks (no outbound calls).

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, nullcontext
 
 from dotenv import load_dotenv
 
@@ -13,6 +13,7 @@ from fastapi.responses import FileResponse  # noqa: E402
 from fastapi.staticfiles import StaticFiles  # noqa: E402
 
 import cyclic_send  # noqa: E402
+import mcp_server  # noqa: E402
 from api import get_backend_version  # noqa: E402
 from api import router as api_router  # noqa: E402
 from database import READ_ONLY, engine  # noqa: E402
@@ -34,7 +35,13 @@ async def lifespan(app: FastAPI):
         await companion_startup()
     else:
         await knx_startup()
-    yield
+
+    # The MCP endpoint's session manager must run for the app's lifetime while
+    # its ASGI app is mounted (a nullcontext keeps this a no-op when disabled).
+    mcp_ctx = mcp_server.session_manager_run() if mcp_server.mcp_enabled() else nullcontext()
+    async with mcp_ctx:
+        yield
+
     # Shutdown
     if READ_ONLY:
         await companion_shutdown()
@@ -55,6 +62,12 @@ app.add_middleware(
 )
 
 app.include_router(api_router)
+
+# Mount the MCP Streamable HTTP endpoint before the SPA catch-all so /mcp is not
+# swallowed by static routing (#332). Disabled when MCP_MODE=off.
+if mcp_server.mcp_enabled():
+    app.mount("/mcp", mcp_server.get_asgi_app())
+    logger.info(f"MCP endpoint mounted at /mcp (mode: {mcp_server.MCP_MODE})")
 
 # Serve static files in production
 STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -1,0 +1,150 @@
+"""Model Context Protocol (MCP) server for SpectrumKNX.
+
+Exposes the KNX telegram store to MCP clients (Claude Desktop, Cursor, …) over
+the Streamable HTTP transport, mounted into the FastAPI app at ``/mcp``.
+
+The tool logic lives in the shared ``knx_telegram_store.mcp`` package so it is
+identical to the Home Assistant consumer; this module only wraps those
+functions into MCP tools and wires them to SpectrumKNX's store.
+
+Access is gated by ``MCP_MODE``:
+
+- ``off`` — the endpoint is not mounted.
+- ``read-only`` (default) — query/introspection tools only.
+- ``read-write`` — additionally exposes bus/write tools (added in a later step).
+"""
+
+import os
+from dataclasses import asdict
+from typing import Any
+
+from knx_telegram_store.mcp import (
+    LastValuesInput,
+    QueryTelegramsInput,
+)
+from knx_telegram_store.mcp import (
+    count_telegrams as lib_count_telegrams,
+)
+from knx_telegram_store.mcp import (
+    get_last_values as lib_get_last_values,
+)
+from knx_telegram_store.mcp import (
+    get_store_capabilities as lib_get_store_capabilities,
+)
+from knx_telegram_store.mcp import (
+    get_store_stats as lib_get_store_stats,
+)
+from knx_telegram_store.mcp import (
+    query_telegrams as lib_query_telegrams,
+)
+from mcp.server.fastmcp import FastMCP
+
+import knx_daemon
+from database import store
+
+MCP_MODE = os.getenv("MCP_MODE", "read-only").strip().lower()
+_VALID_MODES = ("off", "read-only", "read-write")
+
+
+def mcp_enabled() -> bool:
+    """Whether the MCP endpoint should be mounted."""
+    return MCP_MODE in ("read-only", "read-write")
+
+
+def write_tools_enabled() -> bool:
+    """Whether bus/write tools may be exposed (read-write mode only)."""
+    return MCP_MODE == "read-write"
+
+
+def mcp_status() -> dict[str, Any]:
+    """MCP state for the server-config/status API."""
+    mode = MCP_MODE if MCP_MODE in _VALID_MODES else "off"
+    return {"mode": mode, "enabled": mcp_enabled(), "write_tools": write_tools_enabled()}
+
+
+def _build_server() -> FastMCP:
+    # stateless_http keeps each request self-contained — no server-side session
+    # state to manage, which is all these read tools need and simplifies mounting.
+    mcp = FastMCP("spectrum-knx", stateless_http=True)
+
+    @mcp.tool()
+    async def query_telegrams(
+        start_time: str | None = None,
+        end_time: str | None = None,
+        sources: list[str] | None = None,
+        destinations: list[str] | None = None,
+        telegram_types: list[str] | None = None,
+        directions: list[str] | None = None,
+        dpt_mains: list[int] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+        order_descending: bool = True,
+    ) -> dict[str, Any]:
+        """Search stored KNX telegrams. Times are ISO-8601; address/type/direction
+        filters are lists (OR within a filter, AND across filters)."""
+        result = await lib_query_telegrams(
+            store,
+            QueryTelegramsInput(
+                start_time=start_time,
+                end_time=end_time,
+                sources=sources or [],
+                destinations=destinations or [],
+                telegram_types=telegram_types or [],
+                directions=directions or [],
+                dpt_mains=dpt_mains or [],
+                limit=limit,
+                offset=offset,
+                order_descending=order_descending,
+            ),
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def get_last_values(destinations: list[str] | None = None) -> dict[str, Any]:
+        """Most recent telegram for each group address (optionally filtered to
+        the given destinations)."""
+        result = await lib_get_last_values(store, LastValuesInput(destinations=destinations or []))
+        return {"telegrams": [asdict(t) for t in result]}
+
+    @mcp.tool()
+    async def get_store_stats() -> dict[str, Any]:
+        """Telegram count, covered time range, on-disk size, backend and retention."""
+        return asdict(await lib_get_store_stats(store))
+
+    @mcp.tool()
+    async def get_store_capabilities() -> dict[str, Any]:
+        """What the telegram-store backend supports (time range, pagination, size, …)."""
+        return asdict(await lib_get_store_capabilities(store))
+
+    @mcp.tool()
+    async def count_telegrams() -> dict[str, Any]:
+        """Total number of stored telegrams."""
+        return asdict(await lib_count_telegrams(store))
+
+    @mcp.tool()
+    async def get_server_config() -> dict[str, Any]:
+        """SpectrumKNX connection/security configuration (passwords masked)."""
+        return knx_daemon.get_server_config()
+
+    return mcp
+
+
+_fastmcp: FastMCP | None = None
+_asgi_app: Any = None
+
+
+def get_asgi_app() -> Any:
+    """The Streamable HTTP ASGI app to mount, built once on first use."""
+    global _fastmcp, _asgi_app
+    if _asgi_app is None:
+        _fastmcp = _build_server()
+        _asgi_app = _fastmcp.streamable_http_app()
+    return _asgi_app
+
+
+def session_manager_run() -> Any:
+    """Async context manager that runs the MCP session manager for the app's
+    lifetime. Must be entered while the endpoint is mounted."""
+    get_asgi_app()  # ensure the server (and its session manager) exists
+    assert _fastmcp is not None
+    return _fastmcp.session_manager.run()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,9 @@ dependencies = [
     "asyncpg",
     "fastapi",
     "httpx",
-    "knx-telegram-store>=0.10.2",
+    # Git pin for the unreleased MCP tools; revert to ">=0.11.0" once on PyPI.
+    "knx-telegram-store @ git+https://github.com/XKNX/knx-telegram-store.git@33aebf42baac37102ee8e8f9801629cf6f8cd4ff",
+    "mcp",
     "pydantic",
     "python-dotenv",
     "python-multipart",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,9 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.10.2
+# Temporary git pin for the unreleased MCP tools (knx_telegram_store.mcp, 0.11.0).
+# Revert to `knx-telegram-store==0.11.0` once it is published to PyPI.
+knx-telegram-store @ git+https://github.com/XKNX/knx-telegram-store.git@33aebf42baac37102ee8e8f9801629cf6f8cd4ff
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0
@@ -41,3 +43,14 @@ pytest-asyncio==1.4.0
 aiosqlite==0.22.1
 python-multipart==0.0.32
 pre-commit==4.6.0
+# MCP server (SDK + transitives) for the /mcp endpoint.
+mcp==1.28.1
+PyJWT==2.13.0
+attrs==26.1.0
+httpx-sse==0.4.3
+jsonschema==4.26.0
+jsonschema-specifications==2025.9.1
+pydantic-settings==2.14.2
+referencing==0.37.0
+rpds-py==2026.6.3
+sse-starlette==3.4.6

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,0 +1,112 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from knx_telegram_store import StoredTelegram
+from knx_telegram_store.backends.memory import MemoryStore
+
+import mcp_server
+
+NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=UTC)
+
+
+async def _seeded_store() -> MemoryStore:
+    store = MemoryStore(max_telegrams=100)
+    await store.initialize()
+    await store.store_many(
+        [
+            StoredTelegram(
+                timestamp=NOW - timedelta(minutes=2),
+                source="1.1.1",
+                destination="1/1/1",
+                telegramtype="GroupValueWrite",
+                direction="Incoming",
+                value=21.0,
+                value_numeric=21.0,
+                dpt_main=9,
+                dpt_sub=1,
+            ),
+            StoredTelegram(
+                timestamp=NOW - timedelta(minutes=1),
+                source="1.1.2",
+                destination="1/2/2",
+                telegramtype="GroupValueWrite",
+                direction="Outgoing",
+                value=True,
+                dpt_main=1,
+                dpt_sub=1,
+            ),
+        ]
+    )
+    return store
+
+
+@pytest_asyncio.fixture
+async def server(monkeypatch):
+    """A freshly built MCP server wired to a seeded in-memory store."""
+    store = await _seeded_store()
+    monkeypatch.setattr(mcp_server, "store", store)
+    return mcp_server._build_server()
+
+
+async def _structured(server, name, args=None):
+    """The structured (dict/list) result of a tool call."""
+    _, structured = await server.call_tool(name, args or {})
+    return structured
+
+
+@pytest.mark.asyncio
+async def test_lists_read_only_tools(server):
+    names = {t.name for t in await server.list_tools()}
+    assert {
+        "query_telegrams",
+        "get_last_values",
+        "get_store_stats",
+        "get_store_capabilities",
+        "count_telegrams",
+        "get_server_config",
+    } <= names
+
+
+@pytest.mark.asyncio
+async def test_query_telegrams(server):
+    result = await _structured(server, "query_telegrams", {"destinations": ["1/1/1"]})
+    assert result["total_count"] == 1
+    assert result["telegrams"][0]["destination"] == "1/1/1"
+    assert result["telegrams"][0]["dpt"] == "9.001"
+
+
+@pytest.mark.asyncio
+async def test_count_and_stats(server):
+    assert (await _structured(server, "count_telegrams"))["count"] == 2
+    stats = await _structured(server, "get_store_stats")
+    assert stats["telegram_count"] == 2
+    assert stats["backend"]
+
+
+@pytest.mark.asyncio
+async def test_get_last_values_filter(server):
+    last = await _structured(server, "get_last_values", {"destinations": ["1/2/2"]})
+    assert [t["destination"] for t in last["telegrams"]] == ["1/2/2"]
+
+
+@pytest.mark.parametrize(
+    ("mode", "enabled", "write"),
+    [
+        ("off", False, False),
+        ("read-only", True, False),
+        ("read-write", True, True),
+    ],
+)
+def test_mode_gating(monkeypatch, mode, enabled, write):
+    monkeypatch.setattr(mcp_server, "MCP_MODE", mode)
+    assert mcp_server.mcp_enabled() is enabled
+    assert mcp_server.write_tools_enabled() is write
+    status = mcp_server.mcp_status()
+    assert status == {"mode": mode, "enabled": enabled, "write_tools": write}
+
+
+def test_invalid_mode_reported_as_off(monkeypatch):
+    monkeypatch.setattr(mcp_server, "MCP_MODE", "bogus")
+    assert mcp_server.mcp_enabled() is False
+    assert mcp_server.mcp_status()["mode"] == "off"


### PR DESCRIPTION
Part of #328. Implements #332 (transport + mode gating) and the store slice of #333.

## Summary

Adds a **Model Context Protocol** server to the SpectrumKNX backend, mounted at `/mcp` over the Streamable HTTP transport, so AI agents (Claude Desktop, Cursor, …) can query the telegram store.

Gated by `MCP_MODE`:
- `off` — endpoint not mounted
- `read-only` (default) — query/introspection tools
- `read-write` — will additionally expose bus/write tools (follow-up #334)

## Tools (read-only)

Wrap the shared `knx_telegram_store.mcp` functions (identical logic to the HA consumer):
`query_telegrams`, `get_last_values`, `get_store_stats`, `get_store_capabilities`, `count_telegrams`, plus a spectrum-specific `get_server_config` (masked).

## Changes

- `backend/mcp_server.py` — FastMCP server, `MCP_MODE` gating, ASGI app + session-manager lifecycle.
- `backend/main.py` — mount `/mcp` before the SPA catch-all; run the session manager in the app lifespan when enabled.
- Deps: `mcp` SDK added to the pinned lock; `knx-telegram-store` **git-pinned to the merged 0.11.0** (`knx_telegram_store.mcp`) until it is published to PyPI — the pin has a `revert to ==0.11.0` note.
- `.env_example` documents `MCP_MODE`.

## Tests

`backend/tests/test_mcp_server.py`: tool listing + dispatch against an in-memory store, and mode gating (off/read-only/read-write, invalid → off). Full backend suite green (180 passed).

## Follow-ups (tracked)

- #334 write/bus tools in `read-write` mode
- #333 project/DPT tools (need the xknxproject/xknx library tools, #330/#331)
- #335 resources + prompts, #336 docs
- Revert the git pin to `knx-telegram-store==0.11.0` once released to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)