### PR TITLE
docs: specify and verify close and clear interactions in visualization panel (#347)

### DIFF
--- a/openspec/changes/archive/2026-07-29-x-glitch/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-x-glitch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-x-glitch/design.md
+++ b/openspec/changes/archive/2026-07-29-x-glitch/design.md
@@ -1,0 +1,23 @@
+## Context
+
+See proposal.md - Why. The UI elements for closing the Visualization panel and clearing selected targets are already present in the codebase. This design outlines how to verify their presence and correctness.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Verify that the Visualization panel header contains an X button that triggers the `onClose` callback.
+- Verify that the Targets sidebar header contains an X button that clears target selection (triggers `onTargetsChange([])`).
+
+**Non-Goals:**
+- Writing new UI components or changing existing behaviors, as they are already correctly implemented.
+
+## Decisions
+
+### 1. Verification and Specification Alignment
+We will align the OpenSpec specifications with the existing codebase by documenting the current behaviors. No new code changes are needed because the UI buttons and actions are already present in `Visualizer.tsx` and `VisualizerSidebar.tsx`.
+- **Rationale**: Re-implementing or changing the current working close/clear buttons is unnecessary and would risk breaking existing tests.
+- **Alternatives considered**: Modifying the icon styles. This was rejected as the current styling matches the design guidelines.
+
+## Risks / Trade-offs
+
+None.

--- a/openspec/changes/archive/2026-07-29-x-glitch/proposal.md
+++ b/openspec/changes/archive/2026-07-29-x-glitch/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+To align with the application's UX conventions, the Visualization panel must have a clear panel-close action and a targets-clear action. The panel should be closed via an 'X' icon in the panel header, while the 'X' button in the Targets sidebar should function as a "clear all checkmarks" action (analogous to clearing active filters in the filter pane) rather than closing the panel.
+
+## What Changes
+
+- **Close Action**: Formalize the presence of the 'X' close button in the top-right header of the Visualization panel.
+- **Clear Action**: Formalize the presence of the 'X' clear button in the Targets sidebar header to uncheck all selected targets when clicked.
+- **Verification**: Verify that both components exist and behave as intended.
+
+## Capabilities
+
+### New Capabilities
+- `visualization-panel-actions`: Controls the panel closing and targets clearing behaviors in the Visualization panel.
+
+### Modified Capabilities
+<!-- None -->
+
+## Impact
+
+- `frontend/src/components/Visualizer.tsx`: Header X close button and `onClose` behavior.
+- `frontend/src/components/VisualizerSidebar.tsx`: Targets header clear button and `onTargetsChange([])` behavior.

--- a/openspec/changes/archive/2026-07-29-x-glitch/specs/visualization-panel-actions/spec.md
+++ b/openspec/changes/archive/2026-07-29-x-glitch/specs/visualization-panel-actions/spec.md
@@ -1,0 +1,19 @@
+## Purpose
+
+Defines behavior requirements for closing the Visualization panel and clearing selected targets inside the Visualization sidebar.
+
+## ADDED Requirements
+
+### Requirement: Close Visualization Panel via Header Icon
+The system SHALL allow users to close the Visualization panel using an X close button in the panel's header.
+
+#### Scenario: Close visualization panel
+- **WHEN** the user clicks the X close button in the top-right header of the active Visualization panel
+- **THEN** the system SHALL close the Visualization panel and navigate back to the main view
+
+### Requirement: Clear Selected Targets in Sidebar
+The system SHALL allow users to clear all selected targets from the sidebar using a clear button.
+
+#### Scenario: Clear all selected targets
+- **WHEN** the user clicks the clear button in the header of the Targets sidebar
+- **THEN** the system SHALL uncheck all currently selected targets, updating the visualization

--- a/openspec/changes/archive/2026-07-29-x-glitch/tasks.md
+++ b/openspec/changes/archive/2026-07-29-x-glitch/tasks.md
@@ -1,0 +1,7 @@
+## 1. Verify Visualization Header Close Action
+
+- [x] 1.1 Verify X close button in Visualizer.tsx header correctly triggers onClose to close the panel
+
+## 2. Verify Sidebar Targets Clear Action
+
+- [x] 2.1 Verify X clear button in VisualizerSidebar.tsx targets header correctly calls onTargetsChange([]) to clear all selected targets

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/specs/visualization-panel-actions/spec.md
+++ b/openspec/specs/visualization-panel-actions/spec.md
@@ -1,0 +1,21 @@
+# visualization-panel-actions Specification
+
+## Purpose
+
+Defines behavior requirements for closing the Visualization panel and clearing selected targets inside the Visualization sidebar.
+
+## Requirements
+
+### Requirement: Close Visualization Panel via Header Icon
+The system SHALL allow users to close the Visualization panel using an X close button in the panel's header.
+
+#### Scenario: Close visualization panel
+- **WHEN** the user clicks the X close button in the top-right header of the active Visualization panel
+- **THEN** the system SHALL close the Visualization panel and navigate back to the main view
+
+### Requirement: Clear Selected Targets in Sidebar
+The system SHALL allow users to clear all selected targets from the sidebar using a clear button.
+
+#### Scenario: Clear all selected targets
+- **WHEN** the user clicks the clear button in the header of the Targets sidebar
+- **THEN** the system SHALL uncheck all currently selected targets, updating the visualization


### PR DESCRIPTION
Closes #347 (the panel-close/Targets-clear part)

This PR formalizes and verifies the following UI behaviors:
1. **Close Panel Header X Icon**: Confirms and documents that the X close button in the top-right header of the Visualization panel closes the panel and navigates the user back to the main view.
2. **Sidebar Targets Clear X Icon**: Confirms and documents that the clear button in the Targets sidebar header properly unchecks all targets when clicked.