### PR TITLE
MCP: bus read/write tools in read-write mode (#334)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -282,6 +282,24 @@ def _build_server() -> FastMCP:
         """KNX bus connection state, connection type and local individual address."""
         return asdict(await xknx_mcp.get_connection_status(_require_xknx()))
 
+    @mcp.tool()
+    async def encode_value(value: Any, value_type: str) -> dict[str, Any]:
+        """Encode a value using a specific DPT into its raw payload bytes.
+        `value` is the Python native value; `value_type` is DPT number (e.g. "9.001") or name."""
+        result = await xknx_mcp.encode_value(
+            xknx_mcp.EncodeValueInput(value=value, value_type=value_type)
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def decode_payload(payload: list[int] | int, value_type: str) -> dict[str, Any]:
+        """Decode raw payload bytes or integer using a specific DPT.
+        `payload` is a list of byte integers, or a single integer for 6-bit DPTs (like 1.001)."""
+        result = await xknx_mcp.decode_payload(
+            xknx_mcp.DecodePayloadInput(payload=payload, value_type=value_type)
+        )
+        return asdict(result)
+
     if write_tools_enabled():
         _register_bus_tools(mcp)
 

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -286,8 +286,8 @@ def _build_server() -> FastMCP:
     async def encode_value(value: Any, value_type: str) -> dict[str, Any]:
         """Encode a value using a specific DPT into its raw payload bytes.
         `value` is the Python native value; `value_type` is DPT number (e.g. "9.001") or name."""
-        result = await xknx_mcp.encode_value(
-            xknx_mcp.EncodeValueInput(value=value, value_type=value_type)
+        result = await xknx_mcp.encode_dpt_payload(
+            xknx_mcp.EncodeDptPayloadInput(value=value, value_type=value_type)
         )
         return asdict(result)
 
@@ -295,8 +295,8 @@ def _build_server() -> FastMCP:
     async def decode_payload(payload: list[int] | int, value_type: str) -> dict[str, Any]:
         """Decode raw payload bytes or integer using a specific DPT.
         `payload` is a list of byte integers, or a single integer for 6-bit DPTs (like 1.001)."""
-        result = await xknx_mcp.decode_payload(
-            xknx_mcp.DecodePayloadInput(payload=payload, value_type=value_type)
+        result = await xknx_mcp.decode_dpt_payload(
+            xknx_mcp.DecodeDptPayloadInput(payload=payload, value_type=value_type)
         )
         return asdict(result)
 

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -11,7 +11,8 @@ Access is gated by ``MCP_MODE``:
 
 - ``off`` — the endpoint is not mounted.
 - ``read-only`` (default) — query/introspection tools only.
-- ``read-write`` — additionally exposes bus/write tools (added in a later step).
+- ``read-write`` — additionally exposes bus tools that transmit on the KNX
+  bus (live read, GroupValueRead, GroupValueWrite).
 """
 
 import os
@@ -259,7 +260,56 @@ def _build_server() -> FastMCP:
         """KNX bus connection state, connection type and local individual address."""
         return asdict(await xknx_mcp.get_connection_status(_require_xknx()))
 
+    if write_tools_enabled():
+        _register_bus_tools(mcp)
+
     return mcp
+
+
+def _register_bus_tools(mcp: FastMCP) -> None:
+    """Register the bus tools that transmit on the KNX bus.
+
+    Only mounted in ``read-write`` mode: these send telegrams (a live read
+    triggers a GroupValueRead; a write mutates a group address).
+    """
+
+    @mcp.tool()
+    async def read_group_value(
+        group_address: str, value_type: str | None = None
+    ) -> dict[str, Any]:
+        """Read a group address live from the bus (sends a GroupValueRead and
+        waits). `value_type` is a DPT number ("9.001") or value type name
+        ("temperature"); without it the raw payload is returned."""
+        result = await xknx_mcp.read_group_value(
+            _require_xknx(),
+            xknx_mcp.GroupValueReadInput(group_address=group_address, value_type=value_type),
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def send_group_value_read(group_address: str) -> dict[str, Any]:
+        """Queue a GroupValueRead telegram to trigger a response on the bus."""
+        result = await xknx_mcp.send_group_value_read(
+            _require_xknx(), xknx_mcp.GroupAddressInput(group_address=group_address)
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def send_group_value_write(
+        group_address: str,
+        value: bool | int | float | str | list[int],
+        value_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Write a value to a group address (queues a GroupValueWrite). `value_type`
+        selects the DPT used to encode `value`; without it an int is sent as a
+        6-bit payload and a list of ints as a byte array."""
+        result = await xknx_mcp.send_group_value_write(
+            _require_xknx(),
+            xknx_mcp.GroupValueWriteInput(
+                group_address=group_address, value=value, value_type=value_type
+            ),
+        )
+        return asdict(result)
 
 
 _fastmcp: FastMCP | None = None

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -233,6 +233,28 @@ def _build_server() -> FastMCP:
         """Building/location tree (spaces, nested, with devices and functions)."""
         return asdict(await xknxproject_mcp.list_locations(_require_project()))
 
+    @mcp.tool()
+    async def list_functions(
+        text: str | None = None,
+        space_id: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """List project functions/functional blocks. `text` matches identifier/name/type/usage;
+        `space_id` restricts to a specific space/room."""
+        result = await xknxproject_mcp.list_functions(
+            _require_project(),
+            xknxproject_mcp.FunctionFilter(
+                text=text, space_id=space_id, limit=limit, offset=offset
+            ),
+        )
+        return asdict(result)
+
+    @mcp.tool()
+    async def describe_function(identifier: str) -> dict[str, Any]:
+        """Resolve one function/functional block by identifier to its group address references and roles."""
+        return asdict(await xknxproject_mcp.describe_function(_require_project(), identifier))
+
     # --- KNX data point types + bus status (xknx.mcp) -------------------------
 
     @mcp.tool()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,10 +25,11 @@ dependencies = [
     "uvicorn",
     "websockets",
     # Git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
-    # Revert to "xknx"/"xknxproject" once XKNX/xknx#1876 and
-    # XKNX/xknxproject#625 are merged and released to PyPI.
-    "xknx @ git+https://github.com/martinhoefling/xknx.git@f9e48018595c377d6904e34b9a6ffcee399c320a",
-    "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@a6498fb497828cd9ba10acd6e76456749909bf9c",
+    # xknx tracks upstream main (XKNX/xknx#1876/#1880 merged); xknxproject stays on
+    # the fork branch until XKNX/xknxproject#625 merges. Revert both to
+    # "xknx"/"xknxproject" once released to PyPI.
+    "xknx @ git+https://github.com/XKNX/xknx.git@678f2eac302c1a2a8b1a2ec1b13adaeb78c8358f",
+    "xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@aba891dae69d9b14227e8565e811b317ed0dabb7",
 ]
 
 [dependency-groups]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -36,10 +36,11 @@ typing_extensions==4.16.0
 uvicorn==0.51.0
 websockets==16.1.1
 # Temporary git pins for the unreleased MCP tools (xknx.mcp / xknxproject.mcp).
-# Revert to `xknx==3.17.0` / `xknxproject==3.9.0` once XKNX/xknx#1876 and
-# XKNX/xknxproject#625 are merged and released to PyPI.
-xknx @ git+https://github.com/martinhoefling/xknx.git@f9e48018595c377d6904e34b9a6ffcee399c320a
-xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@a6498fb497828cd9ba10acd6e76456749909bf9c
+# xknx tracks upstream main (XKNX/xknx#1876/#1880 merged); xknxproject stays on the
+# fork branch until XKNX/xknxproject#625 merges. Revert to `xknx==3.17.0` /
+# `xknxproject==3.9.0` once released to PyPI.
+xknx @ git+https://github.com/XKNX/xknx.git@678f2eac302c1a2a8b1a2ec1b13adaeb78c8358f
+xknxproject @ git+https://github.com/martinhoefling/xknxproject.git@aba891dae69d9b14227e8565e811b317ed0dabb7
 httpx==0.28.1
 ruff==0.16.0
 pytest-asyncio==1.4.0

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -203,6 +203,8 @@ async def test_lists_read_only_tools(server):
         "list_dpts",
         "describe_dpt",
         "get_connection_status",
+        "encode_value",
+        "decode_payload",
     } <= names
 
 
@@ -386,3 +388,18 @@ async def test_connection_status_tool(server, monkeypatch):
     monkeypatch.setattr(knx_daemon, "xknx_instance", None)
     with pytest.raises(Exception):  # noqa: B017, PT011
         await _structured(server, "get_connection_status")
+
+
+@pytest.mark.asyncio
+async def test_encode_decode_value_tools(server):
+    encoded = await _structured(server, "encode_value", {"value": 21.0, "value_type": "9.001"})
+    assert encoded["payload"] == [0x0C, 0x1A]
+    assert encoded["value_type"] == "9.001"
+
+    decoded = await _structured(server, "decode_payload", {"payload": [0x0C, 0x1A], "value_type": "9.001"})
+    assert decoded["value"] == 21.0
+    assert decoded["value_type"] == "9.001"
+
+    decoded_binary = await _structured(server, "decode_payload", {"payload": 1, "value_type": "1.001"})
+    assert decoded_binary["value"] == "Switch.ON"
+

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -113,7 +113,24 @@ def _sample_project() -> dict:
             }
         },
         "group_ranges": {},
-        "functions": {},
+        "functions": {
+            "F-1": {
+                "function_type": "FT-1",
+                "group_addresses": {
+                    "1/0/0": {
+                        "address": "1/0/0",
+                        "name": "Kitchen Light",
+                        "project_uid": 12,
+                        "role": "SwitchOnOff",
+                    }
+                },
+                "identifier": "F-1",
+                "name": "Kitchen Light Function",
+                "project_uid": 10,
+                "space_id": "B1",
+                "usage_text": "Control kitchen light",
+            }
+        },
     }
 
 
@@ -180,6 +197,8 @@ async def test_lists_read_only_tools(server):
         "list_communication_objects",
         "get_topology",
         "list_locations",
+        "list_functions",
+        "describe_function",
         # DPT catalogue + bus status (xknx.mcp)
         "list_dpts",
         "describe_dpt",
@@ -277,6 +296,18 @@ async def test_project_tools(server, monkeypatch):
 
     locations = await _structured(server, "list_locations")
     assert locations["spaces"][0]["type"] == "Building"
+
+    functions = await _structured(server, "list_functions", {"text": "kitchen"})
+    assert len(functions["functions"]) == 1
+    assert functions["functions"][0]["identifier"] == "F-1"
+    assert functions["functions"][0]["group_address_count"] == 1
+
+    detail = await _structured(server, "describe_function", {"identifier": "F-1"})
+    assert detail["found"] is True
+    assert detail["function"]["identifier"] == "F-1"
+    assert len(detail["group_addresses"]) == 1
+    assert detail["group_addresses"][0]["role"] == "SwitchOnOff"
+    assert detail["group_addresses"][0]["address"] == "1/0/0"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -401,5 +401,5 @@ async def test_encode_decode_value_tools(server):
     assert decoded["value_type"] == "9.001"
 
     decoded_binary = await _structured(server, "decode_payload", {"payload": 1, "value_type": "1.001"})
-    assert decoded_binary["value"] == "Switch.ON"
+    assert decoded_binary["value"] == "on"
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -5,6 +5,8 @@ import pytest_asyncio
 from knx_telegram_store import StoredTelegram
 from knx_telegram_store.backends.memory import MemoryStore
 from xknx import XKNX
+from xknx.dpt import DPTArray
+from xknx.telegram import GroupAddress, Telegram, apci
 
 import knx_daemon
 import mcp_server
@@ -297,6 +299,50 @@ async def test_dpt_tools(server):
 
     missing = await _structured(server, "describe_dpt", {"dpt": "999.999"})
     assert missing["found"] is False
+
+
+@pytest_asyncio.fixture
+async def rw_server(monkeypatch):
+    """An MCP server built in read-write mode, wired to a seeded store."""
+    store = await _seeded_store()
+    monkeypatch.setattr(mcp_server, "store", store)
+    monkeypatch.setattr(mcp_server, "MCP_MODE", "read-write")
+    return mcp_server._build_server()
+
+
+@pytest.mark.asyncio
+async def test_write_tools_hidden_in_read_only_mode(server):
+    names = {t.name for t in await server.list_tools()}
+    assert {"read_group_value", "send_group_value_read", "send_group_value_write"} & names == set()
+
+
+@pytest.mark.asyncio
+async def test_write_tools_exposed_in_read_write_mode(rw_server):
+    names = {t.name for t in await rw_server.list_tools()}
+    assert {"read_group_value", "send_group_value_read", "send_group_value_write"} <= names
+
+
+@pytest.mark.asyncio
+async def test_send_group_value_write_queues_telegram(rw_server, monkeypatch):
+    xknx = XKNX()
+    monkeypatch.setattr(knx_daemon, "xknx_instance", xknx)
+    result = await _structured(
+        rw_server,
+        "send_group_value_write",
+        {"group_address": "1/2/3", "value": 50, "value_type": "percent"},
+    )
+    assert result["apci"] == "GroupValueWrite"
+    assert xknx.telegrams.get_nowait() == Telegram(
+        destination_address=GroupAddress("1/2/3"),
+        payload=apci.GroupValueWrite(DPTArray((0x80,))),
+    )
+
+
+@pytest.mark.asyncio
+async def test_bus_tools_require_running_stack(rw_server, monkeypatch):
+    monkeypatch.setattr(knx_daemon, "xknx_instance", None)
+    with pytest.raises(Exception):  # noqa: B017, PT011
+        await _structured(rw_server, "send_group_value_read", {"group_address": "1/2/3"})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds the bus-transmitting MCP tools to the SpectrumKNX `/mcp` endpoint, exposed **only when `MCP_MODE=read-write`** (sub-issue #334 of epic #328). Rebased onto `main` after #352 merged.

## New tools

Registered by `_register_bus_tools()` behind `write_tools_enabled()` (read-write only):

- `read_group_value` — live read from the bus (sends a `GroupValueRead`, waits, DPT-decodes)
- `send_group_value_read` — queue a `GroupValueRead`
- `send_group_value_write` — write a value (queue a `GroupValueWrite`, DPT-encoded)

Always-on read-only additions:

- `list_functions` / `describe_function` — ETS project functions (via `xknxproject.mcp`)
- `encode_value` / `decode_payload` — DPT encode/decode (via `xknx.mcp`)

## Dependency change

`encode_value` / `decode_payload` were wired to `xknx.mcp.encode_value` / `decode_payload`, which never existed in the previously pinned fork commit and were named `encode_dpt_payload` / `decode_dpt_payload` in merged upstream (XKNX/xknx #1876/#1880). This PR:

- repoints the **xknx** dependency from the obsolete fork commit to **upstream `XKNX/xknx@678f2eac`** (which carries the encode/decode API);
- wires the two tools to `encode_dpt_payload` / `decode_dpt_payload` and their `*Input` dataclasses;
- updates the enum-decode assertion (1.001 → `"on"`, matching the merged `_jsonify` lower-casing).

`xknxproject` stays on its fork branch until XKNX/xknxproject#625 merges.

## Validation

Full backend suite (`pytest tests/`) — **191 passed**. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
