### PR TITLE
Visualization panel: header close X; Targets X clears selection (#347)

### DIFF
--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -5,7 +5,7 @@ import { useChartData } from '../hooks/useChartData';
 import { MixedChart } from './MixedChart';
 import { TimelineChart } from './TimelineChart';
 import { TimeBrush } from './TimeBrush';
-import { Download, Link2, Check } from 'lucide-react';
+import { Download, Link2, Check, X } from 'lucide-react';
 import { getPref, setPref } from '../utils/prefs';
 import { clearSeriesHidden } from '../utils/legendVisibility';
 import { expandDegenerateRange } from '../utils/timeRange';
@@ -164,7 +164,6 @@ export const Visualizer: React.FC<VisualizerProps> = ({
           telegrams={telegrams}
           selectedTargets={selectedTargets}
           onTargetsChange={handleTargetsChange}
-          onClose={onClose}
           untypedTargets={untypedTargets}
           dptOverrides={dptOverrides}
           onDptOverrideChange={setDptOverride}
@@ -182,8 +181,9 @@ export const Visualizer: React.FC<VisualizerProps> = ({
               )}
             </div>
 
-            {buckets.length > 0 && (
-              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              {buckets.length > 0 && (
+                <>
                 <button
                   onClick={toggleStepped}
                   title={stepped ? 'Switch to linear interpolation' : 'Switch to stepped (hold-last-value)'}
@@ -232,8 +232,18 @@ export const Visualizer: React.FC<VisualizerProps> = ({
                 >
                   <Download size={16} /> Export
                 </button>
-              </div>
-            )}
+                </>
+              )}
+              {/* Close X in the panel header, like every other main panel (#347). */}
+              <button
+                className="icon-button"
+                onClick={onClose}
+                title="Close Visualization"
+                style={{ padding: '0.4rem', display: 'flex', color: 'var(--text-dim)' }}
+              >
+                <X size={18} />
+              </button>
+            </div>
           </div>
 
           {charts}

--- a/frontend/src/components/VisualizerSidebar.test.tsx
+++ b/frontend/src/components/VisualizerSidebar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { VisualizerSidebar } from './VisualizerSidebar';
+import { makeTelegram } from '../test/telegramFactory';
+
+const telegrams = [
+  makeTelegram({ target_address: '1/2/3', target_name: 'Light' }),
+  makeTelegram({ target_address: '1/2/4', target_name: 'Blind' }),
+];
+
+test('the header X clears all selected targets rather than closing the panel (#347)', () => {
+  const onTargetsChange = vi.fn();
+  render(
+    <VisualizerSidebar
+      telegrams={telegrams}
+      selectedTargets={['1/2/3', '1/2/4']}
+      onTargetsChange={onTargetsChange}
+    />,
+  );
+
+  const clearBtn = screen.getByTitle('Clear all selected targets');
+  expect(clearBtn).not.toBeDisabled();
+  fireEvent.click(clearBtn);
+  expect(onTargetsChange).toHaveBeenCalledWith([]);
+});
+
+test('the clear button is disabled when no targets are selected (#347)', () => {
+  render(
+    <VisualizerSidebar
+      telegrams={telegrams}
+      selectedTargets={[]}
+      onTargetsChange={vi.fn()}
+    />,
+  );
+
+  expect(screen.getByTitle('Clear all selected targets')).toBeDisabled();
+});

--- a/frontend/src/components/VisualizerSidebar.tsx
+++ b/frontend/src/components/VisualizerSidebar.tsx
@@ -14,7 +14,6 @@ interface VisualizerSidebarProps {
   telegrams: Telegram[];
   selectedTargets: string[];
   onTargetsChange: (targets: string[]) => void;
-  onClose: () => void;
   /** Selected GAs with no project DPT that need a manual datatype to plot (#315). */
   untypedTargets?: Set<string>;
   /** Chosen datatype key per address. */
@@ -24,7 +23,7 @@ interface VisualizerSidebarProps {
 }
 
 export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
-  telegrams, selectedTargets, onTargetsChange, onClose,
+  telegrams, selectedTargets, onTargetsChange,
   untypedTargets, dptOverrides = {}, onDptOverrideChange,
 }) => {
   const [search, setSearch] = useState('');
@@ -68,7 +67,15 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
         <span style={{ fontWeight: 600, fontSize: '0.875rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
           <LineChart size={16} style={{ color: 'var(--accent-primary)' }} /> Targets
         </span>
-        <button onClick={onClose} className="icon-button" title="Close Visualization" style={{ padding: '0.2rem' }}>
+        {/* Clears the checkmarks, like the filter panel's clear-all (#347). The
+            panel itself is closed with the X in the chart-area header. */}
+        <button
+          onClick={() => onTargetsChange([])}
+          disabled={selectedTargets.length === 0}
+          className="icon-button"
+          title="Clear all selected targets"
+          style={{ padding: '0.2rem', opacity: selectedTargets.length === 0 ? 0.4 : 1 }}
+        >
           <X size={14} />
         </button>
       </div>


### PR DESCRIPTION
Fixes #347. The chart-layout items originally in that issue are split out to #359.

## Problem
The **Visualization** panel was the only main panel without an X close button in its header. The only X lived in the **Targets** sidebar and closed the whole panel — so clicking it to quickly uncheck targets (as one does in the filter panel) navigated back to the telegram list instead.

## Change
- **Chart-area header** now has an always-visible X (even with no targets selected) that closes the panel, matching every other main panel.
- **Targets sidebar** X now clears all selected targets (routing through the existing handler that also resets legend-hide state), and is disabled when nothing is selected.

## Deferred to #359
The chart-layout glitches (lx y-axis scale clipped at the left margin; a suggestion to move the GA legend left of binary-state bars so all graph borders line up) need visual iteration and are tracked separately in #359.

## Verification
- Unit tests for the sidebar clear behavior (clears on click; disabled when empty).
- `tsc -b` + `eslint` clean; full frontend suite (230 tests) green.