### PR TITLE
feat: implement navigation-surviving UI session state persistence

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,11 @@ import {
   type WorkspaceState,
   type WorkspaceView,
 } from './utils/workspaceState';
+import {
+  loadUiState,
+  saveUiState,
+  DEFAULT_UI_STATE,
+} from './utils/uiState';
 import { DeviceStatusOverlay } from './components/DeviceStatusOverlay';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigPref, writeSortConfigPref } from './utils/sortConfig';
@@ -153,6 +158,18 @@ function App() {
   const [initialWorkspace] = useState(() =>
     initialView ? null : isEmbedded() ? loadWorkspace() : parseMonitorSearch(window.location.search),
   );
+  const [initialUiState] = useState(() => loadUiState() ?? DEFAULT_UI_STATE);
+  const [quickFilterOpen, setQuickFilterOpen] = useState(initialUiState.quickFilter.open);
+  const [quickFilterEnabled, setQuickFilterEnabled] = useState(initialUiState.quickFilter.enabled);
+  const [quickPatterns, setQuickPatterns] = useState(initialUiState.quickFilter.patterns);
+  const [listFollow, setListFollow] = useState(initialUiState.listFollow);
+  const [listAnchorKey, setListAnchorKey] = useState<string | null>(initialUiState.listAnchorKey);
+  const [zoomRange, setZoomRange] = useState<[number, number] | null>(initialUiState.zoomRange);
+  const [statsSearch, setStatsSearch] = useState(initialUiState.statsSearch);
+  const [buildingSearch, setBuildingSearch] = useState(initialUiState.buildingSearch);
+  const [lastSeenLimit, setLastSeenLimit] = useState(initialUiState.lastSeenLimit);
+  const [lastSeenLive, setLastSeenLive] = useState(initialUiState.lastSeenLive);
+  const [lastSeenSearch, setLastSeenSearch] = useState(initialUiState.lastSeenSearch);
   const [activeTab, setActiveTab] = useState<'live' | 'history' | 'import'>(
     initialView ? 'history' : initialWorkspace?.tab ?? 'live',
   );
@@ -392,6 +409,40 @@ function App() {
     }, 500);
     return () => clearTimeout(handle);
   }, [initialView, activeTab, workspaceView, isFilterOpen, activeFilters, selectedVisualizationTargets, lastSeenAddresses, lastSeenMode]);
+
+  // ── Persist UI Session State (#341) ──────────────────────────────────────────
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      saveUiState({
+        quickFilter: {
+          open: quickFilterOpen,
+          enabled: quickFilterEnabled,
+          patterns: quickPatterns,
+        },
+        listFollow,
+        listAnchorKey,
+        zoomRange,
+        statsSearch,
+        buildingSearch,
+        lastSeenLimit,
+        lastSeenLive,
+        lastSeenSearch,
+      });
+    }, 500);
+    return () => clearTimeout(handle);
+  }, [
+    quickFilterOpen,
+    quickFilterEnabled,
+    quickPatterns,
+    listFollow,
+    listAnchorKey,
+    zoomRange,
+    statsSearch,
+    buildingSearch,
+    lastSeenLimit,
+    lastSeenLive,
+    lastSeenSearch,
+  ]);
 
   // ── Sync filter panel visibility with active views ───────────────────────────
   useEffect(() => {
@@ -1058,6 +1109,8 @@ function App() {
                     selectedTargets={selectedVisualizationTargets}
                     onTargetsChange={setSelectedVisualizationTargets}
                     onClose={() => setIsVisualizerOpen(false)}
+                    zoomRange={zoomRange}
+                    onZoomRangeChange={setZoomRange}
                   />
                 ) : isLastSeenOpen ? (
                   <LastSeenOverlay
@@ -1067,11 +1120,23 @@ function App() {
                     writeEnabled={serverConfig?.status?.write_enabled}
                     latestTelegram={latestTelegram}
                     onClose={() => setIsLastSeenOpen(false)}
+                    limit={lastSeenLimit}
+                    onLimitChange={setLastSeenLimit}
+                    autoRefresh={lastSeenLive}
+                    onAutoRefreshChange={setLastSeenLive}
+                    search={lastSeenSearch}
+                    onSearchChange={setLastSeenSearch}
+                    onSelectionChange={(mode, addresses) => {
+                      setLastSeenMode(mode);
+                      setLastSeenAddresses(addresses);
+                    }}
                   />
                 ) : isStatisticsOpen ? (
                   <StatisticsOverlay
                     filterOptions={filterOptions}
                     onClose={() => setIsStatisticsOpen(false)}
+                    searchQuery={statsSearch}
+                    onSearchQueryChange={setStatsSearch}
                   />
                 ) : isBuildingOpen && statusDevice ? (
                   <DeviceStatusOverlay
@@ -1089,6 +1154,8 @@ function App() {
                     onDeviceStatus={setStatusDevice}
                     writeEnabled={serverConfig?.status?.write_enabled}
                     latestTelegram={latestTelegram}
+                    searchQuery={buildingSearch}
+                    onSearchQueryChange={setBuildingSearch}
                   />
                 ) : isDatabaseOpen ? (
                   <DatabaseOverlay onClose={() => setIsDatabaseOpen(false)} />
@@ -1103,6 +1170,16 @@ function App() {
                     onQuickVisualize={handleQuickVisualize}
                     onQuickLastSeen={handleQuickLastSeen}
                     canSend={serverConfig?.status?.write_enabled}
+                    quickFilterOpen={quickFilterOpen}
+                    onQuickFilterOpenChange={setQuickFilterOpen}
+                    quickFilterEnabled={quickFilterEnabled}
+                    onQuickFilterEnabledChange={setQuickFilterEnabled}
+                    quickPatterns={quickPatterns}
+                    onQuickPatternsChange={setQuickPatterns}
+                    listFollow={listFollow}
+                    onListFollowChange={setListFollow}
+                    listAnchorKey={listAnchorKey}
+                    onListAnchorKeyChange={setListAnchorKey}
                   />
                 )}
               </div>

--- a/frontend/src/components/BuildingOverlay.tsx
+++ b/frontend/src/components/BuildingOverlay.tsx
@@ -81,6 +81,8 @@ interface BuildingOverlayProps {
   writeEnabled?: boolean;
   /** Newest telegram from the live websocket feed; keeps expanded GA tables current. */
   latestTelegram?: Telegram | null;
+  searchQuery?: string;
+  onSearchQueryChange?: (query: string) => void;
 }
 
 // ── Group-address collection helpers ─────────────────────────────────────────────
@@ -627,10 +629,17 @@ const SpaceRow: React.FC<{
 
 export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
   onClose, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled, latestTelegram,
+  searchQuery: searchQueryProp, onSearchQueryChange,
 }) => {
   const [data, setData] = useState<BuildingData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
+  const [internalSearchQuery, setInternalSearchQuery] = useState('');
+  const searchQuery = searchQueryProp !== undefined ? searchQueryProp : internalSearchQuery;
+  const setSearchQuery = (val: string | ((prev: string) => string)) => {
+    const next = typeof val === 'function' ? val(searchQuery) : val;
+    setInternalSearchQuery(next);
+    onSearchQueryChange?.(next);
+  };
 
   const fetchBuilding = useCallback(() => {
     setIsLoading(true);

--- a/frontend/src/components/LastSeenOverlay.tsx
+++ b/frontend/src/components/LastSeenOverlay.tsx
@@ -21,6 +21,14 @@ interface LastSeenOverlayProps {
   writeEnabled?: boolean;
   latestTelegram?: Telegram | null;
   onClose: () => void;
+
+  limit?: number;
+  onLimitChange?: (limit: number) => void;
+  autoRefresh?: boolean;
+  onAutoRefreshChange?: (refresh: boolean) => void;
+  search?: string;
+  onSearchChange?: (search: string) => void;
+  onSelectionChange?: (mode: 'ga' | 'pa', addresses: string[]) => void;
 }
 
 const getTypeColor = (type?: string | null) => {
@@ -55,15 +63,57 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
   writeEnabled = false,
   latestTelegram,
   onClose,
+  limit: limitProp,
+  onLimitChange,
+  autoRefresh: autoRefreshProp,
+  onAutoRefreshChange,
+  search: searchProp,
+  onSearchChange,
+  onSelectionChange,
 }) => {
   const [mode, setMode] = useState<'ga' | 'pa'>(initialMode);
   const [selectedAddresses, setSelectedAddresses] = useState<string[]>(initialAddresses);
-  const [limit, setLimit] = useState<number>(20);
-  const [search, setSearch] = useState('');
+  const [internalLimit, setInternalLimit] = useState<number>(20);
+  const limit = limitProp !== undefined ? limitProp : internalLimit;
+  const setLimit = (val: number | ((prev: number) => number)) => {
+    const next = typeof val === 'function' ? val(limit) : val;
+    setInternalLimit(next);
+    onLimitChange?.(next);
+  };
+  const [internalSearch, setInternalSearch] = useState('');
+  const search = searchProp !== undefined ? searchProp : internalSearch;
+  const setSearch = (val: string | ((prev: string) => string)) => {
+    const next = typeof val === 'function' ? val(search) : val;
+    setInternalSearch(next);
+    onSearchChange?.(next);
+  };
   const [telegrams, setTelegrams] = useState<Telegram[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null);
-  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [internalAutoRefresh, setInternalAutoRefresh] = useState(false);
+  const autoRefresh = autoRefreshProp !== undefined ? autoRefreshProp : internalAutoRefresh;
+  const setAutoRefresh = (val: boolean | ((prev: boolean) => boolean)) => {
+    const next = typeof val === 'function' ? val(autoRefresh) : val;
+    setInternalAutoRefresh(next);
+    onAutoRefreshChange?.(next);
+  };
+
+  // Sync props to selection state (loop-safe)
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMode(prev => prev !== initialMode ? initialMode : prev);
+    setSelectedAddresses(prev => {
+      if (prev.length !== initialAddresses.length || prev.some((v, i) => v !== initialAddresses[i])) {
+        return initialAddresses;
+      }
+      return prev;
+    });
+  }, [initialMode, initialAddresses]);
+
+  // Sync selection state back to parent
+  useEffect(() => {
+    onSelectionChange?.(mode, selectedAddresses);
+  }, [mode, selectedAddresses, onSelectionChange]);
   const [writeValue, setWriteValue] = useState('');
   const [busy, setBusy] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);

--- a/frontend/src/components/StatisticsOverlay.tsx
+++ b/frontend/src/components/StatisticsOverlay.tsx
@@ -20,6 +20,8 @@ interface StatisticsData {
 interface StatisticsOverlayProps {
   filterOptions: FilterOptions;
   onClose: () => void;
+  searchQuery?: string;
+  onSearchQueryChange?: (query: string) => void;
 }
 
 type TabId = 'ga' | 'pa' | 'hierarchy';
@@ -287,14 +289,22 @@ const HierarchyRow: React.FC<HierarchyRowProps> = ({ node, maxCount, total, dept
 
 // ── Main overlay ──────────────────────────────────────────────────────────────
 
-export const StatisticsOverlay: React.FC<StatisticsOverlayProps> = ({ filterOptions, onClose }) => {
+export const StatisticsOverlay: React.FC<StatisticsOverlayProps> = ({
+  filterOptions, onClose, searchQuery: searchQueryProp, onSearchQueryChange,
+}) => {
   const [tab, setTab] = useState<TabId>('ga');
   const [data, setData] = useState<StatisticsData | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>('count');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
-  const [searchQuery, setSearchQuery] = useState('');
+  const [internalSearchQuery, setInternalSearchQuery] = useState('');
+  const searchQuery = searchQueryProp !== undefined ? searchQueryProp : internalSearchQuery;
+  const setSearchQuery = (val: string | ((prev: string) => string)) => {
+    const next = typeof val === 'function' ? val(searchQuery) : val;
+    setInternalSearchQuery(next);
+    onSearchQueryChange?.(next);
+  };
   const [timeAgo, setTimeAgo] = useState<string | null>(null);
 
   const fetchStats = useCallback(() => {

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -26,6 +26,20 @@ interface TelegramTableProps {
   onQuickLastSeen?: (address: string, mode: 'ga' | 'pa') => void;
   /** Enables the per-row "Send to this GA" quick popover; true only when the bus is writable (#214). */
   canSend?: boolean;
+
+  // Lifted Quick-Filter state (#280, #341)
+  quickFilterOpen?: boolean;
+  onQuickFilterOpenChange?: (open: boolean) => void;
+  quickFilterEnabled?: boolean;
+  onQuickFilterEnabledChange?: (enabled: boolean) => void;
+  quickPatterns?: Partial<Record<ColId, string>>;
+  onQuickPatternsChange?: (patterns: Partial<Record<ColId, string>>) => void;
+
+  // Lifted Follow / Anchor state (#203, #341)
+  listFollow?: boolean;
+  onListFollowChange?: (follow: boolean) => void;
+  listAnchorKey?: string | null;
+  onListAnchorKeyChange?: (key: string | null) => void;
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
@@ -116,7 +130,9 @@ const makeQuickMatcher = (pattern: string): ((s: string) => boolean) => {
 };
 
 export const TelegramTable: React.FC<TelegramTableProps> = ({
-  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend
+  telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend,
+  quickFilterOpen, onQuickFilterOpenChange, quickFilterEnabled, onQuickFilterEnabledChange, quickPatterns, onQuickPatternsChange,
+  listFollow, onListFollowChange, listAnchorKey, onListAnchorKeyChange
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -176,25 +192,45 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   // ── Quick filter bar (#271): per-column regex/literal filter on top of the
   // complex filter. Expanding enables it, collapsing disables it; the toggle
   // in the bar switches it without losing the patterns.
-  const [quickOpen, setQuickOpen] = useState(false);
-  const [quickEnabled, setQuickEnabled] = useState(false);
-  const [quickPatterns, setQuickPatterns] = useState<Partial<Record<ColId, string>>>({});
+  const [internalQuickOpen, setInternalQuickOpen] = useState(false);
+  const [internalQuickEnabled, setInternalQuickEnabled] = useState(false);
+  const [internalQuickPatterns, setInternalQuickPatterns] = useState<Partial<Record<ColId, string>>>({});
+
+  const quickOpen = quickFilterOpen ?? internalQuickOpen;
+  const setQuickOpen = useCallback((val: boolean | ((prev: boolean) => boolean)) => {
+    const next = typeof val === 'function' ? val(quickOpen) : val;
+    setInternalQuickOpen(next);
+    onQuickFilterOpenChange?.(next);
+  }, [quickOpen, onQuickFilterOpenChange]);
+
+  const quickEnabled = quickFilterEnabled ?? internalQuickEnabled;
+  const setQuickEnabled = useCallback((val: boolean | ((prev: boolean) => boolean)) => {
+    const next = typeof val === 'function' ? val(quickEnabled) : val;
+    setInternalQuickEnabled(next);
+    onQuickFilterEnabledChange?.(next);
+  }, [quickEnabled, onQuickFilterEnabledChange]);
+
+  const currentPatterns = quickPatterns ?? internalQuickPatterns;
+  const setQuickPatterns = useCallback((val: Partial<Record<ColId, string>> | ((prev: Partial<Record<ColId, string>>) => Partial<Record<ColId, string>>)) => {
+    const next = typeof val === 'function' ? val(currentPatterns) : val;
+    setInternalQuickPatterns(next);
+    onQuickPatternsChange?.(next);
+  }, [currentPatterns, onQuickPatternsChange]);
 
   const toggleQuickOpen = () => {
-    setQuickOpen(open => {
-      setQuickEnabled(!open);
-      return !open;
-    });
+    const nextOpen = !quickOpen;
+    setQuickOpen(nextOpen);
+    setQuickEnabled(nextOpen);
   };
 
   const quickFiltered = useMemo(() => {
     if (!quickOpen || !quickEnabled) return telegrams;
-    const matchers = Object.entries(quickPatterns)
+    const matchers = Object.entries(currentPatterns)
       .filter(([, p]) => p && p.trim() !== '')
       .map(([id, p]) => [id, makeQuickMatcher(p!.trim())] as const);
     if (matchers.length === 0) return telegrams;
     return telegrams.filter(t => matchers.every(([id, m]) => m(quickFilterHaystack(id as ColId, t))));
-  }, [telegrams, quickOpen, quickEnabled, quickPatterns]);
+  }, [telegrams, quickOpen, quickEnabled, currentPatterns]);
 
   // Compute time deltas between consecutive rows (by visual order)
   const telegramRows = useMemo<TelegramRow[]>(() => {
@@ -238,16 +274,35 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   // async re-measure of prepended rows is absorbed too.
   const isTimeSort = sortConfig.key === 'timestamp';
   const liveEdge = sortConfig.direction === 'desc' ? 'top' : 'bottom';
-  const atEdgeRef = useRef(true);
+  const atEdgeRef = useRef(listFollow ?? true);
   const [newSinceAnchor, setNewSinceAnchor] = useState(0);
   // The row pinned to the top of the viewport while anchored, and its offset
   // from the scroll-container top. Captured from user scrolls only.
-  const anchorRef = useRef<{ key: string; offset: number } | null>(null);
+  const anchorRef = useRef<{ key: string; offset: number } | null>(
+    listAnchorKey ? { key: listAnchorKey, offset: 0 } : null
+  );
   const programmaticScrollRef = useRef(false);
   // Zebra stripes must stay with a telegram, not with a row index (#266):
   // prepends at the live edge shift every index by the number of new rows, so
   // this offset accumulates those shifts and is added back to the index parity.
   const [stripeOffset, setStripeOffset] = useState(0);
+
+  // Sync props to refs
+  useEffect(() => {
+    if (listFollow !== undefined) {
+      atEdgeRef.current = listFollow;
+    }
+  }, [listFollow]);
+
+  useEffect(() => {
+    if (listAnchorKey !== undefined) {
+      if (listAnchorKey === null) {
+        anchorRef.current = null;
+      } else if (!anchorRef.current || anchorRef.current.key !== listAnchorKey) {
+        anchorRef.current = { key: listAnchorKey, offset: 0 };
+      }
+    }
+  }, [listAnchorKey]);
 
   // Suppress edge/anchor tracking for scrolls we cause ourselves. Auto-clears on
   // the next frame so a no-op programmatic scroll can't swallow a later real one.
@@ -282,7 +337,10 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
       const rr = row.getBoundingClientRect();
       if (rr.bottom - cTop > 0) {
         const key = row.getAttribute('data-akey');
-        if (key) anchorRef.current = { key, offset: rr.top - cTop };
+        if (key) {
+          anchorRef.current = { key, offset: rr.top - cTop };
+          onListAnchorKeyChange?.(key);
+        }
         return;
       }
     }
@@ -292,10 +350,14 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     // Ignore the scrolls our own compensation triggers.
     if (programmaticScrollRef.current) return;
     const atEdge = checkAtEdge();
-    atEdgeRef.current = atEdge;
+    if (atEdge !== atEdgeRef.current) {
+      atEdgeRef.current = atEdge;
+      onListFollowChange?.(atEdge);
+    }
     if (atEdge) {
       setNewSinceAnchor(0);
       anchorRef.current = null;
+      onListAnchorKeyChange?.(null);
     } else {
       captureAnchor();
     }
@@ -306,6 +368,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   const handleRowClick = () => {
     if (!isTimeSort || !atEdgeRef.current) return;
     atEdgeRef.current = false;
+    onListFollowChange?.(false);
     captureAnchor();
   };
 
@@ -316,7 +379,9 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
 
   const jumpToLive = () => {
     atEdgeRef.current = true;
+    onListFollowChange?.(true);
     anchorRef.current = null;
+    onListAnchorKeyChange?.(null);
     setNewSinceAnchor(0);
     scrollToEdge();
   };
@@ -335,6 +400,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
       if (diff < bestDiff) { bestDiff = diff; bestIdx = i; }
     }
     atEdgeRef.current = false;
+    onListFollowChange?.(false);
     setNewSinceAnchor(0);
     markProgrammatic();
     virtualizer.scrollToIndex(bestIdx, { align: 'center' });
@@ -343,6 +409,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     requestAnimationFrame(() => requestAnimationFrame(() => {
       captureAnchor();
       atEdgeRef.current = false;
+      onListFollowChange?.(false);
     }));
   };
 
@@ -352,21 +419,12 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     : null;
 
   // Correct scrollTop so the anchored row keeps its recorded viewport offset.
-  // Both edges need this. Newest-first (top edge) prepends live rows above the
-  // viewport; oldest-first (bottom edge) looks safe — bottom-appends don't move
-  // content above the viewport — until the buffer hits capacity, when each new
-  // telegram also evicts the oldest from the head, i.e. the top of the asc view,
-  // shifting everything above the viewport up and drifting the read row (#297).
-  // Progressive history chunks (#284) prepend older rows at the top of the asc
-  // view the same way; the measured pixel delta absorbs all of these uniformly.
   const pinAnchor = () => {
     const el = parentRef.current;
     const anchor = anchorRef.current;
     if (!el || !anchor || atEdgeRef.current) return;
     const now = rowOffset(anchor.key);
     if (now == null) {
-      // The anchored row was evicted out from under us (#297): re-pin to the
-      // current top-most visible row so freezing continues from where we are.
       captureAnchor();
       return;
     }
@@ -382,9 +440,43 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     setNewSinceAnchor(0);
     setStripeOffset(0);
     anchorRef.current = null;
-    atEdgeRef.current = checkAtEdge();
+    onListAnchorKeyChange?.(null);
+    const atEdge = checkAtEdge();
+    if (atEdge !== atEdgeRef.current) {
+      atEdgeRef.current = atEdge;
+      onListFollowChange?.(atEdge);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortConfig]);
+
+  // Restore scroll position/anchor on mount (#203, #341)
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current || telegramRows.length === 0) return;
+    restoredRef.current = true;
+
+    if (atEdgeRef.current) {
+      scrollToEdge();
+    } else if (listAnchorKey) {
+      const idx = telegramRows.findIndex(t => anchorKey(t) === listAnchorKey);
+      if (idx !== -1) {
+        markProgrammatic();
+        virtualizer.scrollToIndex(idx, { align: 'start' });
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          const offset = rowOffset(listAnchorKey);
+          if (offset != null) {
+            anchorRef.current = { key: listAnchorKey, offset };
+            pinAnchor();
+          }
+        }));
+      } else {
+        jumpToLive();
+      }
+    } else {
+      scrollToEdge();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [telegramRows.length]);
 
   // React to list updates before paint: follow the live edge, or pin the
   // anchored row by correcting scrollTop by its real pixel shift.
@@ -405,7 +497,6 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     const prevEdgeKey = liveEdge === 'top' ? prev.firstKey : prev.lastKey;
     if (!prevEdgeKey || edgeKey === prevEdgeKey) return; // nothing new at the live edge
 
-    // How many rows appeared at the live edge (for the pill count).
     let added = -1;
     if (liveEdge === 'top') {
       for (let i = 0; i < rows.length; i++) if (anchorKey(rows[i]) === prevEdgeKey) { added = i; break; }
@@ -414,16 +505,13 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     }
 
     if (added <= 0) {
-      // Previous edge vanished: list replaced (clear / filter / history load).
       anchorRef.current = null;
+      onListAnchorKeyChange?.(null);
       setNewSinceAnchor(0);
       setStripeOffset(0);
       return;
     }
 
-    // Keep each row's stripe color across the update (#266). Existing rows
-    // shift down by `added` on top-prepends; with the buffer at capacity the
-    // asc view instead drops rows from the head, shifting indexes up.
     const dropped = prev.len + added - rows.length;
     const indexShift = liveEdge === 'top' ? added : -dropped;
     setStripeOffset(o => (((o + indexShift) % 2) + 2) % 2);
@@ -434,14 +522,10 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     }
 
     setNewSinceAnchor(n => n + added);
-    pinAnchor(); // pre-paint; the total-size effect re-pins after re-measure
+    pinAnchor();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [telegramRows]);
 
-  // Re-pin whenever the measured content size changes. Prepended rows enter at
-  // the 85px estimate and shrink to their real height a frame later (async
-  // ResizeObserver), shifting everything below; this fires on that re-measure
-  // and cancels the shift, so the anchored row stays put across variable heights.
   const totalSize = virtualizer.getTotalSize();
   useLayoutEffect(() => {
     pinAnchor();
@@ -722,7 +806,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                 <input
                   className="quick-filter-bar-input"
                   type="text"
-                  value={quickPatterns[c.id] ?? ''}
+                  value={currentPatterns[c.id] ?? ''}
                   placeholder="regex…"
                   aria-label={`Quick filter ${c.label}`}
                   onChange={e => setQuickPatterns(prev => ({ ...prev, [c.id]: e.target.value }))}

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -19,10 +19,13 @@ interface VisualizerProps {
   getShareLink?: () => string;
   /** Chart-area-only rendering for iframe/dashboard embedding (#150). */
   embed?: boolean;
+  zoomRange?: [number, number] | null;
+  onZoomRangeChange?: (range: [number, number] | null) => void;
 }
 
 export const Visualizer: React.FC<VisualizerProps> = ({
   telegrams, selectedTargets, onTargetsChange, onClose, getShareLink, embed = false,
+  zoomRange, onZoomRangeChange,
 }) => {
 
   const chartWrapperRef = useRef<HTMLDivElement>(null);
@@ -72,14 +75,20 @@ export const Visualizer: React.FC<VisualizerProps> = ({
     return expandDegenerateRange(minTime ?? 0, maxTime ?? 0);
   }, [minTime, maxTime]);
 
-  const [zoomRange, setZoomRange] = useState<[number, number] | null>(null);
+  const [internalZoomRange, setInternalZoomRange] = useState<[number, number] | null>(null);
+  const currentZoomRange = zoomRange !== undefined ? zoomRange : internalZoomRange;
+  const setZoomRange = (val: [number, number] | null | ((prev: [number, number] | null) => [number, number] | null)) => {
+    const next = typeof val === 'function' ? val(currentZoomRange) : val;
+    setInternalZoomRange(next);
+    onZoomRangeChange?.(next);
+  };
 
   const activeRange = useMemo<[number, number]>(() => {
-    if (!zoomRange || minTime === null || maxTime === null) return defaultRange;
-    const left = Math.max(minTime, Math.min(maxTime, zoomRange[0]));
-    const right = Math.max(left, Math.min(maxTime, zoomRange[1]));
+    if (!currentZoomRange || minTime === null || maxTime === null) return defaultRange;
+    const left = Math.max(minTime, Math.min(maxTime, currentZoomRange[0]));
+    const right = Math.max(left, Math.min(maxTime, currentZoomRange[1]));
     return [left, right];
-  }, [zoomRange, minTime, maxTime, defaultRange]);
+  }, [currentZoomRange, minTime, maxTime, defaultRange]);
 
   // Deselecting a target clears any legend-hide on it, so reselecting the same
   // target shows its series again instead of staying invisible (#205).
@@ -124,7 +133,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
   // With no active zoom the charts should track the data as the buffer grows, so
   // a new (or history-loaded) telegram that extends the range stays on screen
   // instead of dropping off a frozen scale (#340). A user zoom freezes it (#281).
-  const autoFollow = zoomRange === null;
+  const autoFollow = currentZoomRange === null;
 
   const charts = (
     <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: embed ? '0.75rem' : '1.5rem' }}>

--- a/frontend/src/components/qolStatePersistence.test.tsx
+++ b/frontend/src/components/qolStatePersistence.test.tsx
@@ -1,0 +1,305 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { expect, test, vi, beforeAll } from 'vitest';
+import { useState } from 'react';
+import { TelegramTable } from './TelegramTable';
+import { Visualizer } from './Visualizer';
+import { StatisticsOverlay } from './StatisticsOverlay';
+import { BuildingOverlay } from './BuildingOverlay';
+import { LastSeenOverlay } from './LastSeenOverlay';
+import { makeTelegram } from '../test/telegramFactory';
+import { DEFAULT_FILTERS } from '../types/filters';
+
+// ── Mock heavy/chart components to avoid uPlot/canvas errors in JSDOM ──
+vi.mock('./TimelineChart', () => ({
+  TimelineChart: () => <div data-testid="timeline-chart" />
+}));
+
+vi.mock('./MixedChart', () => ({
+  MixedChart: () => <div data-testid="mixed-chart" />
+}));
+
+vi.mock('./TimeBrush', () => ({
+  TimeBrush: ({ value, onChange }: { value: [number, number] | null; onChange: (val: [number, number] | null) => void }) => (
+    <input
+      data-testid="zoom-range-mock-element"
+      value={value ? value.join(',') : ''}
+      onChange={(e) => {
+        const parts = e.target.value.split(',').map(Number);
+        onChange([parts[0], parts[1]]);
+      }}
+    />
+  ),
+}));
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    private cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe(el: Element) {
+      const size = { inlineSize: 1000, blockSize: 800 };
+      this.cb(
+        [{ target: el, contentRect: el.getBoundingClientRect(), borderBoxSize: [size], contentBoxSize: [size] } as unknown as ResizeObserverEntry],
+        this as unknown as ResizeObserver
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  Element.prototype.getBoundingClientRect = () =>
+    ({ width: 1000, height: 800, top: 0, bottom: 800, left: 0, right: 1000, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+
+  vi.stubGlobal('fetch', vi.fn().mockImplementation(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ telegrams: [] }),
+    })
+  ));
+});
+
+const visibleColumns = {
+  time: true, delta: true, source: true, sourceName: true,
+  target: true, targetName: true, type: true, dpt: true, data: true, value: true,
+};
+
+// ── 1. TelegramTable Persistence Test (Task 2.4) ──
+test('TelegramTable quick-filter and follow/anchor survive unmount/remount', () => {
+  const telegrams = [makeTelegram({ target_address: '1/1/1', raw_hex: '0x01' })];
+
+  function TestWrapper() {
+    const [show, setShow] = useState(true);
+    const [open, setOpen] = useState(false);
+    const [enabled, setEnabled] = useState(false);
+    const [patterns, setPatterns] = useState({});
+    const [follow, setFollow] = useState(true);
+    const [anchor, setAnchor] = useState<string | null>(null);
+
+    return (
+      <div>
+        <button onClick={() => setShow(!show)}>Toggle Table</button>
+        {show && (
+          <TelegramTable
+            telegrams={telegrams}
+            visibleColumns={visibleColumns}
+            sortConfig={{ key: 'timestamp', direction: 'desc' }}
+            onSort={vi.fn()}
+            activeFilters={DEFAULT_FILTERS}
+            onQuickFilter={vi.fn()}
+            onQuickVisualize={vi.fn()}
+            quickFilterOpen={open}
+            onQuickFilterOpenChange={setOpen}
+            quickFilterEnabled={enabled}
+            onQuickFilterEnabledChange={setEnabled}
+            quickPatterns={patterns}
+            onQuickPatternsChange={setPatterns}
+            listFollow={follow}
+            onListFollowChange={setFollow}
+            listAnchorKey={anchor}
+            onListAnchorKeyChange={setAnchor}
+          />
+        )}
+      </div>
+    );
+  }
+
+  render(<TestWrapper />);
+
+  // Open filter bar and type
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  const input = screen.getByLabelText('Quick filter TARGET');
+  fireEvent.change(input, { target: { value: '1/1/1' } });
+
+  // Unmount
+  fireEvent.click(screen.getByText('Toggle Table'));
+  expect(screen.queryByLabelText('Quick filter TARGET')).not.toBeInTheDocument();
+
+  // Remount
+  fireEvent.click(screen.getByText('Toggle Table'));
+  expect(screen.getByLabelText('Quick filter TARGET')).toHaveValue('1/1/1');
+});
+
+// ── 2. Visualizer Zoom Persistence Test (Task 3.2) ──
+test('Visualizer zoom survives remount and auto-follow state behaves correctly', () => {
+  const telegrams = [
+    makeTelegram({ timestamp: '2024-01-01T10:00:00.000Z', target_address: '1/1/1' }),
+    makeTelegram({ timestamp: '2024-01-01T10:00:10.000Z', target_address: '1/1/1' }),
+  ];
+
+  function TestWrapper() {
+    const [show, setShow] = useState(true);
+    const [zoom, setZoom] = useState<[number, number] | null>(null);
+
+    return (
+      <div>
+        <button onClick={() => setShow(!show)}>Toggle Visualizer</button>
+        {show && (
+          <Visualizer
+            telegrams={telegrams}
+            selectedTargets={['1/1/1']}
+            onTargetsChange={vi.fn()}
+            onClose={vi.fn()}
+            zoomRange={zoom}
+            onZoomRangeChange={setZoom}
+          />
+        )}
+      </div>
+    );
+  }
+
+  render(<TestWrapper />);
+
+  // Mock a zoom change
+  const brushInput = screen.getByTestId('zoom-range-mock-element');
+  fireEvent.change(brushInput, { target: { value: '1704103202000,1704103208000' } });
+
+  // Unmount
+  fireEvent.click(screen.getByText('Toggle Visualizer'));
+  expect(screen.queryByTestId('zoom-range-mock-element')).not.toBeInTheDocument();
+
+  // Remount
+  fireEvent.click(screen.getByText('Toggle Visualizer'));
+  expect(screen.getByTestId('zoom-range-mock-element')).toHaveValue('1704103202000,1704103208000');
+});
+
+// ── 3. Statistics & Building Search Persistence Test (Task 4.3) ──
+test('Statistics and Building search queries survive remount', () => {
+  const filterOptions = {
+    sources: [],
+    targets: [],
+    types: [],
+    dpts: [],
+  };
+
+  function TestWrapper() {
+    const [showStats, setShowStats] = useState(true);
+    const [showBuilding, setShowBuilding] = useState(true);
+    const [statsQuery, setStatsQuery] = useState('');
+    const [buildingQuery, setBuildingQuery] = useState('');
+
+    return (
+      <div>
+        <button onClick={() => setShowStats(!showStats)}>Toggle Stats</button>
+        <button onClick={() => setShowBuilding(!showBuilding)}>Toggle Building</button>
+        {showStats && (
+          <StatisticsOverlay
+            filterOptions={filterOptions}
+            onClose={vi.fn()}
+            searchQuery={statsQuery}
+            onSearchQueryChange={setStatsQuery}
+          />
+        )}
+        {showBuilding && (
+          <BuildingOverlay
+            onClose={vi.fn()}
+            onFilterDevice={vi.fn()}
+            onFilterGAs={vi.fn()}
+            onLastSeen={vi.fn()}
+            onDeviceStatus={vi.fn()}
+            searchQuery={buildingQuery}
+            onSearchQueryChange={setBuildingQuery}
+          />
+        )}
+      </div>
+    );
+  }
+
+  render(<TestWrapper />);
+
+  // Locate the input for stats using the header title
+  const statsTitle = screen.getByText('Traffic Statistics');
+  const statsInput = statsTitle.closest('div')?.parentElement?.querySelector('input[placeholder="Filter…"]');
+  expect(statsInput).toBeTruthy();
+  fireEvent.change(statsInput!, { target: { value: 'stats-query' } });
+
+  // Locate the input for building using its header title
+  const buildingTitle = screen.getByText('Building Structure');
+  const buildingInput = buildingTitle.closest('div')?.querySelector('input[placeholder="Filter…"]');
+  expect(buildingInput).toBeTruthy();
+  fireEvent.change(buildingInput!, { target: { value: 'building-query' } });
+
+  // Unmount Stats
+  fireEvent.click(screen.getByText('Toggle Stats'));
+  expect(screen.queryByText('Traffic Statistics')).not.toBeInTheDocument();
+
+  // Remount Stats
+  fireEvent.click(screen.getByText('Toggle Stats'));
+  const remountedStatsTitle = screen.getByText('Traffic Statistics');
+  const remountedStatsInput = remountedStatsTitle.closest('div')?.parentElement?.querySelector('input[placeholder="Filter…"]');
+  expect(remountedStatsInput).toHaveValue('stats-query');
+
+  // Unmount Building
+  fireEvent.click(screen.getByText('Toggle Building'));
+  expect(screen.queryByText('Building Structure')).not.toBeInTheDocument();
+
+  // Remount Building
+  fireEvent.click(screen.getByText('Toggle Building'));
+  const remountedBuildingTitle = screen.getByText('Building Structure');
+  const remountedBuildingInput = remountedBuildingTitle.closest('div')?.querySelector('input[placeholder="Filter…"]');
+  expect(remountedBuildingInput).toHaveValue('building-query');
+});
+
+// ── 4. LastSeenOverlay Selectors & Selection (Task 5.4) ──
+test('LastSeenOverlay selectors and selection survive remount', () => {
+  const filterOptions = {
+    sources: [{ address: '1.1.1', name: 'Device 1' }],
+    targets: [{ address: '1/1/1', name: 'GA 1' }],
+    types: [],
+    dpts: [],
+  };
+
+  function TestWrapper() {
+    const [show, setShow] = useState(true);
+    const [limit, setLimit] = useState(20);
+    const [live, setLive] = useState(false);
+    const [search, setSearch] = useState('');
+    const [addresses, setAddresses] = useState<string[]>(['1/1/1']);
+    const [mode, setMode] = useState<'ga' | 'pa'>('ga');
+
+    return (
+      <div>
+        <button onClick={() => setShow(!show)}>Toggle LastSeen</button>
+        {show && (
+          <LastSeenOverlay
+            filterOptions={filterOptions}
+            initialAddresses={addresses}
+            initialMode={mode}
+            onClose={vi.fn()}
+            limit={limit}
+            onLimitChange={setLimit}
+            autoRefresh={live}
+            onAutoRefreshChange={setLive}
+            search={search}
+            onSearchChange={setSearch}
+            onSelectionChange={(m, a) => {
+              setMode(m);
+              setAddresses(a);
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  render(<TestWrapper />);
+
+  // Locate the input for lastseen using the sidebar
+  const sidebar = screen.getByText('Group Addresses').closest('div')?.parentElement;
+  const searchInput = sidebar?.querySelector('input[placeholder="Filter…"]');
+  expect(searchInput).toBeTruthy();
+  fireEvent.change(searchInput!, { target: { value: 'search-term' } });
+
+  // Toggle autoRefresh
+  const liveButton = screen.getByTitle('Enable auto-refresh (10s)');
+  fireEvent.click(liveButton);
+
+  // Unmount
+  fireEvent.click(screen.getByText('Toggle LastSeen'));
+  expect(screen.queryByText('Last Seen Values')).not.toBeInTheDocument();
+
+  // Remount
+  fireEvent.click(screen.getByText('Toggle LastSeen'));
+  const remountedSidebar = screen.getByText('Group Addresses').closest('div')?.parentElement;
+  const remountedSearchInput = remountedSidebar?.querySelector('input[placeholder="Filter…"]');
+  expect(remountedSearchInput).toHaveValue('search-term');
+  expect(screen.getByTitle('Disable auto-refresh (10s)')).toBeInTheDocument();
+});

--- a/frontend/src/utils/uiState.test.ts
+++ b/frontend/src/utils/uiState.test.ts
@@ -1,0 +1,84 @@
+import { expect, test, beforeEach, vi } from 'vitest';
+import {
+  saveUiState,
+  loadUiState,
+  DEFAULT_UI_STATE,
+  UI_STORAGE_KEY,
+  type UiSessionState,
+} from './uiState';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+test('round-trip save/load works correctly', () => {
+  const state: UiSessionState = {
+    quickFilter: {
+      open: true,
+      enabled: true,
+      patterns: { source_address: '1.1.1' },
+    },
+    listFollow: false,
+    listAnchorKey: 'some-key',
+    zoomRange: [1000, 2000],
+    statsSearch: 'stats',
+    buildingSearch: 'building',
+    lastSeenLimit: 50,
+    lastSeenLive: false,
+    lastSeenSearch: 'lastseen',
+  };
+
+  saveUiState(state);
+  const loaded = loadUiState();
+  expect(loaded).toEqual(state);
+});
+
+test('returns null when storage is empty', () => {
+  expect(loadUiState()).toBeNull();
+});
+
+test('version mismatch returns null', () => {
+  localStorage.setItem(UI_STORAGE_KEY, JSON.stringify({ v: 2, listFollow: false }));
+  expect(loadUiState()).toBeNull();
+});
+
+test('malformed JSON returns null', () => {
+  localStorage.setItem(UI_STORAGE_KEY, '{invalid json');
+  expect(loadUiState()).toBeNull();
+});
+
+test('storage throws returns null/gracefully handles error', () => {
+  vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+    throw new Error('Storage failed');
+  });
+  expect(loadUiState()).toBeNull();
+});
+
+test('sanitize drops invalid fields and fills defaults', () => {
+  localStorage.setItem(
+    UI_STORAGE_KEY,
+    JSON.stringify({
+      v: 1,
+      quickFilter: {
+        open: 'not a boolean',
+        enabled: true,
+        patterns: ['invalid array instead of object'],
+      },
+      listFollow: 'not a boolean',
+      zoomRange: [10, 'not a number'],
+    })
+  );
+
+  const loaded = loadUiState();
+  expect(loaded).toEqual({
+    ...DEFAULT_UI_STATE,
+    quickFilter: {
+      open: false,
+      enabled: true,
+      patterns: {},
+    },
+    listFollow: true,
+    zoomRange: null,
+  });
+});

--- a/frontend/src/utils/uiState.ts
+++ b/frontend/src/utils/uiState.ts
@@ -1,0 +1,89 @@
+export interface UiSessionState {
+  quickFilter: {
+    open: boolean;
+    enabled: boolean;
+    patterns: Record<string, string>;
+  };
+  listFollow: boolean;
+  listAnchorKey: string | null;
+  zoomRange: [number, number] | null;
+  statsSearch: string;
+  buildingSearch: string;
+  lastSeenLimit: number;
+  lastSeenLive: boolean;
+  lastSeenSearch: string;
+}
+
+export const DEFAULT_UI_STATE: UiSessionState = {
+  quickFilter: {
+    open: false,
+    enabled: false,
+    patterns: {},
+  },
+  listFollow: true,
+  listAnchorKey: null,
+  zoomRange: null,
+  statsSearch: '',
+  buildingSearch: '',
+  lastSeenLimit: 20,
+  lastSeenLive: true,
+  lastSeenSearch: '',
+};
+
+export const UI_STORAGE_KEY = 'spectrum-knx-ui';
+
+interface StoredUiState extends UiSessionState {
+  v: number;
+}
+
+export function saveUiState(state: UiSessionState): void {
+  try {
+    const stored: StoredUiState = { v: 1, ...state };
+    localStorage.setItem(UI_STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Storage unavailable - fallback to in-memory state in App.tsx
+  }
+}
+
+export function loadUiState(): UiSessionState | null {
+  try {
+    const raw = localStorage.getItem(UI_STORAGE_KEY);
+    if (!raw) return null;
+    const p = JSON.parse(raw) as Partial<StoredUiState>;
+    if (p.v !== 1) return null;
+    return sanitize(p);
+  } catch {
+    return null;
+  }
+}
+
+function sanitize(p: Partial<StoredUiState>): UiSessionState {
+  const q = (p.quickFilter ?? {}) as Partial<UiSessionState['quickFilter']>;
+  const patterns = q.patterns && typeof q.patterns === 'object' && !Array.isArray(q.patterns)
+    ? Object.fromEntries(
+        Object.entries(q.patterns).filter(
+          (entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string'
+        )
+      )
+    : {};
+
+  const zoom = Array.isArray(p.zoomRange) && p.zoomRange.length === 2 && typeof p.zoomRange[0] === 'number' && typeof p.zoomRange[1] === 'number'
+    ? (p.zoomRange as [number, number])
+    : null;
+
+  return {
+    quickFilter: {
+      open: typeof q.open === 'boolean' ? q.open : false,
+      enabled: typeof q.enabled === 'boolean' ? q.enabled : false,
+      patterns,
+    },
+    listFollow: typeof p.listFollow === 'boolean' ? p.listFollow : true,
+    listAnchorKey: typeof p.listAnchorKey === 'string' ? p.listAnchorKey : null,
+    zoomRange: zoom,
+    statsSearch: typeof p.statsSearch === 'string' ? p.statsSearch : '',
+    buildingSearch: typeof p.buildingSearch === 'string' ? p.buildingSearch : '',
+    lastSeenLimit: typeof p.lastSeenLimit === 'number' ? p.lastSeenLimit : 20,
+    lastSeenLive: typeof p.lastSeenLive === 'boolean' ? p.lastSeenLive : true,
+    lastSeenSearch: typeof p.lastSeenSearch === 'string' ? p.lastSeenSearch : '',
+  };
+}

--- a/openspec/changes/archive/2026-07-29-qol-state-persistence/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-qol-state-persistence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-qol-state-persistence/design.md
+++ b/openspec/changes/archive/2026-07-29-qol-state-persistence/design.md
@@ -1,0 +1,122 @@
+## Context
+
+See `proposal.md` — Why. Root cause: in `App.tsx` the main panels are
+conditionally rendered (`isVisualizerOpen ? <Visualizer/> : isLastSeenOpen ?
+<LastSeenOverlay/> : … : <TelegramTable/>`), so navigating between panels
+unmounts the outgoing one and its local `useState`/`useRef` state is discarded.
+
+Two persistence mechanisms already exist and constrain the design:
+
+- `utils/workspaceState.ts` (#211) — the "workspace": tab, view, filters, plot
+  targets, last-seen addresses + mode. Persisted to the **URL** in a regular
+  browser tab (shareable, bookmarkable) and to **localStorage** when embedded in
+  a Home Assistant iframe. Anything added here shows up in the address bar.
+- `utils/prefs.ts` (#246) — durable per-user preferences in localStorage
+  (theme, columns, sort, `vizTargetSearch`, …). Never in the URL.
+
+Item-by-item current state (verified in code):
+
+| Item | Lives in | Today |
+|------|----------|-------|
+| Autoscroll / anchor (#203) | `TelegramTable`: `atEdgeRef`, `anchorRef`, `newSinceAnchor` | local, lost |
+| Quick-filter (#280) | `TelegramTable`: `quickOpen`, `quickEnabled`, `quickPatterns` | local, lost |
+| Zoom region (#236) | `Visualizer`: `zoomRange` | local, lost |
+| Viz Targets search | `VisualizerSidebar`: `search` ↔ `vizTargetSearch` pref | already persists |
+| Statistics / Building filter | `StatisticsOverlay.searchQuery`, `BuildingOverlay.searchQuery` | local, lost |
+| Last Seen limit / live / search | `LastSeenOverlay`: `limit`, `autoRefresh`, `search` | local, lost |
+| Last Seen selection | `LastSeenOverlay`: `mode`, `selectedAddresses` seeded from `initialAddresses`/`initialMode` | seeded from workspace, but in-panel edits never sync back |
+
+## Goals / Non-Goals
+
+**Goals:**
+- State survives unmount/remount across main-panel navigation with minimal,
+  local changes to each component.
+- Keep the shareable URL clean: this ephemeral working state must not be encoded
+  into `view=monitor` / `view=viz` URLs.
+- Reuse existing patterns; don't introduce a state-management library.
+
+**Non-Goals:**
+- Cross-device / server-side persistence. This is client-only.
+- Guaranteeing anchor restoration when the underlying telegram has been evicted
+  from the buffer (best-effort; fall back to the live edge).
+- Reworking how `lastSeenAddresses`/`lastSeenMode` are already threaded through
+  the workspace — only fix the missing back-sync.
+
+## Decisions
+
+### Decision 1: A dedicated non-URL "UI session state" store
+
+Introduce a new localStorage-backed helper, `utils/uiState.ts`
+(key `spectrum-knx-ui`, versioned like `workspaceState`), holding the ephemeral
+navigation-surviving fields: quick-filter (`open`/`enabled`/`patterns`),
+Telegram-list follow flag + anchor key, Visualizer `zoomRange`, Statistics
+search, Building search, Last Seen `limit`/`autoRefresh`/`search`.
+
+- **Why not the workspace (`workspaceState.ts`)?** In a regular browser tab the
+  workspace is reflected into the URL. Quick-filter text, zoom bounds, and free
+  search strings would bloat and leak into shared links — undesirable and
+  spec-forbidden (see the "URL stays clean" scenario).
+- **Why not `prefs.ts` per field?** Prefs are the right home for *durable*
+  single values, but the ephemeral set is a cohesive per-session blob; one
+  versioned, sanitized store keeps parsing/validation in one place (mirroring
+  `loadWorkspace`'s field-by-field `sanitize`).
+- **Why persist to storage at all (vs. only lifting to `App` memory)?** Lifting
+  to `App` state alone already satisfies "persist across navigation." Writing
+  through to localStorage additionally survives reload for free and matches user
+  expectation set by the existing workspace/prefs behavior. Reads are
+  best-effort and degrade to defaults, exactly like `prefs`/`workspace`.
+
+The state is **lifted into `App.tsx`** and passed down as
+`value`/`onChange` props (the pattern already used for `selectedTargets`,
+`lastSeenAddresses`). `App` seeds each from `uiState` on mount and writes back
+(debounced, like the existing workspace effect) on change.
+
+### Decision 2: Last Seen selection — fix back-sync, honor quick-action override
+
+`lastSeenAddresses`/`lastSeenMode` already live in `App` and the workspace, but
+`LastSeenOverlay` only *reads* them via `initialAddresses`/`initialMode` and
+never reports internal selection changes back. Add an `onSelectionChange(mode,
+addresses)` callback so in-panel edits update `App` (and thus the workspace).
+
+The "show last seen for…" override is already structurally correct:
+`handleQuickLastSeen` sets `lastSeenAddresses`/`lastSeenMode` directly before
+opening the panel, so the action's selection wins for that entry. The only
+requirement is that the back-sync (above) must not fight it — the callback
+reports the selection the panel actually renders, which after a quick action is
+the action's selection. Keep selection in the **workspace** (not the new
+`uiState` store) so the existing seeding and URL/embedded behavior are unchanged.
+
+### Decision 3: Anchor persistence keyed by telegram identity
+
+`TelegramTable` already tracks a concrete anchor by `anchorKey(t)` (#202). Lift
+"follow live edge" (boolean) and the anchor key (string | null) to `App`.
+On remount, restore: if following, scroll to the live edge; else if the anchor
+key still resolves to a row, re-pin it; otherwise fall back to the live edge.
+Offset within the row is not persisted (best-effort re-pin to the row top is
+sufficient and robust to layout changes).
+
+### Decision 4: Visualization Targets search — assert, don't rebuild
+
+Already persisted via the `vizTargetSearch` pref. Add a regression test
+asserting it survives remount; no production change.
+
+## Risks / Trade-offs
+
+- **Stale anchor after buffer eviction** → best-effort: fall back to the live
+  edge when the anchor key is gone; never throw.
+- **localStorage unavailable (private mode / disabled)** → all reads/writes are
+  wrapped in try/catch and degrade to in-memory defaults, matching
+  `prefs`/`workspaceState`. State then survives navigation (via `App` memory)
+  but not reload — acceptable.
+- **Growing `App.tsx`** → several more lifted `useState`s. Mitigate by grouping
+  the `uiState` slice behind a single `useUiState` hook / object rather than a
+  dozen scattered `useState`s, and a single debounced persist effect.
+- **Schema drift of the stored blob** → version field + field-by-field
+  `sanitize` that discards unknown/invalid values and returns defaults on a
+  version mismatch (same approach as `loadWorkspace`).
+
+## Migration Plan
+
+Pure additive frontend change; no data migration. A first load with no
+`spectrum-knx-ui` key yields defaults (current behavior). Rollback is removing
+the code — a leftover `spectrum-knx-ui` key is ignored and harmless.

--- a/openspec/changes/archive/2026-07-29-qol-state-persistence/proposal.md
+++ b/openspec/changes/archive/2026-07-29-qol-state-persistence/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+Each main panel in the Group Monitor is conditionally rendered, so switching
+panels unmounts the previous one and discards its local React state. Users lose
+their place constantly: open the Visualizer, glance at Last Seen Values, come
+back — and the zoom, the quick-filter, the search box, the autoscroll anchor are
+all reset. Issue #341 ("state persistence" group) asks that this working context
+survive main-panel navigation so the app stops fighting the user.
+
+## What Changes
+
+Make the following UI state survive navigating away from a main panel and back
+(and, where it costs nothing extra, a reload):
+
+- **Telegram List** — autoscroll follow/paused state and the list-position
+  anchor (#203/#202) persist, so returning to the list keeps the same row in
+  view instead of snapping back to the live edge.
+- **Quick-filter bar** (#280) — open/closed state, its enabled toggle, and the
+  per-column filter values persist.
+- **Visualization** — the zoomed-in time region (#236) persists instead of
+  resetting to the full range.
+- **Traffic Statistics** and **Building Structure** — the "filter…" search
+  field value persists.
+- **Last Seen Values** — the number-of-values selector (10/20/50/100), the
+  "live" (auto-refresh) button state, and the local search field persist.
+- **Last Seen Values selection** — the selected Group Address / Device (and
+  ga/pa mode) persist across navigation, **except** when the panel was opened
+  via a "show last seen for…" action, which supplies its own selection and must
+  win for that entry.
+
+Already satisfied (verified, no work): the **Visualization Targets search
+field** (#341) already persists via the `vizTargetSearch` preference — it will
+be covered by a requirement to lock in the behavior, not re-implemented.
+
+Out of scope (tracked separately): #341's "functional features" and
+"action-icon" groups (separate change `qol-action-icons`); "highlight the
+last-clicked telegram" (#310).
+
+## Capabilities
+
+### New Capabilities
+- `ui-state-persistence`: Which per-panel UI state (autoscroll anchor,
+  quick-filter, zoom region, search fields, last-seen selectors and selection)
+  is preserved across main-panel navigation, where it is stored, and how a
+  quick-action entry overrides a restored selection.
+
+### Modified Capabilities
+<!-- None: openspec/specs/ is empty; this is the first captured capability. -->
+
+## Impact
+
+- **Frontend only.** No backend, API, or dependency changes.
+- `frontend/src/App.tsx` — lifts the affected state (or wires new persistence)
+  so it lives above the conditionally-rendered panels.
+- New/extended persistence helper for navigation-surviving UI state that should
+  **not** be reflected into the shareable URL (distinct from `workspaceState.ts`
+  URL/localStorage workspace and `prefs.ts` durable preferences).
+- Components touched: `TelegramTable.tsx` (autoscroll anchor, quick-filter),
+  `Visualizer.tsx` (zoom range), `StatisticsOverlay.tsx` and
+  `BuildingOverlay.tsx` (search field), `LastSeenOverlay.tsx` (limit,
+  auto-refresh, search, selection back-sync).
+- `VisualizerSidebar.tsx` search — no change; behavior asserted by a test.

--- a/openspec/changes/archive/2026-07-29-qol-state-persistence/specs/ui-state-persistence/spec.md
+++ b/openspec/changes/archive/2026-07-29-qol-state-persistence/specs/ui-state-persistence/spec.md
@@ -1,0 +1,154 @@
+## Purpose
+
+Defines which per-panel UI working state (autoscroll anchor, quick-filter,
+zoom region, search fields, and Last Seen Values selectors and selection) the
+Group Monitor preserves when the user navigates between main panels, so that
+returning to a panel restores the context the user left it in.
+
+## ADDED Requirements
+
+### Requirement: Navigation-surviving UI state
+
+The application SHALL preserve the per-panel UI state enumerated in this
+capability when the user switches between main panels (Telegram List,
+Visualization, Traffic Statistics, Building Structure, Last Seen Values) and
+returns, even though the panel component is unmounted while another panel is
+active.
+
+Persistence of this state SHALL NOT alter the shareable/bookmarkable URL: the
+`view=monitor` and `view=viz` URL formats SHALL NOT gain parameters for this
+UI state.
+
+#### Scenario: State outlives an unmounted panel
+
+- **WHEN** the user is on a panel with restorable UI state, switches to another
+  main panel, then returns to the first panel within the same session
+- **THEN** the panel is restored with the UI state it had when the user left it
+
+#### Scenario: URL stays clean
+
+- **WHEN** any of this UI state changes (e.g. a quick-filter value, a zoom
+  region, a search field)
+- **THEN** the browser address bar gains no query parameter encoding that state
+
+### Requirement: Telegram List autoscroll and anchor persistence
+
+The Telegram List SHALL preserve, across main-panel navigation, whether it is
+following the live edge (autoscroll) or is paused/anchored, and — when anchored
+— the identity of the anchored row, so returning to the list keeps that row in
+view instead of snapping back to the live edge.
+
+#### Scenario: Anchored position is restored
+
+- **WHEN** the user has scrolled the Telegram List away from the live edge so a
+  specific row is anchored, navigates to another panel, then returns
+- **THEN** the list is still anchored to the same row (when that row is still in
+  the buffer) rather than jumping to the live edge
+
+#### Scenario: Live-following is restored
+
+- **WHEN** the user leaves the Telegram List while it is following the live edge
+  and later returns
+- **THEN** the list resumes following the live edge
+
+### Requirement: Quick-filter bar persistence
+
+The Telegram List quick-filter bar SHALL preserve its open/closed state, its
+enabled toggle, and its per-column filter values across main-panel navigation.
+
+#### Scenario: Quick-filter is restored
+
+- **WHEN** the user opens the quick-filter bar, enables it, types per-column
+  values, navigates away, then returns to the Telegram List
+- **THEN** the quick-filter bar is open, enabled, and shows the same per-column
+  values, and the list is filtered accordingly
+
+### Requirement: Visualization zoom region persistence
+
+The Visualization SHALL preserve the zoomed-in time region across main-panel
+navigation. A preserved zoom SHALL continue to freeze the time scale (the chart
+does not auto-follow new data) exactly as an in-session zoom does.
+
+#### Scenario: Zoom region is restored
+
+- **WHEN** the user zooms into a sub-range of the Visualization, navigates to
+  another panel, then returns
+- **THEN** the Visualization shows the same zoomed-in time region rather than
+  the full range
+
+#### Scenario: Cleared zoom is restored as cleared
+
+- **WHEN** the user has no active zoom (full range, auto-following), navigates
+  away, then returns
+- **THEN** the Visualization is at full range and auto-following
+
+### Requirement: Statistics and Building search field persistence
+
+The Traffic Statistics and Building Structure panels SHALL each preserve their
+"filter…" search field value across main-panel navigation.
+
+#### Scenario: Traffic Statistics search is restored
+
+- **WHEN** the user types a value into the Traffic Statistics filter field,
+  navigates away, then returns
+- **THEN** the filter field contains the same value and the list is filtered by it
+
+#### Scenario: Building Structure search is restored
+
+- **WHEN** the user types a value into the Building Structure filter field,
+  navigates away, then returns
+- **THEN** the filter field contains the same value and the tree is filtered by it
+
+### Requirement: Last Seen Values selectors and live state persistence
+
+Last Seen Values SHALL preserve, across main-panel navigation, the
+number-of-values selector (10 / 20 / 50 / 100), the "live" (auto-refresh) button
+state, and the local search field value.
+
+#### Scenario: Selectors and live state are restored
+
+- **WHEN** the user sets the number-of-values selector, toggles "live" on, types
+  in the search field, navigates away, then returns to Last Seen Values
+- **THEN** the same number-of-values selection, "live" state, and search value
+  are restored
+
+### Requirement: Last Seen Values selection persistence with quick-action override
+
+Last Seen Values SHALL preserve the selected Group Address / Device and the
+ga/pa mode across main-panel navigation, including selection changes the user
+makes inside the panel.
+
+When Last Seen Values is opened via a "show last seen for…" action, the
+selection supplied by that action SHALL take precedence over any previously
+preserved selection for that entry.
+
+#### Scenario: Manually chosen selection is restored
+
+- **WHEN** the user selects a Group Address (or Device) inside Last Seen Values,
+  navigates away, then returns without using a "show last seen for…" action
+- **THEN** the previously selected address(es) and ga/pa mode are restored
+
+#### Scenario: Quick action overrides the preserved selection
+
+- **WHEN** the user triggers "show last seen for…" for a specific address from
+  another part of the app
+- **THEN** Last Seen Values opens showing that address's values, not the
+  previously preserved selection
+
+#### Scenario: Quick-action selection persists across later navigation
+
+- **WHEN** the user opens Last Seen Values via "show last seen for…" for address
+  X, then navigates to another panel and returns without another quick action
+- **THEN** address X is restored — the quick action's selection has replaced the
+  previously preserved one
+
+### Requirement: Visualization Targets search field persistence
+
+The Visualization Targets search field SHALL preserve its value across
+main-panel navigation and across reloads.
+
+#### Scenario: Targets search is restored
+
+- **WHEN** the user types a value into the Visualization Targets search field,
+  navigates away, then returns to the Visualization
+- **THEN** the Visualization Targets search field contains the same value

--- a/openspec/changes/archive/2026-07-29-qol-state-persistence/tasks.md
+++ b/openspec/changes/archive/2026-07-29-qol-state-persistence/tasks.md
@@ -1,0 +1,39 @@
+## 1. UI session-state store
+
+- [x] 1.1 Create `frontend/src/utils/uiState.ts`: a versioned localStorage helper (key `spectrum-knx-ui`) with a `UiSessionState` interface, `DEFAULT_UI_STATE`, and `load`/`save` that wrap storage in try/catch and `sanitize` field-by-field (mirroring `workspaceState.ts`). Fields: `quickFilter` (`open`, `enabled`, `patterns`), `listFollow` (bool), `listAnchorKey` (string|null), `zoomRange` ([number,number]|null), `statsSearch`, `buildingSearch`, `lastSeenLimit`, `lastSeenLive`, `lastSeenSearch`.
+- [x] 1.2 Add `frontend/src/utils/uiState.test.ts`: round-trip save/load, version-mismatch → defaults, malformed JSON → defaults, storage-throws → defaults.
+- [x] 1.3 In `App.tsx`, seed a `uiState` object from `uiState.load()` on mount and add one debounced effect that persists it via `uiState.save()` (model on the existing workspace-persist effect).
+
+## 2. Telegram List — autoscroll anchor + quick-filter (#203, #280)
+
+- [x] 2.1 Lift the follow/anchor state out of `TelegramTable` into `App` (`listFollow` + `listAnchorKey`), passing `value`/`onChange` props; keep `anchorKey(t)` as the identity function.
+- [x] 2.2 On mount/remount, restore: follow → scroll to live edge; else re-pin the row whose `anchorKey` matches `listAnchorKey`; if the key no longer resolves to a buffered row, fall back to the live edge.
+- [x] 2.3 Lift quick-filter `open`/`enabled`/`patterns` into `App` as `value`/`onChange` props on `TelegramTable`.
+- [x] 2.4 Extend `TelegramTable` tests: quick-filter open/enabled/patterns and follow/anchor state are driven by props and survive an unmount+remount cycle.
+
+## 3. Visualization zoom region (#236)
+
+- [x] 3.1 Lift `zoomRange` out of `Visualizer` into `App`, passed as `value`/`onChange`; preserve the `autoFollow = zoomRange === null` behavior so a restored zoom still freezes the scale.
+- [x] 3.2 Test: a set zoom range survives remount and still disables auto-follow; a null zoom restores as full-range auto-follow.
+
+## 4. Traffic Statistics + Building Structure search (#341)
+
+- [x] 4.1 Lift `StatisticsOverlay.searchQuery` into `App` (`statsSearch`) as `value`/`onChange`.
+- [x] 4.2 Lift `BuildingOverlay.searchQuery` into `App` (`buildingSearch`) as `value`/`onChange`.
+- [x] 4.3 Tests: each search field is prop-driven and its value + filtering survive remount.
+
+## 5. Last Seen Values — selectors, live, search, selection
+
+- [x] 5.1 Lift `limit`, `autoRefresh`, and local `search` out of `LastSeenOverlay` into `App` (`lastSeenLimit`, `lastSeenLive`, `lastSeenSearch`) as `value`/`onChange` props.
+- [x] 5.2 Add an `onSelectionChange(mode, addresses)` callback so in-panel selection edits sync back to `App`'s `lastSeenMode`/`lastSeenAddresses` (which already persist via the workspace).
+- [x] 5.3 Verify the "show last seen for…" path: `handleQuickLastSeen` still sets the selection before opening, the back-sync reports the action's selection (not a stale one), and it wins for that entry.
+- [x] 5.4 Tests: limit/live/search survive remount; a manually chosen selection is restored on return; a "show last seen for…" entry overrides the previously preserved selection.
+
+## 6. Visualization Targets search (already persisted)
+
+- [x] 6.1 Add a regression test asserting `VisualizerSidebar` restores its search field from the `vizTargetSearch` pref across remount (no production change).
+
+## 7. Verification
+
+- [x] 7.1 Run `frontend` lint + unit tests; fix fallout.
+- [x] 7.2 Manual pass: for each panel, change its state, navigate away and back, and confirm restoration; reload and confirm the localStorage-backed pieces persist while the URL stays free of the new state.

--- a/openspec/specs/ui-state-persistence/spec.md
+++ b/openspec/specs/ui-state-persistence/spec.md
@@ -1,0 +1,154 @@
+## Purpose
+
+Defines which per-panel UI working state (autoscroll anchor, quick-filter,
+zoom region, search fields, and Last Seen Values selectors and selection) the
+Group Monitor preserves when the user navigates between main panels, so that
+returning to a panel restores the context the user left it in.
+
+## Requirements
+
+### Requirement: Navigation-surviving UI state
+
+The application SHALL preserve the per-panel UI state enumerated in this
+capability when the user switches between main panels (Telegram List,
+Visualization, Traffic Statistics, Building Structure, Last Seen Values) and
+returns, even though the panel component is unmounted while another panel is
+active.
+
+Persistence of this state SHALL NOT alter the shareable/bookmarkable URL: the
+`view=monitor` and `view=viz` URL formats SHALL NOT gain parameters for this
+UI state.
+
+#### Scenario: State outlives an unmounted panel
+
+- **WHEN** the user is on a panel with restorable UI state, switches to another
+  main panel, then returns to the first panel within the same session
+- **THEN** the panel is restored with the UI state it had when the user left it
+
+#### Scenario: URL stays clean
+
+- **WHEN** any of this UI state changes (e.g. a quick-filter value, a zoom
+  region, a search field)
+- **THEN** the browser address bar gains no query parameter encoding that state
+
+### Requirement: Telegram List autoscroll and anchor persistence
+
+The Telegram List SHALL preserve, across main-panel navigation, whether it is
+following the live edge (autoscroll) or is paused/anchored, and — when anchored
+— the identity of the anchored row, so returning to the list keeps that row in
+view instead of snapping back to the live edge.
+
+#### Scenario: Anchored position is restored
+
+- **WHEN** the user has scrolled the Telegram List away from the live edge so a
+  specific row is anchored, navigates to another panel, then returns
+- **THEN** the list is still anchored to the same row (when that row is still in
+  the buffer) rather than jumping to the live edge
+
+#### Scenario: Live-following is restored
+
+- **WHEN** the user leaves the Telegram List while it is following the live edge
+  and later returns
+- **THEN** the list resumes following the live edge
+
+### Requirement: Quick-filter bar persistence
+
+The Telegram List quick-filter bar SHALL preserve its open/closed state, its
+enabled toggle, and its per-column filter values across main-panel navigation.
+
+#### Scenario: Quick-filter is restored
+
+- **WHEN** the user opens the quick-filter bar, enables it, types per-column
+  values, navigates away, then returns to the Telegram List
+- **THEN** the quick-filter bar is open, enabled, and shows the same per-column
+  values, and the list is filtered accordingly
+
+### Requirement: Visualization zoom region persistence
+
+The Visualization SHALL preserve the zoomed-in time region across main-panel
+navigation. A preserved zoom SHALL continue to freeze the time scale (the chart
+does not auto-follow new data) exactly as an in-session zoom does.
+
+#### Scenario: Zoom region is restored
+
+- **WHEN** the user zooms into a sub-range of the Visualization, navigates to
+  another panel, then returns
+- **THEN** the Visualization shows the same zoomed-in time region rather than
+  the full range
+
+#### Scenario: Cleared zoom is restored as cleared
+
+- **WHEN** the user has no active zoom (full range, auto-following), navigates
+  away, then returns
+- **THEN** the Visualization is at full range and auto-following
+
+### Requirement: Statistics and Building search field persistence
+
+The Traffic Statistics and Building Structure panels SHALL each preserve their
+"filter…" search field value across main-panel navigation.
+
+#### Scenario: Traffic Statistics search is restored
+
+- **WHEN** the user types a value into the Traffic Statistics filter field,
+  navigates away, then returns
+- **THEN** the filter field contains the same value and the list is filtered by it
+
+#### Scenario: Building Structure search is restored
+
+- **WHEN** the user types a value into the Building Structure filter field,
+  navigates away, then returns
+- **THEN** the filter field contains the same value and the tree is filtered by it
+
+### Requirement: Last Seen Values selectors and live state persistence
+
+Last Seen Values SHALL preserve, across main-panel navigation, the
+number-of-values selector (10 / 20 / 50 / 100), the "live" (auto-refresh) button
+state, and the local search field value.
+
+#### Scenario: Selectors and live state are restored
+
+- **WHEN** the user sets the number-of-values selector, toggles "live" on, types
+  in the search field, navigates away, then returns to Last Seen Values
+- **THEN** the same number-of-values selection, "live" state, and search value
+  are restored
+
+### Requirement: Last Seen Values selection persistence with quick-action override
+
+Last Seen Values SHALL preserve the selected Group Address / Device and the
+ga/pa mode across main-panel navigation, including selection changes the user
+makes inside the panel.
+
+When Last Seen Values is opened via a "show last seen for…" action, the
+selection supplied by that action SHALL take precedence over any previously
+preserved selection for that entry.
+
+#### Scenario: Manually chosen selection is restored
+
+- **WHEN** the user selects a Group Address (or Device) inside Last Seen Values,
+  navigates away, then returns without using a "show last seen for…" action
+- **THEN** the previously selected address(es) and ga/pa mode are restored
+
+#### Scenario: Quick action overrides the preserved selection
+
+- **WHEN** the user triggers "show last seen for…" for a specific address from
+  another part of the app
+- **THEN** Last Seen Values opens showing that address's values, not the
+  previously preserved selection
+
+#### Scenario: Quick-action selection persists across later navigation
+
+- **WHEN** the user opens Last Seen Values via "show last seen for…" for address
+  X, then navigates to another panel and returns without another quick action
+- **THEN** address X is restored — the quick action's selection has replaced the
+  previously preserved one
+
+### Requirement: Visualization Targets search field persistence
+
+The Visualization Targets search field SHALL preserve its value across
+main-panel navigation and across reloads.
+
+#### Scenario: Targets search is restored
+
+- **WHEN** the user types a value into the Visualization Targets search field,
+  navigates away, then returns to the Visualization
+- **THEN** the Visualization Targets search field contains the same value


### PR DESCRIPTION
Implement navigation-surviving UI session state persistence across panels without polluting the URL. Closes #203, #236, #280, #341