### PR TITLE
feat: fix history search custom date range timezone offset (#355)

### DIFF
--- a/frontend/src/utils/historyLoad.test.ts
+++ b/frontend/src/utils/historyLoad.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from 'vitest';
+import { buildHistoryUrl, rangeToMs } from './historyLoad';
+
+test('buildHistoryUrl handles relative ranges correctly', () => {
+  const url = buildHistoryUrl({ kind: 'relative', seconds: 3600 }, 100);
+  expect(url).toContain('limit=100');
+  expect(url).toContain('start_time=');
+});
+
+test('buildHistoryUrl parses absolute local datetimes as local time and formats to UTC ISO', () => {
+  const startTime = '2001-01-01T07:00';
+  const endTime = '2001-01-01T09:00';
+  const url = buildHistoryUrl({ kind: 'absolute', startTime, endTime }, 50);
+
+  const expectedStart = new Date(startTime).toISOString();
+  const expectedEnd = new Date(endTime).toISOString();
+
+  expect(url).toContain('limit=50');
+  expect(url).toContain(`start_time=${encodeURIComponent(expectedStart)}`);
+  expect(url).toContain(`end_time=${encodeURIComponent(expectedEnd)}`);
+});
+
+test('rangeToMs resolves relative ranges to epoch ms', () => {
+  const now = Date.now();
+  const { startMs, endMs } = rangeToMs({ kind: 'relative', seconds: 10 }, now);
+  expect(endMs).toBe(now);
+  expect(startMs).toBe(now - 10000);
+});
+
+test('rangeToMs resolves absolute ranges to local timezone epoch ms', () => {
+  const startTime = '2001-01-01T07:00';
+  const endTime = '2001-01-01T09:00';
+  const { startMs, endMs } = rangeToMs({ kind: 'absolute', startTime, endTime });
+
+  expect(startMs).toBe(new Date(startTime).getTime());
+  expect(endMs).toBe(new Date(endTime).getTime());
+});

--- a/frontend/src/utils/historyLoad.ts
+++ b/frontend/src/utils/historyLoad.ts
@@ -26,16 +26,32 @@ export function applyFilterParams(url: string, filters?: ActiveFilters): string 
   return url + (url.includes('?') ? '&' : '?') + params.join('&');
 }
 
+/** Converts local datetime-local string to UTC ISO string, returns empty string if invalid. */
+function localToUtcIso(localStr: string): string {
+  if (!localStr) return '';
+  const d = new Date(localStr);
+  return isNaN(d.getTime()) ? '' : d.toISOString();
+}
+
+/** Converts local datetime-local string to epoch milliseconds, returns fallback if invalid. */
+function localToEpochMs(localStr: string, fallback: number): number {
+  if (!localStr) return fallback;
+  const d = new Date(localStr);
+  return isNaN(d.getTime()) ? fallback : d.getTime();
+}
+
 /** Builds the /api/telegrams URL for a range. Times use the loader's
- * datetime-local format ("YYYY-MM-DDTHH:MM", treated as UTC). */
+ * datetime-local format ("YYYY-MM-DDTHH:MM", interpreted in the local timezone). */
 export function buildHistoryUrl(range: LoadedRange, limit: number): string {
   let url = apiUrl(`/api/telegrams?limit=${limit}`);
   if (range.kind === 'relative') {
     const start = new Date(Date.now() - range.seconds * 1000).toISOString();
     url += `&start_time=${encodeURIComponent(start)}`;
   } else {
-    if (range.startTime) url += `&start_time=${encodeURIComponent(range.startTime + ':00Z')}`;
-    if (range.endTime) url += `&end_time=${encodeURIComponent(range.endTime + ':00Z')}`;
+    const startUtc = localToUtcIso(range.startTime);
+    if (startUtc) url += `&start_time=${encodeURIComponent(startUtc)}`;
+    const endUtc = localToUtcIso(range.endTime);
+    if (endUtc) url += `&end_time=${encodeURIComponent(endUtc)}`;
   }
   return url;
 }
@@ -46,8 +62,8 @@ export function rangeToMs(range: LoadedRange, nowMs = Date.now()): { startMs: nu
     return { startMs: nowMs - range.seconds * 1000, endMs: nowMs };
   }
   return {
-    startMs: range.startTime ? Date.parse(range.startTime + ':00Z') : 0,
-    endMs: range.endTime ? Date.parse(range.endTime + ':00Z') : nowMs,
+    startMs: localToEpochMs(range.startTime, 0),
+    endMs: localToEpochMs(range.endTime, nowMs),
   };
 }
 

--- a/openspec/changes/archive/2026-07-29-search-range-off/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-search-range-off/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-search-range-off/design.md
+++ b/openspec/changes/archive/2026-07-29-search-range-off/design.md
@@ -1,0 +1,27 @@
+## Context
+
+See proposal.md - Why. Currently, the local datetime string from `<input type="datetime-local" />` is incorrectly appended with `:00Z`, forcing it to be parsed as UTC and causing a timezone offset shift.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Interpret range values as local time when querying the backend.
+- Interpret range values as local time when computing epoch ms ranges for the visualizer.
+- Ensure the changes do not break any existing history search filters.
+
+**Non-Goals:**
+- Modifying backend datetime parsing or database storage (the backend correctly processes UTC datetimes).
+- Adding heavy third-party date libraries (like moment.js).
+
+## Decisions
+
+### 1. Native Date Parsing for Timezone Offset Correction
+We will use native JavaScript `Date` constructor to parse the `datetime-local` input string.
+- **Why**: Passing `"YYYY-MM-DDTHH:mm"` directly to `new Date()` parses it in the client's local timezone, returning the correct local point.
+- **Formatting for API**: We then call `.toISOString()` on the Date object to get the corresponding UTC timestamp (`YYYY-MM-DDTHH:mm:ss.sssZ`), which we pass to the backend.
+- **Formatting for Epoch MS**: We call `.getTime()` on the Date object to get the correct local epoch milliseconds.
+- **Alternatives**: Manually parsing and adding timezone offsets. This was rejected because `new Date()` does this automatically and is less error-prone.
+
+## Risks / Trade-offs
+
+None.

--- a/openspec/changes/archive/2026-07-29-search-range-off/proposal.md
+++ b/openspec/changes/archive/2026-07-29-search-range-off/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+When performing a historical telegram search with a custom date range, the datetime-local input yields values in the user's local timezone. Currently, the application appends `:00Z` to these inputs, treating them as UTC and causing the queried range to be offset by the user's timezone difference (e.g., 2 hours off in CEST). The application needs to correctly interpret custom absolute start/end times in the local timezone and convert them to UTC before querying the backend.
+
+## What Changes
+
+- **Frontend URL Builder**: Update `buildHistoryUrl` in `frontend/src/utils/historyLoad.ts` to parse the selected local datetimes in local time and convert them to UTC ISO strings.
+- **Frontend Range to Epoch MS**: Update `rangeToMs` in `frontend/src/utils/historyLoad.ts` to parse local datetimes as local time and return the correct epoch milliseconds.
+- **Tests**: Add/update tests to verify that local datetimes are correctly mapped to UTC and epoch milliseconds.
+
+## Capabilities
+
+### New Capabilities
+- `search-range-timezone`: Ensures date-range searches in the history loader correctly honor the user's local timezone.
+
+### Modified Capabilities
+<!-- None -->
+
+## Impact
+
+- `frontend/src/utils/historyLoad.ts`: `buildHistoryUrl` and `rangeToMs` functions.
+- `frontend/src/utils/historyLoad.test.ts` (or similar): Range parsing and API URL builder tests.

--- a/openspec/changes/archive/2026-07-29-search-range-off/specs/search-range-timezone/spec.md
+++ b/openspec/changes/archive/2026-07-29-search-range-off/specs/search-range-timezone/spec.md
@@ -1,0 +1,19 @@
+## Purpose
+
+Defines behavioral requirements for history search time range selection to ensure the selected datetimes are interpreted in the user's local timezone.
+
+## ADDED Requirements
+
+### Requirement: Date Range Selection Local Timezone Alignment
+The system SHALL interpret any selected start and end datetime-local query parameters in the user's local timezone and translate them to the correct UTC timestamp for database query.
+
+#### Scenario: Select local datetime range
+- **WHEN** the user selects a custom date range in the history search panel (e.g. starting at 01/01/2001 07:00)
+- **THEN** the system SHALL fetch and display telegrams starting exactly from that local time point (e.g., matching the user's local time boundary)
+
+### Requirement: Share Link Local Timezone Range Resolution
+The system SHALL correctly resolve absolute time ranges from shared URLs by parsing them as local time rather than treating them as raw UTC.
+
+#### Scenario: Load shared absolute range link
+- **WHEN** the user loads a shared visualizer URL containing an absolute start and end time range
+- **THEN** the visualizer boundary SHALL align exactly with the original local time values

--- a/openspec/changes/archive/2026-07-29-search-range-off/tasks.md
+++ b/openspec/changes/archive/2026-07-29-search-range-off/tasks.md
@@ -1,0 +1,9 @@
+## 1. Frontend Timezone Handling Implementation
+
+- [x] 1.1 Update buildHistoryUrl in historyLoad.ts to parse absolute range datetimes in local timezone and format them as UTC ISO strings
+- [x] 1.2 Update rangeToMs in historyLoad.ts to parse absolute range datetimes in local timezone and return correct epoch milliseconds
+
+## 2. Testing and Verification
+
+- [x] 2.1 Add or update unit tests to verify local timezone parsing for buildHistoryUrl and rangeToMs
+- [x] 2.2 Run Vitest to ensure all tests pass successfully

--- a/openspec/specs/search-range-timezone/spec.md
+++ b/openspec/specs/search-range-timezone/spec.md
@@ -1,0 +1,21 @@
+# search-range-timezone Specification
+
+## Purpose
+
+Defines behavioral requirements for history search time range selection to ensure the selected datetimes are interpreted in the user's local timezone.
+
+## Requirements
+
+### Requirement: Date Range Selection Local Timezone Alignment
+The system SHALL interpret any selected start and end datetime-local query parameters in the user's local timezone and translate them to the correct UTC timestamp for database query.
+
+#### Scenario: Select local datetime range
+- **WHEN** the user selects a custom date range in the history search panel (e.g. starting at 01/01/2001 07:00)
+- **THEN** the system SHALL fetch and display telegrams starting exactly from that local time point (e.g., matching the user's local time boundary)
+
+### Requirement: Share Link Local Timezone Range Resolution
+The system SHALL correctly resolve absolute time ranges from shared URLs by parsing them as local time rather than treating them as raw UTC.
+
+#### Scenario: Load shared absolute range link
+- **WHEN** the user loads a shared visualizer URL containing an absolute start and end time range
+- **THEN** the visualizer boundary SHALL align exactly with the original local time values


### PR DESCRIPTION
Closes #355

This PR resolves the timezone offset bug in custom date range searches:
1. **Local Timezone Input Parsing**: Updates `buildHistoryUrl` and `rangeToMs` to parse absolute date/time selection using native `Date` API to respect the client's local timezone.
2. **UTC Formatting for API**: Formats range limits to correct UTC ISO strings before querying backend, preventing shifted ranges on the server side.
3. **Correct Epoch Bounds**: Converts local times correctly to absolute epoch milliseconds to ensure background loads and visualizer windows align precisely with selected times.
4. **Unit Tests**: Adds `historyLoad.test.ts` verifying timezone range logic correctness.