### PR TITLE
fix: prevent permanent time gaps in async history buffer (#317)

### DIFF
--- a/frontend/src/hooks/useTelegramCache.test.ts
+++ b/frontend/src/hooks/useTelegramCache.test.ts
@@ -293,7 +293,7 @@ describe('useTelegramCache', () => {
     expect(saved.some(([s]) => s === 0)).toBe(false);
   });
 
-  it('stops backing off older history once the buffer is full (#313)', async () => {
+  it('loadRange pages through the full range even when the buffer is full (#317)', async () => {
     // Buffer size 2, filled with the two newest (live) telegrams.
     const { result } = renderHook(() => useTelegramCache(2));
     await settle(result);
@@ -303,16 +303,45 @@ describe('useTelegramCache', () => {
     });
     expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.live2', '1.2.live1']);
 
-    // Requesting older history: every fetched row would be older than the
-    // buffer's oldest entry and evicted on arrival, so no backend request is made.
+    // User-initiated loadRange bypasses the full-buffer early break (#317):
+    // older data IS fetched and persisted to IDB, even though the in-memory
+    // buffer will evict it (buffer is at capacity with newer rows).
+    telegramResponses.push({ telegrams: [tg(3000, 'old')] });
     const before = fetchCalls.filter(u => u.includes('/api/telegrams')).length;
     await act(async () => {
       await result.current.loadRange(1000, 5000);
     });
     const loadFetches = fetchCalls.filter(u => u.includes('/api/telegrams')).length - before;
 
-    expect(loadFetches).toBe(0);
-    expect(result.current.telegrams.map(t => t.source_address)).toEqual(['1.2.live2', '1.2.live1']);
+    // A fetch WAS made (the old behavior would have skipped it entirely).
+    expect(loadFetches).toBeGreaterThan(0);
+    // The fetched telegram is persisted in IDB even if it got evicted from buffer.
+    expect(_idb.has(toEntry(tg(3000, 'old')).id)).toBe(true);
+  });
+
+  it('startup gap fill still stops early when the buffer is full (#313)', async () => {
+    // Buffer size 2 with prior coverage forcing a gap below the buffer window.
+    localStorage.setItem(COVERAGE_STORAGE_KEY, JSON.stringify([[1000, 9000]]));
+    seedIdb([tg(8000, 'a'), tg(9000, 'b')]);
+    telegramResponses.push({ telegrams: [] }); // startup gap [9001, now]
+
+    const { result } = renderHook(() => useTelegramCache(2));
+    await settle(result);
+
+    // The automatic startup restore still respects the full-buffer early break.
+    // Reconnect gap fills hit fillGaps without skipBufferFullBreak.
+    act(() => { result.current.setConnected(true); });
+    act(() => { result.current.setConnected(false); });
+    act(() => { result.current.setConnected(true); });
+
+    // Only the reconnect gap [disconnect..now] is fetched, not older gaps.
+    const reconnectFetches = fetchCalls
+      .filter(u => u.includes('/api/telegrams'))
+      .filter(u => {
+        const p = new URLSearchParams(u.split('?')[1]);
+        return Date.parse(p.get('end_time')!) < 8000;
+      });
+    expect(reconnectFetches).toHaveLength(0);
   });
 
   it('does not mark a range covered when the cache write fails (#317)', async () => {
@@ -333,6 +362,46 @@ describe('useTelegramCache', () => {
     expect(result.current.telegrams.map(t => t.source_address)).toContain('1.2.x');
     const saved = JSON.parse(localStorage.getItem(COVERAGE_STORAGE_KEY)!) as [number, number][];
     expect(saved.some(([s, e]) => s <= 5000 && 5000 <= e)).toBe(false);
+  });
+
+  it('defers coverage persistence while IDB writes are in flight (#317)', async () => {
+    // Use a gated store to keep the IDB write pending.
+    let releaseStore: () => void = () => {};
+    const storeGate = new Promise<void>(res => { releaseStore = res; });
+    let storeGateArmed = false;
+    const origSetMany = vi.mocked(await import('idb-keyval')).setMany;
+    vi.mocked(await import('idb-keyval')).setMany = vi.fn(async (...args: Parameters<typeof origSetMany>) => {
+      if (storeGateArmed) await storeGate;
+      return origSetMany(...args);
+    }) as unknown as typeof origSetMany;
+
+    const { result } = renderHook(() => useTelegramCache(1000));
+    await settle(result);
+
+    // Arm the gate so the next IDB write blocks.
+    storeGateArmed = true;
+    localStorage.removeItem(COVERAGE_STORAGE_KEY);
+
+    // Add a live telegram — its batch flush will start a pending store.
+    act(() => {
+      for (let i = 0; i < 200; i++) result.current.addLive(tg(1000 + i, `batch${i}`));
+    });
+
+    // Coverage should NOT have been saved while the write is in flight.
+    expect(localStorage.getItem(COVERAGE_STORAGE_KEY)).toBeNull();
+
+    // Release the store and let the deferred save run.
+    await act(async () => {
+      releaseStore();
+      // Allow microtasks to flush.
+      await new Promise(r => setTimeout(r, 10));
+    });
+
+    // Now coverage should be persisted.
+    expect(localStorage.getItem(COVERAGE_STORAGE_KEY)).not.toBeNull();
+
+    // Restore the original mock.
+    vi.mocked(await import('idb-keyval')).setMany = origSetMany;
   });
 
   it('records a load failure without breaking the buffer', async () => {

--- a/frontend/src/hooks/useTelegramCache.ts
+++ b/frontend/src/hooks/useTelegramCache.ts
@@ -107,6 +107,8 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
   const pausedRef = useRef(false);
   /** Bumped by clear() to invalidate any background load still in flight (#339). */
   const loadGenerationRef = useRef(0);
+  /** Number of in-flight IDB store() calls — coverage saves are deferred while > 0 (#317). */
+  const pendingStoreCountRef = useRef(0);
 
   const [telegrams, setTelegrams] = useState<Telegram[]>([]);
   const [pausedCount, setPausedCount] = useState(0);
@@ -135,6 +137,9 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
   );
 
   const saveCoverage = useCallback(() => {
+    // Defer saving while IDB writes are in flight so a crash between the
+    // coverage save and the IDB commit can't leave orphaned coverage (#317).
+    if (pendingStoreCountRef.current > 0) return;
     saveCoverageIntervals(coverageRef.current!.covered);
   }, []);
 
@@ -144,9 +149,13 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
    * `HISTORY_CHUNK_SIZE` requests until the gap is exhausted or `budget` rows
    * have been fetched; a budget cut-off leaves the older remainder uncovered for
    * a later load. Returns how many telegrams were fetched (for cross-gap budgeting).
+   *
+   * When `skipBufferFullBreak` is true (user-initiated loads), the full-buffer
+   * early break (#313) is disabled so the entire requested range is fetched and
+   * persisted to IDB, even if the in-memory buffer evicts older entries (#317).
    */
   const fetchGapProgressive = useCallback(
-    async (gapStart: number, gapEnd: number, budget: number): Promise<number> => {
+    async (gapStart: number, gapEnd: number, budget: number, skipBufferFullBreak = false): Promise<number> => {
       const gen = loadGenerationRef.current;
       let cursor = gapEnd;
       let fetched = 0;
@@ -155,9 +164,12 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
         // evicted the instant it arrives. Stop paging backward instead of
         // fetching chunks only to discard them (#313). The skipped remainder
         // stays uncovered so it loads on demand once there is room.
-        const buf = bufferRef.current!;
-        if (buf.length >= maxSize && buf.oldestTs !== null && cursor < buf.oldestTs) {
-          break;
+        // User-initiated loads bypass this to fill the full range (#317).
+        if (!skipBufferFullBreak) {
+          const buf = bufferRef.current!;
+          if (buf.length >= maxSize && buf.oldestTs !== null && cursor < buf.oldestTs) {
+            break;
+          }
         }
         const limit = Math.min(HISTORY_CHUNK_SIZE, budget - fetched);
         const { entries, limitReached } = await fetchRange(gapStart, cursor, limit);
@@ -174,9 +186,10 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
         // Mark the range covered only once its rows are actually persisted. If
         // the cache write fails (e.g. IndexedDB quota), leaving coverage claiming
         // a range the cache can't serve surfaces later as a permanent gap (#317).
+        pendingStoreCountRef.current++;
         const stored = await cacheRef.current!.store(entries).then(
-          () => true,
-          () => false,
+          () => { pendingStoreCountRef.current--; return true; },
+          () => { pendingStoreCountRef.current--; return false; },
         );
         fetched += entries.length;
         const oldestTs = entries[entries.length - 1].ts;
@@ -201,14 +214,16 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
    * chunk, up to `budget` telegrams total. Older gaps (and the remainder of the
    * gap where the budget runs out) stay uncovered for on-demand loading, so a
    * load never blocks on more history than asked for (#284).
+   *
+   * `skipBufferFullBreak` is forwarded to `fetchGapProgressive` (#317).
    */
   const fillGapsBudgeted = useCallback(
-    async (startMs: number, endMs: number, budget: number) => {
+    async (startMs: number, endMs: number, budget: number, skipBufferFullBreak = false) => {
       const gen = loadGenerationRef.current;
       const gaps = coverageRef.current!.gaps(startMs, endMs);
       let remaining = budget;
       for (let i = gaps.length - 1; i >= 0 && remaining > 0; i--) {
-        remaining -= await fetchGapProgressive(gaps[i][0], gaps[i][1], remaining);
+        remaining -= await fetchGapProgressive(gaps[i][0], gaps[i][1], remaining, skipBufferFullBreak);
         // A buffer clear invalidated this load — don't start further gaps (#339).
         if (loadGenerationRef.current !== gen) return;
       }
@@ -217,9 +232,11 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
     [fetchGapProgressive, saveCoverage],
   );
 
-  /** Fills every uncovered sub-range of [startMs, endMs], bounded by the buffer size. */
+  /** Fills every uncovered sub-range of [startMs, endMs], bounded by the buffer size.
+   *  `skipBufferFullBreak` is forwarded to `fetchGapProgressive` (#317). */
   const fillGaps = useCallback(
-    (startMs: number, endMs: number) => fillGapsBudgeted(startMs, endMs, maxSize),
+    (startMs: number, endMs: number, skipBufferFullBreak = false) =>
+      fillGapsBudgeted(startMs, endMs, maxSize, skipBufferFullBreak),
     [fillGapsBudgeted, maxSize],
   );
 
@@ -248,7 +265,8 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
         // A buffer clear during the cache read invalidates this load (#339).
         if (loadGenerationRef.current !== gen) return;
         if (cached.length > 0 && mergeIntoBuffer(cached)) publish();
-        await fillGaps(startMs, endMs);
+        // User-initiated: bypass the full-buffer early break (#317).
+        await fillGaps(startMs, endMs, /* skipBufferFullBreak */ true);
       }),
     [runLoad, mergeIntoBuffer, publish, fillGaps],
   );
@@ -312,7 +330,11 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
       const pending = pendingRef.current;
       if (pending.length > 0) {
         pendingRef.current = [];
-        cacheRef.current!.store(pending).catch(() => {});
+        pendingStoreCountRef.current++;
+        cacheRef.current!.store(pending).then(
+          () => { pendingStoreCountRef.current--; saveCoverage(); },
+          () => { pendingStoreCountRef.current--; },
+        );
       }
       // A quiet-but-connected stream still covers the elapsed time.
       if (connectedRef.current) coverageRef.current!.extendLive(Date.now());
@@ -363,12 +385,16 @@ export function useTelegramCache(maxSize: number, restoreFromCache = true): Tele
       if (pendingRef.current.length >= FLUSH_BATCH_SIZE) {
         const batch = pendingRef.current;
         pendingRef.current = [];
-        cacheRef.current!.store(batch).catch(() => {});
+        pendingStoreCountRef.current++;
+        cacheRef.current!.store(batch).then(
+          () => { pendingStoreCountRef.current--; saveCoverage(); },
+          () => { pendingStoreCountRef.current--; },
+        );
       }
       if (pausedRef.current) setPausedCount(c => c + 1);
       else publish();
     },
-    [trackRemoved, publish],
+    [trackRemoved, publish, saveCoverage],
   );
 
   const setConnected = useCallback(

--- a/openspec/changes/archive/2026-07-29-async-buffer-gaps/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-29-async-buffer-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/archive/2026-07-29-async-buffer-gaps/design.md
+++ b/openspec/changes/archive/2026-07-29-async-buffer-gaps/design.md
@@ -1,0 +1,102 @@
+## Context
+
+See proposal.md for motivation. The Group Monitor's `useTelegramCache` hook
+orchestrates an in-memory buffer, an IndexedDB persistent cache, and a
+coverage-interval tracker. Two interacting problems cause permanent time gaps
+in the telegram timeline:
+
+1. **Coverage/cache desync** — When `fetchGapProgressive` fetches a chunk and
+   the IDB write fails (quota, browser hiccup), the coverage tracker is
+   correctly *not* updated for the chunk's range. However, when the backend
+   returns fewer rows than `limit` (i.e. `!limitReached`), the code
+   unconditionally marks `[gapStart, cursor]` as covered **gated only on
+   `stored`**. This part is actually correct per the current code. The real
+   desync surfaces in the *startup* path: `extendLive()` calls
+   `addCovered()` optimistically for every connected tick, and the periodic
+   flush persists coverage to `localStorage` even when the corresponding IDB
+   batch write hasn't completed yet. A crash or tab close between the
+   coverage save and the IDB commit leaves coverage claiming a range the
+   cache can't serve on next load.
+
+2. **Early break on full buffer** — `fetchGapProgressive` (line 159) breaks
+   out of the paging loop when `buf.length >= maxSize && cursor < buf.oldestTs`.
+   This was added in #313 to avoid fetching rows that are immediately evicted.
+   But when the *user* explicitly requests a history range (the "Load History"
+   dialog), the older portion of the requested range is silently abandoned and
+   left uncovered. On the next startup, the coverage tracker sees no gap
+   (live intervals may have been extended over it), so the user sees a
+   permanent hole in their timeline.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate permanent time gaps caused by desync between coverage state and
+  IDB cache contents.
+- Allow explicit `loadRange` calls to fill their full requested range even
+  when the buffer is at capacity, by continuing to fetch and cache (IDB) the
+  data even if the in-memory buffer evicts older rows.
+
+**Non-Goals:**
+- Changing the `#313` optimisation for the *automatic* startup gap fill;
+  that budget-capped path can still break early to keep startup cheap.
+- Reworking the IndexedDB storage layer or changing `idb-keyval`.
+- Addressing the separate `MAX_CACHE_SIZE` eviction cadence or IDB scan
+  performance.
+
+## Decisions
+
+### 1. Separate "user-initiated" from "automatic" gap fills
+
+**Decision:** Add a `skipBufferFullBreak` flag (or equivalent) to
+`fetchGapProgressive` that disables the early-exit-on-full-buffer check.
+`loadRange` (user-initiated) passes `true`; the startup hydration and
+reconnect paths pass `false` (default).
+
+**Rationale:** The #313 optimisation is correct for the startup path where
+we don't want to churn through rows only to evict them. But an explicit
+user load should honour the full range — the data goes into IDB even if
+it overflows the in-memory buffer. The in-memory buffer already handles
+eviction correctly via `TelegramBufferService.merge()`.
+
+**Alternative considered:** Removing the early break entirely. Rejected
+because startup would regress on low-power hosts (#284, #297).
+
+### 2. Await IDB writes before persisting coverage in the flush timer
+
+**Decision:** Gate the `saveCoverage()` call in the periodic flush on the
+IDB batch write having completed. Track a simple "dirty" flag: set when a
+`store()` call is in flight, clear on resolve. `saveCoverage()` skips when
+dirty.
+
+**Rationale:** The root cause of the crash-window desync: `saveCoverage()`
+runs on a 2 s timer; the `store()` it depends on is async and may not have
+finished. By deferring the coverage save until the pending IDB write
+resolves, a crash between the two can't leave orphaned coverage.
+
+**Alternative considered:** Writing coverage *inside* `store()`. Rejected
+because coverage logic is intentionally separated from the cache service.
+
+### 3. Mark empty ranges as covered only when they are truly DB-confirmed empty
+
+**Decision:** In `fetchGapProgressive`, when `entries.length === 0`, the
+range is genuinely empty in the backend — mark it covered unconditionally
+(the DB confirmed there's nothing there, so no IDB write is needed).
+
+**Rationale:** No change needed here; the current behavior is correct.
+An empty response from the backend means the time range has no telegrams,
+so marking it covered is safe regardless of IDB state.
+
+## Risks / Trade-offs
+
+- **Explicit loads on a full buffer fetch data that won't be visible:**
+  The user-initiated load will page through the full range and persist to
+  IDB, but the in-memory buffer will only show the newest `maxSize` rows.
+  Older rows are available on the next history load from cache.
+  → Acceptable: the user's intent is to load the range into persistent
+  storage; the buffer is a view window.
+
+- **Delayed coverage persistence increases the crash-gap window slightly:**
+  By waiting for IDB writes, a crash during the write leaves the range
+  uncovered (and thus re-fetched on next load) rather than falsely covered.
+  → This is the correct failure mode; re-fetching is cheaper than a
+  permanent gap.

--- a/openspec/changes/archive/2026-07-29-async-buffer-gaps/proposal.md
+++ b/openspec/changes/archive/2026-07-29-async-buffer-gaps/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The group monitor's background history loader can leave permanent un-fillable gaps in the telegram buffer and IndexedDB cache. This happens because the coverage service immediately marks intervals as covered before the corresponding telegrams are successfully written to IndexedDB, causing subsequent load attempts to skip them. Additionally, when the in-memory buffer reaches capacity, the history loader halts paging backward, preventing users from retrieving older data.
+
+## What Changes
+
+- **Synchronized Coverage Tracking**: Adjust the cache ingestion pipelines (both live WS stream and historical fetches) so that time intervals are only added to the coverage service (and saved to localStorage) after their database entries have successfully finished writing to IndexedDB.
+- **Robust History Paging**: Refactor the background history loader to ensure it continues paging and loading requested time ranges even when the in-memory buffer is full, correctly handling evictions to maintain the newest/oldest boundaries instead of breaking out early and leaving gaps.
+
+## Capabilities
+
+### New Capabilities
+
+- `async-buffer-gaps`: Specifies the correct asynchronous gap-fetching, cache synchronization, and buffer eviction behavior to prevent time gaps.
+
+### Modified Capabilities
+
+## Impact
+
+- `frontend/src/hooks/useTelegramCache.ts`: Central logic for WS connection state, pending writes, and gap filling.
+- `frontend/src/components/HistoryLoader.tsx` / `App.tsx`: Triggers for asynchronous loads.

--- a/openspec/changes/archive/2026-07-29-async-buffer-gaps/specs/async-buffer-gaps/spec.md
+++ b/openspec/changes/archive/2026-07-29-async-buffer-gaps/specs/async-buffer-gaps/spec.md
@@ -1,0 +1,23 @@
+## Purpose
+
+This capability defines the synchronization between the IndexedDB persistent telegram cache and the coverage tracking system, as well as the behavior of the background history loader under buffer capacity pressure.
+
+## ADDED Requirements
+
+### Requirement: Synchronized Cache Coverage Ingestion
+The system SHALL ensure that a time interval is marked as covered in the coverage tracker and persisted to local storage only after the telegrams within that interval have been successfully written to the IndexedDB persistent cache.
+
+#### Scenario: Successful database write
+- **WHEN** live or fetched telegrams are successfully written to the IndexedDB persistent cache
+- **THEN** the corresponding time range is marked as covered in the coverage tracker and saved to local storage
+
+#### Scenario: Failed database write
+- **WHEN** a batch of telegrams fails to write to the IndexedDB persistent cache
+- **THEN** the corresponding time range MUST NOT be marked as covered in the coverage tracker
+
+### Requirement: Continuous History Paging and Eviction
+The system SHALL continue paging backward and loading historical telegrams for a requested range even when the in-memory buffer is at maximum capacity. It must evict the oldest entries to maintain size limits while ensuring that the requested range is successfully filled and marked as covered.
+
+#### Scenario: Load range on full buffer
+- **WHEN** a user loads history for a specific range and the in-memory buffer is full
+- **THEN** the history loader continues fetching and merging all chunks for that range, evicting older/newer entries to stay within the buffer limit rather than breaking out early

--- a/openspec/changes/archive/2026-07-29-async-buffer-gaps/tasks.md
+++ b/openspec/changes/archive/2026-07-29-async-buffer-gaps/tasks.md
@@ -1,0 +1,18 @@
+## 1. Allow user-initiated loads to bypass the full-buffer early break
+
+- [x] 1.1 Add a `skipBufferFullBreak` parameter (default `false`) to `fetchGapProgressive` in `useTelegramCache.ts` and skip the `buf.length >= maxSize && cursor < buf.oldestTs` early break when it is `true`
+- [x] 1.2 Thread `skipBufferFullBreak` through `fillGapsBudgeted` and `fillGaps` so callers can opt in
+- [x] 1.3 Update `loadRange` to pass `skipBufferFullBreak: true` so explicit user loads page through the full range
+- [x] 1.4 Keep the startup hydration and reconnect paths passing `false` (existing behavior)
+
+## 2. Guard coverage persistence against incomplete IDB writes
+
+- [x] 2.1 Add a `pendingStoreCount` ref to `useTelegramCache` that tracks in-flight `cacheRef.current!.store()` calls (increment before, decrement in `.then`/`.catch`)
+- [x] 2.2 In the periodic flush timer, skip the `saveCoverage()` call when `pendingStoreCount > 0`
+- [x] 2.3 After the pending store resolves (count drops to 0), trigger a deferred `saveCoverage()` so coverage is persisted once the write completes
+
+## 3. Tests
+
+- [x] 3.1 Add a unit test for `fetchGapProgressive` confirming it continues paging when `skipBufferFullBreak` is `true` and the buffer is full
+- [x] 3.2 Add a unit test verifying that coverage is not saved while an IDB store is in flight
+- [x] 3.3 Add a unit test verifying that a failed IDB store does not mark the range as covered

--- a/openspec/specs/async-buffer-gaps/spec.md
+++ b/openspec/specs/async-buffer-gaps/spec.md
@@ -1,0 +1,23 @@
+## Purpose
+
+This capability defines the synchronization between the IndexedDB persistent telegram cache and the coverage tracking system, as well as the behavior of the background history loader under buffer capacity pressure.
+
+## Requirements
+
+### Requirement: Synchronized Cache Coverage Ingestion
+The system SHALL ensure that a time interval is marked as covered in the coverage tracker and persisted to local storage only after the telegrams within that interval have been successfully written to the IndexedDB persistent cache.
+
+#### Scenario: Successful database write
+- **WHEN** live or fetched telegrams are successfully written to the IndexedDB persistent cache
+- **THEN** the corresponding time range is marked as covered in the coverage tracker and saved to local storage
+
+#### Scenario: Failed database write
+- **WHEN** a batch of telegrams fails to write to the IndexedDB persistent cache
+- **THEN** the corresponding time range MUST NOT be marked as covered in the coverage tracker
+
+### Requirement: Continuous History Paging and Eviction
+The system SHALL continue paging backward and loading historical telegrams for a requested range even when the in-memory buffer is at maximum capacity. It must evict the oldest entries to maintain size limits while ensuring that the requested range is successfully filled and marked as covered.
+
+#### Scenario: Load range on full buffer
+- **WHEN** a user loads history for a specific range and the in-memory buffer is full
+- **THEN** the history loader continues fetching and merging all chunks for that range, evicting older/newer entries to stay within the buffer limit rather than breaking out early


### PR DESCRIPTION
Two interacting bugs caused un-fillable gaps in the telegram timeline:

1. **Early break on full buffer** — The background history loader broke out of the paging loop early when the in-memory buffer was at capacity, silently abandoning the older portion of user-requested ranges.

2. **Coverage/cache desync** — The periodic flush timer persisted coverage intervals to localStorage before the corresponding IndexedDB writes had completed. A crash or tab close in the window between the two left coverage claiming ranges the cache couldn't serve on the next load.

### Fixes

- Add `skipBufferFullBreak` flag to `fetchGapProgressive` so user-initiated `loadRange` calls page through the full requested range. Startup and reconnect paths keep the existing budget-capped early-break behavior (#313).
- Track in-flight IDB `store()` calls via `pendingStoreCountRef`; defer `saveCoverage()` while writes are pending and trigger it on completion.
- Update and add tests covering all three scenarios (18 tests pass).

Closes #317