### PR TITLE
Sort Last Seen Values address list numerically by GA/PA (#348)

### DIFF
--- a/frontend/src/components/LastSeenOverlay.test.tsx
+++ b/frontend/src/components/LastSeenOverlay.test.tsx
@@ -128,3 +128,31 @@ test('renders instruction when no addresses are selected, and clicking a sidebar
     expect(screen.getByText('On')).toBeInTheDocument();
   });
 });
+
+test('sidebar address list is ordered numerically by main/middle/sub, not as text (#348)', () => {
+  const scrambled: FilterOptions = {
+    ...FILTER_OPTIONS,
+    targets: [
+      { address: '1/1/10', name: 'ten', main: 1, sub: 1 },
+      { address: '1/1/2', name: 'two', main: 1, sub: 1 },
+      { address: '0/1/1', name: 'zero', main: 0, sub: 1 },
+      { address: '1/1/1', name: 'one', main: 1, sub: 1 },
+    ],
+  };
+  render(
+    <LastSeenOverlay
+      filterOptions={scrambled}
+      initialAddresses={[]}
+      initialMode="ga"
+      onClose={() => {}}
+    />
+  );
+
+  const rendered = ['0/1/1', '1/1/1', '1/1/2', '1/1/10'].map(a => screen.getByText(a));
+  // Each address appears strictly before the next in document order.
+  for (let i = 0; i < rendered.length - 1; i++) {
+    expect(
+      rendered[i].compareDocumentPosition(rendered[i + 1]) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  }
+});

--- a/frontend/src/components/LastSeenOverlay.tsx
+++ b/frontend/src/components/LastSeenOverlay.tsx
@@ -5,6 +5,7 @@ import type { Telegram } from '../hooks/useWebSocket';
 import type { FilterOptions } from '../types/filters';
 import { apiUrl } from '../utils/basePath';
 import { formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
+import { compareKnxAddress } from '../utils/knxAddress';
 import { WriteControls } from './WriteControls';
 import { SendToGaPopover } from './SendToGaPopover';
 import { secondaryBtn } from '../utils/buttonStyles';
@@ -169,10 +170,14 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
     setSearch('');
   };
 
-  const filteredAddresses = addressList.filter(a => {
-    const q = search.toLowerCase();
-    return (a.address ?? '').toLowerCase().includes(q) || (a.name ?? '').toLowerCase().includes(q);
-  });
+  const filteredAddresses = addressList
+    .filter(a => {
+      const q = search.toLowerCase();
+      return (a.address ?? '').toLowerCase().includes(q) || (a.name ?? '').toLowerCase().includes(q);
+    })
+    // Order by numeric address (main/middle/sub) rather than the backend's
+    // string order, so e.g. 1/1/2 sorts before 1/1/10 (#348).
+    .sort((a, b) => compareKnxAddress(a.address ?? '', b.address ?? ''));
 
   const selectedInfo = !multi
     ? addressList.find(a => a.address === selectedAddresses[0])


### PR DESCRIPTION
Fixes #348 (the primary complaint).

## Problem
In the **Last Seen Values** panel, the sidebar address list was rendered in the backend's string order. Searching "OGB" and scrolling the filtered list showed group addresses ordered as text, so `1/1/10` came before `1/1/2` instead of after it.

## Change
Order `filteredAddresses` with the existing `compareKnxAddress` util, which compares the numeric main/middle/sub parts (and handles both `/`-separated GAs and `.`-separated PAs). Added a unit test asserting DOM order for a scrambled list.

## Not included (raised in the same issue)
The issue also asks about the **Visualization → Targets** pane (sorted by telegram count) and whether that pane should share the telegram list's main filter. That involves a design choice (separate filter instance vs. Targets ignoring the main filter), so I've left it out of this focused fix — happy to follow up once you've decided the intended behavior.

## Verification
- `vitest` unit test added and passing.