### PR TITLE
Install git in the backend image so `docker compose --build` succeeds (#350)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,12 @@ FROM python:3.14-slim
 
 WORKDIR /app
 
+# git is required at build time: on newer Python versions some dependencies
+# have no prebuilt wheels and pip builds them from source, invoking git.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Fixes #350.

## Problem
A fresh clone building the backend image with `docker-compose up -d --build` (via `docker-compose.override.yml`) can fail because `git` is missing in the container. On newer Python versions some pinned dependencies have no prebuilt wheels, so pip builds them from source and the build backend invokes `git`.

## Change
Install `git` in the backend build stage (with `--no-install-recommends` and apt-list cleanup to keep the image lean), matching the fix reported in the issue.

## Verification
- [ ] Deferred to the combined manual/e2e pass: `docker compose up -d --build` on a fresh clone.