### PR TITLE
Update xknx to 3.17.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -35,7 +35,7 @@ typing-inspection==0.4.2
 typing_extensions==4.16.0
 uvicorn==0.51.0
 websockets==16.1.1
-xknx==3.16.0
+xknx==3.17.0
 xknxproject==3.9.0
 httpx==0.28.1
 ruff==0.15.22


### PR DESCRIPTION
Bumps `xknx` from 3.16.0 to 3.17.0 in `backend/requirements.txt`.

This adds some DPTs and fixes parsing issues for invalid APCIs. 

## Testing
- Installed the updated dependency into a fresh venv (Python 3.14).
- Ran the backend test suite: **181 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)