### PR TITLE
Serve MCP endpoint at /mcp, not /mcp/mcp (#332)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -65,7 +65,9 @@ def mcp_status() -> dict[str, Any]:
 def _build_server() -> FastMCP:
     # stateless_http keeps each request self-contained — no server-side session
     # state to manage, which is all these read tools need and simplifies mounting.
-    mcp = FastMCP("spectrum-knx", stateless_http=True)
+    # streamable_http_path="/" so that mounting the app at "/mcp" serves the
+    # endpoint at "/mcp" rather than the doubled-up "/mcp/mcp".
+    mcp = FastMCP("spectrum-knx", stateless_http=True, streamable_http_path="/")
 
     @mcp.tool()
     async def query_telegrams(

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -68,6 +68,14 @@ async def test_lists_read_only_tools(server):
     } <= names
 
 
+def test_endpoint_serves_at_mount_root_not_doubled():
+    # FastMCP must serve at "/" internally so mounting the app at "/mcp" yields
+    # "/mcp" and not the doubled-up "/mcp/mcp" (#332).
+    paths = [getattr(r, "path", None) for r in mcp_server.get_asgi_app().routes]
+    assert "/" in paths
+    assert "/mcp" not in paths
+
+
 @pytest.mark.asyncio
 async def test_query_telegrams(server):
     result = await _structured(server, "query_telegrams", {"destinations": ["1/1/1"]})


### PR DESCRIPTION
Follow-up to #337, found by driving the live endpoint with a real MCP client.

FastMCP's Streamable HTTP app serves at its own `/mcp` path by default; mounting it at `/mcp` in `main.py` produced a doubled **`/mcp/mcp`** endpoint. Setting `streamable_http_path="/"` makes the mount resolve to `/mcp` as intended.

Verified end-to-end: an MCP client (`streamablehttp_client` + `ClientSession`) connects to `http://host:8799/mcp`, initializes, lists all 6 tools, and `get_store_stats` / `count_telegrams` / `query_telegrams` / `get_last_values` return correct data from a seeded store.

Adds a regression guard asserting the mounted app serves at `/` (so the mount yields `/mcp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)