### PR TITLE
Visualization Targets list all GAs, independent of the main filter (#361)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -239,30 +239,10 @@ function App() {
     initialView?.filters ?? initialWorkspace?.filters ?? DEFAULT_FILTERS,
   );
 
+  // The Visualization is independent of the main filter (#361): editing the
+  // filter changes only the telegram list, never the plotted target selection.
   const handleFiltersChange = useCallback((newFilters: ActiveFilters | ((prev: ActiveFilters) => ActiveFilters)) => {
-    setActiveFilters((prevFilters) => {
-      const updatedFilters = typeof newFilters === 'function' ? newFilters(prevFilters) : newFilters;
-
-      const addedTargets = updatedFilters.targets.filter(t => !prevFilters.targets.includes(t));
-      const removedTargets = prevFilters.targets.filter(t => !updatedFilters.targets.includes(t));
-
-      const addedSources = updatedFilters.sources.filter(s => !prevFilters.sources.includes(s));
-      const removedSources = prevFilters.sources.filter(s => !updatedFilters.sources.includes(s));
-
-      const added = [...addedTargets, ...addedSources];
-      const removed = [...removedTargets, ...removedSources];
-
-      if (added.length > 0 || removed.length > 0) {
-        setSelectedVisualizationTargets(prevSelected => {
-          let next = [...prevSelected];
-          added.forEach(a => { if (!next.includes(a)) next.push(a); });
-          removed.forEach(r => { next = next.filter(t => t !== r); });
-          return next;
-        });
-      }
-
-      return updatedFilters;
-    });
+    setActiveFilters(newFilters);
   }, []);
 
   const refreshServerConfig = useCallback(() => {
@@ -1072,7 +1052,9 @@ function App() {
                 )}
                 {isVisualizerOpen ? (
                   <Visualizer
-                    telegrams={filteredLiveTelegrams}
+                    // The main filter applies to the telegram list only; the
+                    // Visualization Targets list every GA in the buffer (#361).
+                    telegrams={liveTelegrams}
                     selectedTargets={selectedVisualizationTargets}
                     onTargetsChange={setSelectedVisualizationTargets}
                     onClose={() => setIsVisualizerOpen(false)}

--- a/frontend/src/components/VisualizerSidebar.search.test.tsx
+++ b/frontend/src/components/VisualizerSidebar.search.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { afterEach, expect, test } from 'vitest';
+import { VisualizerSidebar } from './VisualizerSidebar';
+import { makeTelegram } from '../test/telegramFactory';
+import { getPref } from '../utils/prefs';
+
+const telegrams = [
+  makeTelegram({ target_address: '1/2/3', target_name: 'Light' }),
+  makeTelegram({ target_address: '1/2/4', target_name: 'Blind' }),
+];
+
+const sidebar = () => (
+  <VisualizerSidebar
+    telegrams={telegrams}
+    selectedTargets={[]}
+    onTargetsChange={() => {}}
+    onClose={() => {}}
+  />
+);
+
+afterEach(() => localStorage.clear());
+
+test('persists the Targets search across panel remounts via prefs (#361)', () => {
+  const { unmount } = render(sidebar());
+  fireEvent.change(screen.getByPlaceholderText('Search targets...'), { target: { value: '1/2' } });
+  expect(getPref('vizTargetSearch')).toBe('1/2');
+  unmount();
+
+  // Reopening the panel restores the persisted filter.
+  render(sidebar());
+  expect(screen.getByPlaceholderText('Search targets...')).toHaveValue('1/2');
+});

--- a/frontend/src/components/VisualizerSidebar.tsx
+++ b/frontend/src/components/VisualizerSidebar.tsx
@@ -3,6 +3,7 @@ import { LineChart, X, Search } from 'lucide-react';
 import type { Telegram } from '../hooks/useWebSocket';
 import { OptionRow } from './FilterPanel';
 import { RAW_DPT_OPTIONS } from '../utils/rawDpt';
+import { getPref, setPref } from '../utils/prefs';
 
 interface TargetCount {
   address: string;
@@ -27,7 +28,13 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
   telegrams, selectedTargets, onTargetsChange, onClose,
   untypedTargets, dptOverrides = {}, onDptOverrideChange,
 }) => {
-  const [search, setSearch] = useState('');
+  // Persisted so the Targets filter survives closing/reopening the panel and
+  // reloads, like the other visualization prefs (#361).
+  const [search, setSearch] = useState(() => getPref('vizTargetSearch') ?? '');
+  const changeSearch = (value: string) => {
+    setSearch(value);
+    setPref('vizTargetSearch', value);
+  };
 
   // Extract unique targets and their counts from the currently plotted dataset
   const targetCounts = useMemo(() => {
@@ -84,7 +91,7 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
             type="text"
             placeholder="Search targets..."
             value={search}
-            onChange={e => setSearch(e.target.value)}
+            onChange={e => changeSearch(e.target.value)}
             style={{
               background: 'transparent', border: 'none', outline: 'none',
               color: 'var(--text-main)', fontSize: '0.8125rem', width: '100%',


### PR DESCRIPTION
Fixes #361. Implements the [#354 review comment](https://github.com/martinhoefling/SpectrumKNX/pull/354) from @martinhoefling; child of the #341 umbrella.

## Change
- The main telegram filter now applies to the **telegram list only**. The Visualizer receives the **unfiltered** buffer (`liveTelegrams`), so its Targets list **every** GA in the buffer, not just the filtered ones.
- Editing the filter no longer checks/unchecks plotted targets (the filter → visualization-selection coupling in `handleFiltersChange` is removed), so the visualization is fully independent of the filter.
- The Targets **search field** is persisted via prefs, so it survives closing/reopening the panel (state-persistence item from #341).
- The embed/share view is unchanged — it keeps its saved-view filters by design.

## Verification
- Unit test: the Targets search persists across panel remounts.
- In-browser (Playwright): with an active target filter narrowing the telegram list to one GA (buffer "8 / 16"), the Visualization Targets still list **both** GAs from the full buffer.
- `tsc -b`, `eslint`, full 229-test frontend suite pass.