### PR TITLE
Cancel in-flight history load when the buffer is cleared (#339)

### DIFF
--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -352,6 +352,52 @@ describe('useTelegramCache', () => {
     expect(result.current.telegrams).toHaveLength(1);
   });
 
+  it('discards an in-flight history chunk when the buffer is cleared mid-load (#339)', async () => {
+    let release: () => void = () => {};
+    const gate = new Promise<void>(res => { release = res; });
+    let gateArmed = false;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: RequestInfo | URL) => {
+        const u = String(url);
+        fetchCalls.push(u);
+        if (u.includes('/api/database/info')) return jsonRes({ retention_days: null });
+        // Hold the history chunk in flight until the test releases it.
+        if (gateArmed) await gate;
+        return jsonRes({
+          telegrams: [tg(2000, 'x'), tg(1000, 'y')],
+          metadata: { limit_reached: false },
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    gateArmed = true;
+    let load!: Promise<void>;
+    act(() => {
+      load = result.current.loadRange(0, 5000);
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    // User clears the buffer while the chunk is still loading.
+    await act(async () => {
+      await result.current.clear();
+    });
+
+    // The now-stale chunk resolves: it must be dropped, not merged back in.
+    await act(async () => {
+      release();
+      await load;
+    });
+
+    expect(result.current.telegrams).toEqual([]);
+    // Nothing was marked covered, so a later load can still fetch the range —
+    // no gap between the discarded chunk and newer telegrams (#339).
+    expect(JSON.parse(localStorage.getItem(COVERAGE_STORAGE_KEY)!)).toEqual([]);
+  });
+
   it('clear wipes buffer, persistent cache and coverage', async () => {
     seedIdb([tg(1000, 'a')]);
     localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1000, 1000]]));

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -105,6 +105,8 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
   const pendingRef = useRef<TelegramEntry[]>([]);
   const connectedRef = useRef(false);
   const pausedRef = useRef(false);
+  /** Bumped by clear() to invalidate any background load still in flight (#339). */
+  const loadGenerationRef = useRef(0);
 
   const [telegrams, setTelegrams] = useState<Telegram[]>([]);
   const [pausedCount, setPausedCount] = useState(0);
@@ -145,6 +147,7 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
    */
   const fetchGapProgressive = useCallback(
     async (gapStart: number, gapEnd: number, budget: number): Promise<number> => {
+      const gen = loadGenerationRef.current;
       let cursor = gapEnd;
       let fetched = 0;
       while (cursor >= gapStart && fetched < budget) {
@@ -158,6 +161,10 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
         }
         const limit = Math.min(HISTORY_CHUNK_SIZE, budget - fetched);
         const { entries, limitReached } = await fetchRange(gapStart, cursor, limit);
+        // A buffer clear during the fetch invalidates this load: drop the chunk
+        // and stop paging, so a late arrival can't repopulate the cleared buffer
+        // and leave a gap between it and newer telegrams (#339).
+        if (loadGenerationRef.current !== gen) return fetched;
         if (entries.length === 0) {
           // Nothing left in this window — the rest is covered-but-empty.
           coverageRef.current!.addCovered(gapStart, cursor);
@@ -197,10 +204,13 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
    */
   const fillGapsBudgeted = useCallback(
     async (startMs: number, endMs: number, budget: number) => {
+      const gen = loadGenerationRef.current;
       const gaps = coverageRef.current!.gaps(startMs, endMs);
       let remaining = budget;
       for (let i = gaps.length - 1; i >= 0 && remaining > 0; i--) {
         remaining -= await fetchGapProgressive(gaps[i][0], gaps[i][1], remaining);
+        // A buffer clear invalidated this load — don't start further gaps (#339).
+        if (loadGenerationRef.current !== gen) return;
       }
       saveCoverage();
     },
@@ -232,8 +242,11 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
   const loadRange = useCallback(
     (startMs: number, endMs: number) =>
       runLoad(async () => {
+        const gen = loadGenerationRef.current;
         // Cache hits paint immediately; the backend only fills the gaps.
         const cached = await cacheRef.current!.loadRange(startMs, endMs).catch(() => []);
+        // A buffer clear during the cache read invalidates this load (#339).
+        if (loadGenerationRef.current !== gen) return;
         if (cached.length > 0 && mergeIntoBuffer(cached)) publish();
         await fillGaps(startMs, endMs);
       }),
@@ -247,6 +260,7 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
     if (!restoreFromCache) return;
     let cancelled = false;
     void runLoad(async () => {
+      const gen = loadGenerationRef.current;
       const coverage = coverageRef.current!;
       for (const [s, e] of loadCoverageIntervals()) coverage.addCovered(s, e);
 
@@ -265,7 +279,7 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
       if (cancelled) return;
 
       const cached = await cacheRef.current!.loadAll().catch(() => [] as TelegramEntry[]);
-      if (cancelled) return;
+      if (cancelled || loadGenerationRef.current !== gen) return;
       // Hydrate only the newest slice for a fast first paint; the older cached
       // remainder stays in IDB and is pulled in on demand via the history
       // loader / lazy loads (#284). Never exceed the configured buffer size.
@@ -390,6 +404,9 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
   );
 
   const clear = useCallback(async () => {
+    // Invalidate any in-flight background load so a late-arriving history chunk
+    // can't repopulate the buffer we're about to wipe (#339).
+    loadGenerationRef.current++;
     trackRemoved(bufferRef.current!.clear());
     pendingRef.current = [];
     coverageRef.current!.clear();


### PR DESCRIPTION
Fixes #339.

## Problem
"Load history for the last 7 days", then clear the buffer while *History: Loading…* is still in progress. The background load kept running: a later-arriving chunk merged back into the just-cleared buffer and re-marked its range covered, leaving a gap between that chunk and the newest received telegram.

## Change
`useTelegramCache` now tracks a **load generation** that `clear()` bumps. Every background load (manual `loadRange`, startup restore, connect-time gap fill) captures the generation up front and re-checks it after each `await`:
- the just-fetched chunk is **dropped** instead of merged,
- its range is **not** marked covered (so a later load can still fetch it — no gap),
- paging to older chunks **stops**.

Because history is fetched in 2000-row chunks, the loading indicator clears after at most the current chunk resolves; every subsequent (pending) chunk is discarded immediately.

## Verification
- Added a unit test that gates a chunk mid-flight, calls `clear()`, then releases the chunk and asserts the buffer stays empty and nothing is marked covered.
- Full `vitest` suite + `tsc -b` pass.