### PR TITLE
MCP: query filters + read-only project/DPT tools (#333)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -78,12 +78,18 @@ def _build_server() -> FastMCP:
         telegram_types: list[str] | None = None,
         directions: list[str] | None = None,
         dpt_mains: list[int] | None = None,
+        dpts: list[str] | None = None,
+        delta_before_ms: int = 0,
+        delta_after_ms: int = 0,
         limit: int = 100,
         offset: int = 0,
         order_descending: bool = True,
     ) -> dict[str, Any]:
         """Search stored KNX telegrams. Times are ISO-8601; address/type/direction
-        filters are lists (OR within a filter, AND across filters)."""
+        filters are lists (OR within a filter, AND across filters). `telegram_types`
+        accepts "Write"/"Read"/"Response" or the full GroupValue* names. `dpts` are
+        "main" or "main.sub" strings (e.g. "9.001"). `delta_before_ms`/`delta_after_ms`
+        add a context window of telegrams around each match."""
         result = await lib_query_telegrams(
             store,
             QueryTelegramsInput(
@@ -94,6 +100,9 @@ def _build_server() -> FastMCP:
                 telegram_types=telegram_types or [],
                 directions=directions or [],
                 dpt_mains=dpt_mains or [],
+                dpts=dpts or [],
+                delta_before_ms=delta_before_ms,
+                delta_after_ms=delta_after_ms,
                 limit=limit,
                 offset=offset,
                 order_descending=order_descending,

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -38,6 +38,8 @@ from knx_telegram_store.mcp import (
     query_telegrams as lib_query_telegrams,
 )
 from mcp.server.fastmcp import FastMCP
+from xknx import mcp as xknx_mcp
+from xknxproject import mcp as xknxproject_mcp
 
 import knx_daemon
 from database import store
@@ -60,6 +62,27 @@ def mcp_status() -> dict[str, Any]:
     """MCP state for the server-config/status API."""
     mode = MCP_MODE if MCP_MODE in _VALID_MODES else "off"
     return {"mode": mode, "enabled": mcp_enabled(), "write_tools": write_tools_enabled()}
+
+
+def _require_project() -> Any:
+    """The parsed ETS project, or raise if none is loaded.
+
+    Resolved per call so tools pick up a reloaded project without a rebuild.
+    """
+    project = knx_daemon.global_knx_project
+    if project is None:
+        raise ValueError(
+            "No ETS project is loaded. Configure an ETS .knxproj to use project tools."
+        )
+    return project
+
+
+def _require_xknx() -> Any:
+    """The live XKNX instance, or raise if the bus stack is not running."""
+    instance = knx_daemon.xknx_instance
+    if instance is None:
+        raise ValueError("The KNX bus stack is not running.")
+    return instance
 
 
 def _build_server() -> FastMCP:
@@ -136,6 +159,105 @@ def _build_server() -> FastMCP:
     async def get_server_config() -> dict[str, Any]:
         """SpectrumKNX connection/security configuration (passwords masked)."""
         return knx_daemon.get_server_config()
+
+    # --- ETS project introspection (xknxproject.mcp) --------------------------
+
+    @mcp.tool()
+    async def get_project_info() -> dict[str, Any]:
+        """Loaded ETS project metadata and top-level entity counts."""
+        return asdict(await xknxproject_mcp.get_project_info(_require_project()))
+
+    @mcp.tool()
+    async def list_group_addresses(
+        text: str | None = None,
+        dpts: list[str] | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List project group addresses. `text` matches address/name/description;
+        `dpts` are "main" or "main.sub" strings (e.g. "9.001")."""
+        result = await xknxproject_mcp.list_group_addresses(
+            _require_project(),
+            xknxproject_mcp.GroupAddressFilter(
+                text=text, dpts=dpts or [], limit=limit, offset=offset
+            ),
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def describe_group_address(address: str) -> dict[str, Any]:
+        """Resolve one group address to its communication objects and devices."""
+        return asdict(await xknxproject_mcp.describe_group_address(_require_project(), address))
+
+    @mcp.tool()
+    async def list_devices(
+        text: str | None = None, limit: int = 100, offset: int = 0
+    ) -> dict[str, Any]:
+        """List project devices. `text` matches individual address/name/manufacturer."""
+        result = await xknxproject_mcp.list_devices(
+            _require_project(),
+            xknxproject_mcp.DeviceFilter(text=text, limit=limit, offset=offset),
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def list_communication_objects(
+        device_address: str | None = None,
+        group_address: str | None = None,
+        text: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List communication objects, optionally scoped to a device and/or a
+        linked group address."""
+        result = await xknxproject_mcp.list_communication_objects(
+            _require_project(),
+            xknxproject_mcp.CommunicationObjectFilter(
+                device_address=device_address,
+                group_address=group_address,
+                text=text,
+                limit=limit,
+                offset=offset,
+            ),
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def get_topology() -> dict[str, Any]:
+        """Bus topology: areas, their lines and device addresses."""
+        return asdict(await xknxproject_mcp.get_topology(_require_project()))
+
+    @mcp.tool()
+    async def list_locations() -> dict[str, Any]:
+        """Building/location tree (spaces, nested, with devices and functions)."""
+        return asdict(await xknxproject_mcp.list_locations(_require_project()))
+
+    # --- KNX data point types + bus status (xknx.mcp) -------------------------
+
+    @mcp.tool()
+    async def list_dpts(
+        main: int | None = None,
+        text: str | None = None,
+        limit: int = 200,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List known KNX data point types. `main` restricts to a DPT main
+        number; `text` matches the DPT number/value type/unit."""
+        result = await xknx_mcp.list_dpts(
+            xknx_mcp.DptFilter(main=main, text=text, limit=limit, offset=offset)
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def describe_dpt(dpt: str) -> dict[str, Any]:
+        """Resolve a DPT number ("9.001") or value type name ("temperature") to
+        its definition (value type, unit, numeric bounds)."""
+        return asdict(await xknx_mcp.describe_dpt(dpt))
+
+    @mcp.tool()
+    async def get_connection_status() -> dict[str, Any]:
+        """KNX bus connection state, connection type and local individual address."""
+        return asdict(await xknx_mcp.get_connection_status(_require_xknx()))
 
     return mcp
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "fastapi",
     "httpx",
     # Git pin for the unreleased MCP tools; revert to ">=0.11.0" once on PyPI.
-    "knx-telegram-store @ git+https://github.com/XKNX/knx-telegram-store.git@33aebf42baac37102ee8e8f9801629cf6f8cd4ff",
+    "knx-telegram-store @ git+https://github.com/XKNX/knx-telegram-store.git@ed484ad4958ccbd971374827baefeff517022aca",
     "mcp",
     "pydantic",
     "python-dotenv",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
     # Git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
     # Revert to "xknx"/"xknxproject" once XKNX/xknx#1876 and
     # XKNX/xknxproject#625 are merged and released to PyPI.
-    "xknx @ git+https://github.com/martinhoefling/xknx.git@ec042264d99481ea1b5db2c7c91a6936354c2344",
-    "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@69853512955e302318839a557a3996f8ec83ef04",
+    "xknx @ git+https://github.com/martinhoefling/xknx.git@f9e48018595c377d6904e34b9a6ffcee399c320a",
+    "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@a6498fb497828cd9ba10acd6e76456749909bf9c",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
     # Git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
     # Revert to "xknx"/"xknxproject" once XKNX/xknx#1876 and
     # XKNX/xknxproject#625 are merged and released to PyPI.
-    "xknx @ git+https://github.com/martinhoefling/xknx.git@f47860fe2f22afca9e43fc26717f21a3262e94aa",
-    "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@71da37a5f88e7693dd07c2eb28a9584fe47f3953",
+    "xknx @ git+https://github.com/martinhoefling/xknx.git@76f974b4a5d39823336d95bd645398b0c37a0eee",
+    "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@69853512955e302318839a557a3996f8ec83ef04",
 ]
 
 [dependency-groups]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # Git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
     # Revert to "xknx"/"xknxproject" once XKNX/xknx#1876 and
     # XKNX/xknxproject#625 are merged and released to PyPI.
-    "xknx @ git+https://github.com/martinhoefling/xknx.git@76f974b4a5d39823336d95bd645398b0c37a0eee",
+    "xknx @ git+https://github.com/martinhoefling/xknx.git@ec042264d99481ea1b5db2c7c91a6936354c2344",
     "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@69853512955e302318839a557a3996f8ec83ef04",
 ]
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,8 +24,11 @@ dependencies = [
     "SQLAlchemy",
     "uvicorn",
     "websockets",
-    "xknx",
-    "xknxproject",
+    # Git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
+    # Revert to "xknx"/"xknxproject" once XKNX/xknx#1876 and
+    # XKNX/xknxproject#625 are merged and released to PyPI.
+    "xknx @ git+https://github.com/martinhoefling/xknx.git@f47860fe2f22afca9e43fc26717f21a3262e94aa",
+    "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@71da37a5f88e7693dd07c2eb28a9584fe47f3953",
 ]
 
 [dependency-groups]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,7 +38,7 @@ websockets==16.1.1
 # Temporary git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
 # Revert to `xknx==3.17.0` / `xknxproject==3.9.0` once XKNX/xknx#1876 and
 # XKNX/xknxproject#625 are merged and released to PyPI.
-xknx @ git+https://github.com/martinhoefling/xknx.git@76f974b4a5d39823336d95bd645398b0c37a0eee
+xknx @ git+https://github.com/martinhoefling/xknx.git@ec042264d99481ea1b5db2c7c91a6936354c2344
 xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@69853512955e302318839a557a3996f8ec83ef04
 httpx==0.28.1
 ruff==0.16.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -35,8 +35,11 @@ typing-inspection==0.4.2
 typing_extensions==4.16.0
 uvicorn==0.51.0
 websockets==16.1.1
-xknx==3.17.0
-xknxproject==3.9.0
+# Temporary git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
+# Revert to `xknx==3.17.0` / `xknxproject==3.9.0` once XKNX/xknx#1876 and
+# XKNX/xknxproject#625 are merged and released to PyPI.
+xknx @ git+https://github.com/martinhoefling/xknx.git@f47860fe2f22afca9e43fc26717f21a3262e94aa
+xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@71da37a5f88e7693dd07c2eb28a9584fe47f3953
 httpx==0.28.1
 ruff==0.16.0
 pytest-asyncio==1.4.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,7 @@ ifaddr==0.2.0
 iniconfig==2.3.0
 # Temporary git pin for the unreleased MCP tools (knx_telegram_store.mcp, 0.11.0).
 # Revert to `knx-telegram-store==0.11.0` once it is published to PyPI.
-knx-telegram-store @ git+https://github.com/XKNX/knx-telegram-store.git@33aebf42baac37102ee8e8f9801629cf6f8cd4ff
+knx-telegram-store @ git+https://github.com/XKNX/knx-telegram-store.git@ed484ad4958ccbd971374827baefeff517022aca
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,8 +38,8 @@ websockets==16.1.1
 # Temporary git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
 # Revert to `xknx==3.17.0` / `xknxproject==3.9.0` once XKNX/xknx#1876 and
 # XKNX/xknxproject#625 are merged and released to PyPI.
-xknx @ git+https://github.com/martinhoefling/xknx.git@f47860fe2f22afca9e43fc26717f21a3262e94aa
-xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@71da37a5f88e7693dd07c2eb28a9584fe47f3953
+xknx @ git+https://github.com/martinhoefling/xknx.git@76f974b4a5d39823336d95bd645398b0c37a0eee
+xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@69853512955e302318839a557a3996f8ec83ef04
 httpx==0.28.1
 ruff==0.16.0
 pytest-asyncio==1.4.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,8 +38,8 @@ websockets==16.1.1
 # Temporary git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
 # Revert to `xknx==3.17.0` / `xknxproject==3.9.0` once XKNX/xknx#1876 and
 # XKNX/xknxproject#625 are merged and released to PyPI.
-xknx @ git+https://github.com/martinhoefling/xknx.git@ec042264d99481ea1b5db2c7c91a6936354c2344
-xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@69853512955e302318839a557a3996f8ec83ef04
+xknx @ git+https://github.com/martinhoefling/xknx.git@f9e48018595c377d6904e34b9a6ffcee399c320a
+xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@a6498fb497828cd9ba10acd6e76456749909bf9c
 httpx==0.28.1
 ruff==0.16.0
 pytest-asyncio==1.4.0

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -4,10 +4,115 @@ import pytest
 import pytest_asyncio
 from knx_telegram_store import StoredTelegram
 from knx_telegram_store.backends.memory import MemoryStore
+from xknx import XKNX
 
+import knx_daemon
 import mcp_server
 
 NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=UTC)
+
+
+def _sample_project() -> dict:
+    """A minimal parsed-KNXProject shape covering the project introspection tools."""
+    flags = {
+        "read": False,
+        "write": True,
+        "communication": True,
+        "transmit": True,
+        "update": False,
+        "read_on_init": False,
+    }
+    return {
+        "info": {
+            "project_id": "P-1",
+            "name": "Demo",
+            "last_modified": None,
+            "group_address_style": "ThreeLevel",
+            "guid": "g",
+            "created_by": "ETS",
+            "schema_version": "21",
+            "tool_version": "6.0",
+            "xknxproject_version": "3.9.0",
+            "language_code": None,
+        },
+        "communication_objects": {
+            "1.1.5/O-1": {
+                "name": "CO",
+                "number": 1,
+                "text": "Switch",
+                "function_text": "On/Off",
+                "description": "",
+                "device_address": "1.1.5",
+                "device_application": None,
+                "module": None,
+                "channel": None,
+                "dpts": [{"main": 1, "sub": 1}],
+                "object_size": "1 Bit",
+                "group_address_links": ["1/0/0"],
+                "flags": flags,
+                "dpas": None,
+            }
+        },
+        "devices": {
+            "1.1.5": {
+                "name": "Switch Actuator",
+                "hardware_name": "HW",
+                "order_number": "ORD-1",
+                "description": "",
+                "manufacturer_name": "ACME",
+                "individual_address": "1.1.5",
+                "application": None,
+                "project_uid": None,
+                "communication_object_ids": ["1.1.5/O-1"],
+                "channels": {},
+            }
+        },
+        "topology": {
+            "1": {
+                "name": "Area 1",
+                "description": None,
+                "lines": {
+                    "1.1": {
+                        "name": "Line 1",
+                        "medium_type": "TP",
+                        "description": None,
+                        "devices": ["1.1.5"],
+                    }
+                },
+            }
+        },
+        "locations": {
+            "B1": {
+                "type": "Building",
+                "identifier": "B1",
+                "name": "House",
+                "usage_id": None,
+                "usage_text": "",
+                "number": "",
+                "description": "",
+                "project_uid": None,
+                "devices": ["1.1.5"],
+                "spaces": {},
+                "functions": [],
+            }
+        },
+        "group_addresses": {
+            "1/0/0": {
+                "name": "Kitchen Light",
+                "identifier": "GA-1",
+                "raw_address": 2048,
+                "address": "1/0/0",
+                "project_uid": None,
+                "dpt": {"main": 1, "sub": 1},
+                "data_secure": False,
+                "communication_object_ids": ["1.1.5/O-1"],
+                "description": "",
+                "comment": "",
+            }
+        },
+        "group_ranges": {},
+        "functions": {},
+    }
 
 
 async def _seeded_store() -> MemoryStore:
@@ -65,6 +170,18 @@ async def test_lists_read_only_tools(server):
         "get_store_capabilities",
         "count_telegrams",
         "get_server_config",
+        # ETS project introspection (xknxproject.mcp)
+        "get_project_info",
+        "list_group_addresses",
+        "describe_group_address",
+        "list_devices",
+        "list_communication_objects",
+        "get_topology",
+        "list_locations",
+        # DPT catalogue + bus status (xknx.mcp)
+        "list_dpts",
+        "describe_dpt",
+        "get_connection_status",
     } <= names
 
 
@@ -128,3 +245,67 @@ def test_invalid_mode_reported_as_off(monkeypatch):
     monkeypatch.setattr(mcp_server, "MCP_MODE", "bogus")
     assert mcp_server.mcp_enabled() is False
     assert mcp_server.mcp_status()["mode"] == "off"
+
+
+@pytest.mark.asyncio
+async def test_project_tools(server, monkeypatch):
+    monkeypatch.setattr(knx_daemon, "global_knx_project", _sample_project())
+
+    info = await _structured(server, "get_project_info")
+    assert info["name"] == "Demo"
+    assert info["group_address_count"] == 1
+    assert info["device_count"] == 1
+
+    gas = await _structured(server, "list_group_addresses", {"text": "kitchen"})
+    assert [g["address"] for g in gas["group_addresses"]] == ["1/0/0"]
+    assert gas["group_addresses"][0]["dpt"] == "1.001"
+
+    detail = await _structured(server, "describe_group_address", {"address": "1/0/0"})
+    assert detail["found"] is True
+    assert detail["devices"] == ["1.1.5"]
+
+    devices = await _structured(server, "list_devices", {"text": "acme"})
+    assert devices["devices"][0]["individual_address"] == "1.1.5"
+
+    cos = await _structured(server, "list_communication_objects", {"group_address": "1/0/0"})
+    assert cos["total_count"] == 1
+
+    topo = await _structured(server, "get_topology")
+    assert topo["areas"][0]["lines"][0]["devices"] == ["1.1.5"]
+
+    locations = await _structured(server, "list_locations")
+    assert locations["spaces"][0]["type"] == "Building"
+
+
+@pytest.mark.asyncio
+async def test_project_tool_without_project_errors(server, monkeypatch):
+    monkeypatch.setattr(knx_daemon, "global_knx_project", None)
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        await _structured(server, "get_project_info")
+
+
+@pytest.mark.asyncio
+async def test_dpt_tools(server):
+    listed = await _structured(server, "list_dpts", {"main": 9})
+    assert all(d["dpt"].split(".")[0] == "9" for d in listed["dpts"])
+    assert "9.001" in {d["dpt"] for d in listed["dpts"]}
+
+    described = await _structured(server, "describe_dpt", {"dpt": "9.001"})
+    assert described["found"] is True
+    assert described["dpt"]["value_type"] == "temperature"
+    assert described["dpt"]["unit"] == "°C"
+
+    missing = await _structured(server, "describe_dpt", {"dpt": "999.999"})
+    assert missing["found"] is False
+
+
+@pytest.mark.asyncio
+async def test_connection_status_tool(server, monkeypatch):
+    monkeypatch.setattr(knx_daemon, "xknx_instance", XKNX())
+    status = await _structured(server, "get_connection_status")
+    assert status["state"] == "DISCONNECTED"
+    assert status["connected"] is False
+
+    monkeypatch.setattr(knx_daemon, "xknx_instance", None)
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        await _structured(server, "get_connection_status")

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -85,6 +85,16 @@ async def test_query_telegrams(server):
 
 
 @pytest.mark.asyncio
+async def test_query_dpt_subtype_and_type_alias(server):
+    # DPT subtype filter reaches the store (only the 9.001 temperature telegram).
+    by_dpt = await _structured(server, "query_telegrams", {"dpts": ["9.001"]})
+    assert [t["destination"] for t in by_dpt["telegrams"]] == ["1/1/1"]
+    # "Write" alias resolves to GroupValueWrite (both seeded rows are writes).
+    by_type = await _structured(server, "query_telegrams", {"telegram_types": ["Write"]})
+    assert by_type["total_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_count_and_stats(server):
     assert (await _structured(server, "count_telegrams"))["count"] == 2
     stats = await _structured(server, "get_store_stats")


### PR DESCRIPTION
## Summary

Extends the SpectrumKNX `/mcp` endpoint with the shared XKNX MCP tool functions, completing the read-only tool wiring for the KNX MCP epic (#328, sub-issue #333). Two commits:

1. **Query filters** — the `query_telegrams` tool now exposes the new `knx-telegram-store` filters: `dpts` ("main"/"main.sub"), `delta_before_ms`/`delta_after_ms` context windows, and the short `Write`/`Read`/`Response` type aliases.
2. **Project + DPT tools** — wires `xknxproject.mcp` and `xknx.mcp` through the endpoint.

## New read-only tools

**ETS project introspection** (`xknxproject.mcp`, needs a loaded `.knxproj`):
`get_project_info`, `list_group_addresses`, `describe_group_address`, `list_devices`, `list_communication_objects`, `get_topology`, `list_locations`

**KNX data point types + bus status** (`xknx.mcp`):
`list_dpts`, `describe_dpt` (static catalogue), `get_connection_status` (live `XKNX`)

Project tools resolve `knx_daemon.global_knx_project` per call (a reloaded project is picked up without a rebuild); connection status uses `knx_daemon.xknx_instance`. All tools are available in both `read-only` and `read-write` mode. Bus read/write tools remain for the read-write-mode step (#334).

## Dependencies

Git-pins `xknx` and `xknxproject` to the branches carrying the new `.mcp` subpackages, matching the existing `knx-telegram-store` pin:

- `xknx` → XKNX/xknx#1876
- `xknxproject` → XKNX/xknxproject#625
- (`knx-telegram-store` filters already merged: XKNX/knx-telegram-store#21)

Revert each to the PyPI release once merged and published.

## Tests

New tests cover every added tool against a minimal parsed project and a fresh `XKNX`, plus the "no project / no bus" error paths. Full backend suite green (186 passed); `ruff` clean.

Tracking: #333 (epic #328).

🤖 Generated with [Claude Code](https://claude.com/claude-code)