### PR TITLE
Keep visualization charts on screen when the buffer grows (#340)

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -15,13 +15,17 @@ interface MixedChartProps {
   stepped: boolean;
   /** Draw a dot at each telegram timestamp so cyclic repeats are visible (#195). */
   showDots: boolean;
+  /** When true (no active zoom), let the chart re-fit to new data so a telegram
+   * that extends the range stays visible instead of falling off a frozen scale
+   * (#340). When zoomed, stays false to preserve the app-controlled range (#281). */
+  autoFollow?: boolean;
   onZoomRangeChange?: (value: [number, number] | null) => void;
 }
 
 // Ensure we have a shared sync cursor across all charts
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime, stepped, showDots, onZoomRangeChange }) => {
+export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime, stepped, showDots, autoFollow = false, onZoomRangeChange }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const themeTick = useThemeTick();
@@ -181,9 +185,10 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
         {isBinary ? 'Binary States (Ein/Aus)' : `Metrics (${unit})`}
       </h4>
       <div ref={containerRef} style={{ width: '100%', overflow: 'hidden' }}>
-         {/* resetScales=false: keep the app-controlled zoom on live updates so a
-             new telegram doesn't snap the x-axis back to the full range (#281). */}
-         <UplotReact options={options} data={data} resetScales={false} />
+         {/* Re-fit to new data only while not zoomed (#340): keeps a new telegram
+             visible instead of dropping off a frozen scale. When the user has
+             zoomed, autoFollow is false so the range is preserved (#281). */}
+         <UplotReact options={options} data={data} resetScales={autoFollow} />
       </div>
       {/* Always spell out the visible window's start and end, so the range is
           readable even when the axis ticks are sparse or zoomed out (#314). */}

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -12,12 +12,16 @@ interface TimelineChartProps {
   maxTime: number | null;
   /** Draw a tick at each telegram timestamp so cyclic repeats are visible (#195). */
   showDots: boolean;
+  /** When true (no active zoom), let the chart re-fit to new data so a telegram
+   * that extends the range stays visible instead of falling off a frozen scale
+   * (#340). When zoomed, stays false to preserve the app-controlled range (#281). */
+  autoFollow?: boolean;
   onZoomRangeChange?: (value: [number, number] | null) => void;
 }
 
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, maxTime, showDots, onZoomRangeChange }) => {
+export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, maxTime, showDots, autoFollow = false, onZoomRangeChange }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const themeTick = useThemeTick();
@@ -223,9 +227,10 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
         Binary States Timeline
       </h4>
       <div ref={containerRef} style={{ width: '100%', overflow: 'visible' }}>
-         {/* resetScales=false: keep the app-controlled zoom on live updates so a
-             new telegram doesn't snap the x-axis back to the full range (#281). */}
-         <UplotReact options={options} data={data} resetScales={false} />
+         {/* Re-fit to new data only while not zoomed (#340): keeps a new telegram
+             visible instead of dropping off a frozen scale. When the user has
+             zoomed, autoFollow is false so the range is preserved (#281). */}
+         <UplotReact options={options} data={data} resetScales={autoFollow} />
       </div>
       {/* Always spell out the visible window's start and end (#314). The right
           gutter holds the series labels, so pad the caption to match the plot. */}

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -121,13 +121,18 @@ export const Visualizer: React.FC<VisualizerProps> = ({
     }
   };
 
+  // With no active zoom the charts should track the data as the buffer grows, so
+  // a new (or history-loaded) telegram that extends the range stays on screen
+  // instead of dropping off a frozen scale (#340). A user zoom freezes it (#281).
+  const autoFollow = zoomRange === null;
+
   const charts = (
     <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: embed ? '0.75rem' : '1.5rem' }}>
       {buckets.map(b => (
         b.isBinary ? (
-          <TimelineChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} onZoomRangeChange={setZoomRange} />
+          <TimelineChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} />
         ) : (
-          <MixedChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} stepped={stepped} showDots={showDots} onZoomRangeChange={setZoomRange} />
+          <MixedChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} stepped={stepped} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} />
         )
       ))}
 


### PR DESCRIPTION
Fixes #340 (the disappearing-chart bug). The broader autozoom wishlist from that issue's *Expected behavior* section (wall-clock-now right edge, click-to-pin, zoom persistence across navigation / #236) stays tracked in #341.

## Root cause
The charts passed `resetScales={false}` unconditionally. That flag was added for #281 so a live telegram wouldn't snap a *zoomed* x-axis back to the full range. But with **no** zoom active it also froze the scale, so a telegram that extended the time range (a new live telegram, or a "History: Loading…" chunk) fell outside the rendered window and the entire series vanished — until the user nudged a zoom handle, which set an explicit range and made it reappear. Exactly the behavior in the report.

## Fix
The Visualizer computes `autoFollow = zoomRange === null` and passes it to `MixedChart` / `TimelineChart`, which use `resetScales={autoFollow}`:
- **not zoomed** → re-fit to new data, so the chart tracks the buffer (left edge = oldest buffered telegram, right edge = newest);
- **zoomed** → `false`, preserving the user's range (#281 unchanged).

## Verification (Playwright, in-browser)
Reproduced the bug on `main` (chart disappears after one telegram), then confirmed with the fix:
- un-zoomed chart **stays visible** across a new telegram and a 5-telegram burst;
- a **zoomed** chart keeps its window after a new telegram (no snap-back).

`tsc -b`, `eslint`, and the full 228-test frontend suite pass. (uPlot renders to canvas, so the scale behavior isn't unit-testable in jsdom — hence the browser verification.)