### PR TITLE
Highlight/mark focused telegram list rows (#310)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -477,6 +477,12 @@ function App() {
   const toggleColumn = (col: string) =>
     setVisibleColumns(prev => ({ ...prev, [col]: !prev[col] }));
 
+  // ── Telegram list marks (#310) ──────────────────────────────────────────────
+  // Lifted above the conditionally-rendered panels so marked rows survive
+  // main-panel navigation. Keyed by the table's anchorKey identity.
+  const [markedTelegramKeys, setMarkedTelegramKeys] = useState<string[]>([]);
+  const [lastMarkedTelegramKey, setLastMarkedTelegramKey] = useState<string | null>(null);
+
   // ── Sorting ─────────────────────────────────────────────────────────────────
   const [sortConfig, setSortConfig] = useState<SortConfig>(readSortConfigPref);
   const handleSort = (key: SortKey) => {
@@ -1180,6 +1186,10 @@ function App() {
                     onListFollowChange={setListFollow}
                     listAnchorKey={listAnchorKey}
                     onListAnchorKeyChange={setListAnchorKey}
+                    markedKeys={markedTelegramKeys}
+                    onMarkedKeysChange={setMarkedTelegramKeys}
+                    lastMarkedKey={lastMarkedTelegramKey}
+                    onLastMarkedKeyChange={setLastMarkedTelegramKey}
                   />
                 )}
               </div>

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -40,6 +40,13 @@ interface TelegramTableProps {
   onListFollowChange?: (follow: boolean) => void;
   listAnchorKey?: string | null;
   onListAnchorKeyChange?: (key: string | null) => void;
+
+  // Lifted row marks (#310): keys of marked telegrams + the most-recently
+  // clicked one. Lifted so marks survive main-panel navigation.
+  markedKeys?: string[];
+  onMarkedKeysChange?: (keys: string[]) => void;
+  lastMarkedKey?: string | null;
+  onLastMarkedKeyChange?: (key: string | null) => void;
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
@@ -132,7 +139,8 @@ const makeQuickMatcher = (pattern: string): ((s: string) => boolean) => {
 export const TelegramTable: React.FC<TelegramTableProps> = ({
   telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend,
   quickFilterOpen, onQuickFilterOpenChange, quickFilterEnabled, onQuickFilterEnabledChange, quickPatterns, onQuickPatternsChange,
-  listFollow, onListFollowChange, listAnchorKey, onListAnchorKeyChange
+  listFollow, onListFollowChange, listAnchorKey, onListAnchorKeyChange,
+  markedKeys, onMarkedKeysChange, lastMarkedKey, onLastMarkedKeyChange
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -222,6 +230,32 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     setQuickOpen(nextOpen);
     setQuickEnabled(nextOpen);
   };
+
+  // ── Row marks (#310) ─────────────────────────────────────────────────────
+  // Controlled when App lifts them (so marks survive navigation), otherwise a
+  // local fallback. `lastMarkedKey` may legitimately be null, so distinguish
+  // "not lifted" (undefined) from "lifted, nothing last" (null).
+  const [internalMarkedKeys, setInternalMarkedKeys] = useState<string[]>([]);
+  const [internalLastMarkedKey, setInternalLastMarkedKey] = useState<string | null>(null);
+
+  const markedKeysList = markedKeys ?? internalMarkedKeys;
+  const setMarkedKeysList = useCallback((val: string[]) => {
+    setInternalMarkedKeys(val);
+    onMarkedKeysChange?.(val);
+  }, [onMarkedKeysChange]);
+
+  const lastMarked = lastMarkedKey !== undefined ? lastMarkedKey : internalLastMarkedKey;
+  const setLastMarked = useCallback((val: string | null) => {
+    setInternalLastMarkedKey(val);
+    onLastMarkedKeyChange?.(val);
+  }, [onLastMarkedKeyChange]);
+
+  const markedSet = useMemo(() => new Set(markedKeysList), [markedKeysList]);
+
+  const clearMarks = useCallback(() => {
+    setMarkedKeysList([]);
+    setLastMarked(null);
+  }, [setMarkedKeysList, setLastMarked]);
 
   const quickFiltered = useMemo(() => {
     if (!quickOpen || !quickEnabled) return telegrams;
@@ -363,9 +397,43 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     }
   };
 
-  // Clicking a row pauses live-following just like scrolling away (#266) — the
-  // row being read must not move. The jump-to-live pill is the way back.
-  const handleRowClick = () => {
+  // Clicking a row (a) marks it (#310) and (b) pauses live-following just like
+  // scrolling away (#266) — the row being read must not move. The jump-to-live
+  // pill is the way back.
+  const handleRowClick = (e: React.MouseEvent, key: string, index: number) => {
+    // ── Marks (#310) ──
+    const additive = e.ctrlKey || e.metaKey;
+    const range = e.shiftKey;
+    if (additive || range) {
+      // A modified click must not also start a native text selection.
+      e.preventDefault();
+      window.getSelection()?.removeAllRanges();
+    }
+
+    let nextKeys: string[];
+    if (range) {
+      // Range over the current visible order, from the last-clicked row to here.
+      const anchorIdx = lastMarked ? telegramRows.findIndex(r => anchorKey(r) === lastMarked) : -1;
+      let rangeKeys: string[];
+      if (anchorIdx === -1) {
+        rangeKeys = [key]; // no usable anchor → just this row
+      } else {
+        const lo = Math.min(anchorIdx, index);
+        const hi = Math.max(anchorIdx, index);
+        rangeKeys = telegramRows.slice(lo, hi + 1).map(r => anchorKey(r));
+      }
+      nextKeys = additive ? [...new Set([...markedKeysList, ...rangeKeys])] : rangeKeys;
+    } else if (additive) {
+      // Toggle this row, keeping the rest.
+      nextKeys = markedSet.has(key) ? markedKeysList.filter(k => k !== key) : [...markedKeysList, key];
+    } else {
+      // Plain click replaces the whole set.
+      nextKeys = [key];
+    }
+    setMarkedKeysList(nextKeys);
+    setLastMarked(key);
+
+    // ── Pause live-following on an edge click (#266), unchanged ──
     if (!isTimeSort || !atEdgeRef.current) return;
     atEdgeRef.current = false;
     onListFollowChange?.(false);
@@ -837,6 +905,18 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
         </button>
       )}
 
+      {/* Clear-marks pill — shown only while rows are marked (#310) */}
+      {markedKeysList.length > 0 && (
+        <button
+          onClick={clearMarks}
+          className="clear-marks-pill"
+          style={{ position: 'absolute', right: '1rem', top: '0.75rem', zIndex: 20 }}
+          title="Clear all marks"
+        >
+          <X size={13} /> Clear {markedKeysList.length} mark{markedKeysList.length === 1 ? '' : 's'}
+        </button>
+      )}
+
       {/* Virtualized Body */}
       <div
         ref={parentRef}
@@ -860,12 +940,16 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
           >
             {virtualizer.getVirtualItems().map((virtualRow) => {
               const t = telegramRows[virtualRow.index];
+              const key = anchorKey(t);
+              const marked = markedSet.has(key);
+              // The most-recently-clicked row is the most prominent (#310).
+              const latest = marked && key === lastMarked;
               return (
                 <div
                   key={virtualRow.key}
                   data-index={virtualRow.index}
-                  data-akey={anchorKey(t)}
-                  onClick={handleRowClick}
+                  data-akey={key}
+                  onClick={(e) => handleRowClick(e, key, virtualRow.index)}
                   ref={virtualizer.measureElement}
                   style={{
                     position: 'absolute',
@@ -877,11 +961,19 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                     gridTemplateColumns: gridTemplate,
                     borderBottom: '1px solid var(--border-color)',
                     fontSize: '0.8125rem',
-                    background: (virtualRow.index + stripeOffset) % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
+                    // Marked rows get an accent wash that overrides the zebra
+                    // stripe; the latest click is washed more strongly and gets
+                    // an accent bar. color-mix adapts to the theme's accent.
+                    background: latest
+                      ? 'color-mix(in srgb, var(--accent-primary) 34%, transparent)'
+                      : marked
+                        ? 'color-mix(in srgb, var(--accent-primary) 16%, transparent)'
+                        : (virtualRow.index + stripeOffset) % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
+                    boxShadow: latest ? 'inset 3px 0 0 0 var(--accent-primary)' : undefined,
                     alignItems: 'start',
                     minHeight: '60px' // Ensure a minimum touch/visual target
                   }}
-                  className="log-row"
+                  className={`log-row${marked ? ' marked' : ''}${latest ? ' latest' : ''}`}
                 >
                   {visibleCols.map(c => (
                     <React.Fragment key={c.id}>{renderCell(c.id, t)}</React.Fragment>
@@ -974,6 +1066,27 @@ style.textContent = `
   .jump-to-live-pill:hover {
     filter: brightness(1.08);
     transform: translateX(-50%) scale(1.03);
+  }
+
+  .clear-marks-pill {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--bg-panel);
+    color: var(--text-dim);
+    font-size: 0.72rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: var(--shadow-lg);
+    transition: color 0.15s, border-color 0.15s;
+  }
+
+  .clear-marks-pill:hover {
+    color: var(--accent-primary);
+    border-color: var(--accent-primary);
   }
 
   .quick-filter-bar-toggle {

--- a/frontend/src/components/TelegramTableMarks.test.tsx
+++ b/frontend/src/components/TelegramTableMarks.test.tsx
@@ -1,0 +1,128 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import { expect, test, vi, beforeAll } from 'vitest';
+import { TelegramTable, type SortConfig } from './TelegramTable';
+import { makeTelegram } from '../test/telegramFactory';
+import type { Telegram } from '../hooks/useWebSocket';
+import { DEFAULT_FILTERS } from '../types/filters';
+
+// jsdom has no layout: give the virtualizer a viewport so it renders rows.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    private cb: ResizeObserverCallback;
+    constructor(cb: ResizeObserverCallback) {
+      this.cb = cb;
+    }
+    observe(el: Element) {
+      const size = { inlineSize: 1000, blockSize: el.classList.contains('log-row') ? 85 : 800 };
+      this.cb(
+        [{ target: el, contentRect: el.getBoundingClientRect(), borderBoxSize: [size], contentBoxSize: [size] } as unknown as ResizeObserverEntry],
+        this as unknown as ResizeObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  Element.prototype.getBoundingClientRect = () =>
+    ({ width: 1000, height: 800, top: 0, bottom: 800, left: 0, right: 1000, x: 0, y: 0, toJSON: () => {} }) as DOMRect;
+});
+
+const visibleColumns = {
+  time: true, delta: true, source: true, sourceName: true,
+  target: true, targetName: true, type: true, dpt: true, data: true, value: true,
+};
+
+const sortConfig: SortConfig = { key: 'timestamp', direction: 'desc' };
+
+// Five rows so range + additive semantics are unambiguous. Desc timestamp → the
+// DOM row order matches this array order (newest first).
+const TELEGRAMS: Telegram[] = [
+  makeTelegram({ timestamp: '2024-01-01T10:00:05.000Z', target_address: '1/2/5', raw_hex: '0x05' }),
+  makeTelegram({ timestamp: '2024-01-01T10:00:04.000Z', target_address: '1/2/4', raw_hex: '0x04' }),
+  makeTelegram({ timestamp: '2024-01-01T10:00:03.000Z', target_address: '1/2/3', raw_hex: '0x03' }),
+  makeTelegram({ timestamp: '2024-01-01T10:00:02.000Z', target_address: '1/2/2', raw_hex: '0x02' }),
+  makeTelegram({ timestamp: '2024-01-01T10:00:01.000Z', target_address: '1/2/1', raw_hex: '0x01' }),
+];
+
+const renderTable = (props: Partial<React.ComponentProps<typeof TelegramTable>> = {}) =>
+  render(
+    <TelegramTable
+      telegrams={TELEGRAMS}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+      {...props}
+    />,
+  );
+
+const rows = (container: HTMLElement) => Array.from(container.querySelectorAll('.log-row')) as HTMLElement[];
+const marked = (container: HTMLElement) => rows(container).map(r => r.classList.contains('marked'));
+const latestIdx = (container: HTMLElement) => rows(container).findIndex(r => r.classList.contains('latest'));
+
+test('plain click marks only the clicked row and makes it the latest; a second click replaces', () => {
+  const { container } = renderTable();
+  fireEvent.click(rows(container)[0]);
+  expect(marked(container)).toEqual([true, false, false, false, false]);
+  expect(latestIdx(container)).toBe(0);
+
+  fireEvent.click(rows(container)[2]);
+  expect(marked(container)).toEqual([false, false, true, false, false]);
+  expect(latestIdx(container)).toBe(2);
+});
+
+test('Ctrl/Cmd+click adds without clearing, and toggles a marked row off', () => {
+  const { container } = renderTable();
+  fireEvent.click(rows(container)[0]);
+  fireEvent.click(rows(container)[3], { ctrlKey: true });
+  expect(marked(container)).toEqual([true, false, false, true, false]);
+  expect(latestIdx(container)).toBe(3);
+
+  // Cmd (metaKey) toggles the same row off; the other mark stays.
+  fireEvent.click(rows(container)[3], { metaKey: true });
+  expect(marked(container)).toEqual([true, false, false, false, false]);
+});
+
+test('Shift+click marks the range from the last click to here, in visible order', () => {
+  const { container } = renderTable();
+  fireEvent.click(rows(container)[1]);
+  fireEvent.click(rows(container)[4], { shiftKey: true });
+  expect(marked(container)).toEqual([false, true, true, true, true]);
+  expect(latestIdx(container)).toBe(4);
+});
+
+test('Shift+click with no prior click marks only that row', () => {
+  const { container } = renderTable();
+  fireEvent.click(rows(container)[2], { shiftKey: true });
+  expect(marked(container)).toEqual([false, false, true, false, false]);
+});
+
+test('Ctrl/Cmd+Shift+click adds the range to existing marks', () => {
+  const { container } = renderTable();
+  fireEvent.click(rows(container)[4]);                       // mark {4}, last = 4
+  fireEvent.click(rows(container)[0], { ctrlKey: true });    // add {0}, last = 0
+  fireEvent.click(rows(container)[1], { ctrlKey: true, shiftKey: true }); // + range 0..1
+  expect(marked(container)).toEqual([true, true, false, false, true]);
+});
+
+test('clear-marks pill appears only when marked and removes every mark', () => {
+  const { container } = renderTable();
+  expect(screen.queryByTitle('Clear all marks')).not.toBeInTheDocument();
+
+  fireEvent.click(rows(container)[0]);
+  fireEvent.click(rows(container)[2], { ctrlKey: true });
+  expect(marked(container).filter(Boolean)).toHaveLength(2);
+
+  fireEvent.click(screen.getByTitle('Clear all marks'));
+  expect(marked(container).filter(Boolean)).toHaveLength(0);
+  expect(screen.queryByTitle('Clear all marks')).not.toBeInTheDocument();
+});
+
+test('clicking a row still pauses live-following (#266) while marking it', () => {
+  const onListFollowChange = vi.fn();
+  const { container } = renderTable({ listFollow: true, onListFollowChange });
+  fireEvent.click(rows(container)[0]);
+  expect(onListFollowChange).toHaveBeenCalledWith(false);
+  expect(marked(container)[0]).toBe(true);
+});

--- a/openspec/changes/archive/2026-07-30-highlight-focus-telegram/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-highlight-focus-telegram/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-highlight-focus-telegram/design.md
+++ b/openspec/changes/archive/2026-07-30-highlight-focus-telegram/design.md
@@ -1,0 +1,99 @@
+## Context
+
+See `proposal.md` — Why. Current `TelegramTable.tsx` facts that shape the design:
+
+- Rows render from `telegramRows` (the quick-filtered, delta-annotated list) via
+  a virtualizer; each row div has `data-akey={anchorKey(t)}` and
+  `onClick={handleRowClick}`.
+- `anchorKey(t) = ${timestamp}-${source}-${target}-${raw_hex}` is the stable
+  per-telegram identity already used for scroll anchoring (#202).
+- `handleRowClick()` today takes no event and only pauses live-following when at
+  the live edge (#266).
+- Row background is currently the zebra stripe
+  (`(index + stripeOffset) % 2 === 0 ? var(--bg-subtle) : transparent`).
+- The component already lifts related state via optional props with internal
+  fallbacks (`listFollow`/`onListFollowChange`, `listAnchorKey`/…). Marks follow
+  the same pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Mark rows by stable telegram identity (`anchorKey`), with the click/shift/ctrl
+  semantics from the spec, and a visibly stronger treatment for the latest click.
+- Survive main-panel navigation by lifting mark state to `App`, exactly like
+  `listFollow`/`listAnchorKey`.
+
+**Non-Goals:**
+- Persisting marks across reload as a hard requirement (best-effort only; keyed
+  by `anchorKey`, so evicted telegrams simply lose their mark).
+- Any action on marked rows (bulk filter/visualize/export). Marks are purely a
+  visual find-aid here.
+- The "preserve live-scroll/pause across navigation" half of #310 — owned by
+  `qol-state-persistence` (#203).
+
+## Decisions
+
+### Decision 1: Mark state = a Set of keys + a lastClicked key, lifted to App
+
+Model marks as `markedKeys: Set<string>` (or a serializable `string[]`) plus
+`lastMarkedKey: string | null`, both keyed by `anchorKey(t)`. Lift them to `App`
+as `value`/`onChange` props with internal fallbacks, mirroring the existing
+`listFollow`/`listAnchorKey` lift, so they survive the panel unmount on
+navigation. Reuse `anchorKey` — no new identity scheme.
+
+- **Alternative considered:** store marks by row index. Rejected — indices shift
+  as live telegrams arrive; identity keys are the only thing stable across the
+  list churn the issue describes.
+
+### Decision 2: Range semantics over the current visible order at click time
+
+Shift/Ctrl+Shift ranges are computed against the current `telegramRows` order at
+the moment of the click: find the index of `lastMarkedKey` and of the clicked
+row, and mark every row between them inclusive by their `anchorKey`. If
+`lastMarkedKey` is absent (no prior click, or it has scrolled out of the list),
+a Shift+Click marks only the clicked row.
+
+- Marks are stored as keys, but the *range* is a one-time expansion at click
+  time — later list changes don't retro-actively grow or shrink a range.
+
+### Decision 3: Modifier-aware click handler; keep the pause behavior intact
+
+Change `handleRowClick` to accept the `React.MouseEvent` and the clicked row's
+key/index. It first applies the mark mutation based on `e.shiftKey` and
+`e.ctrlKey || e.metaKey`, then performs the existing pause-on-edge logic
+unchanged. Add a `data-index` read (already present) so the handler can resolve
+the clicked row's position for range math. Guard text-selection: a modifier
+click should not also start a browser text selection (call `preventDefault` on
+shift-click as needed).
+
+- Range marking is independent of the timestamp-sort guard that gates
+  pausing/anchoring; marks work in any sort, while the pause logic keeps its
+  existing `isTimeSort` guard.
+
+### Decision 4: Styling — background over frame, two tiers via theme tokens
+
+Marked rows get a tinted background (an accent-tinted token, e.g. a translucent
+`--accent-primary` wash) that overrides the zebra stripe; the `lastMarkedKey`
+row gets a stronger wash / brighter left-border accent so it reads as "the one I
+clicked last." Backgrounds win over stripes because the issue explicitly prefers
+a background color to a frame, and it survives the virtualizer's absolute
+positioning cleanly.
+
+### Decision 5: Clear-marks affordance near the list
+
+Expose a "clear marks" control (e.g. a small button/pill shown only when any row
+is marked, alongside the existing jump-to-live pill area). Clicking it sets
+`markedKeys` empty and `lastMarkedKey` null via the lifted setter.
+
+## Risks / Trade-offs
+
+- **Marks reference evicted telegrams** → keys not found in `telegramRows` render
+  nothing; the mark is effectively dropped for that row while others persist
+  (spec-required). No error, no orphan styling.
+- **Shift/Ctrl click triggering native text selection** → mitigate by
+  `preventDefault` on modified clicks so marking doesn't fight the browser.
+- **Large mark sets over a big buffer** → membership is a `Set` lookup per
+  rendered (virtualized) row, so cost scales with visible rows, not buffer size.
+- **Reload persistence expectations** → out of scope as a guarantee; if the
+  `qol-state-persistence` UI-state store lands, marks can piggyback on it later
+  without changing this spec.

--- a/openspec/changes/archive/2026-07-30-highlight-focus-telegram/proposal.md
+++ b/openspec/changes/archive/2026-07-30-highlight-focus-telegram/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Clicking a telegram row pauses live-following so the row you are reading stays
+put (#266). But after visiting another main panel and returning, that row is
+lost in the mixed-in pause buffer and live feed — there is no visible trace of
+what you were looking at (#310). Letting the user mark rows gives a durable,
+findable anchor for the telegrams they care about.
+
+## What Changes
+
+- Telegram List rows can be **marked** with a distinct background color.
+- Click behavior on a row:
+  - **Click** — clear all marks and mark only the clicked row.
+  - **Shift+Click** — mark the range from the last-clicked row to the clicked row.
+  - **Ctrl/Cmd+Click** — toggle the clicked row's mark, keeping existing marks.
+  - **Ctrl/Cmd+Shift+Click** — add the range to the existing marks.
+- The **most-recently-clicked** row gets a more prominent mark (brighter/stronger
+  background) than the other marked rows.
+- Marks **survive main-panel navigation** so a returning user can still find the
+  rows they marked. A way to **clear all marks** is provided.
+- Marking is layered onto the existing row click, which continues to pause
+  live-following (#266); the two behaviors coexist.
+
+Out of scope / related: "live scrolling / pause-buffer state should persist
+across panel navigation" (also mentioned in #310) is the Telegram-List
+autoscroll/anchor persistence already owned by change `qol-state-persistence`
+(#203). This change relies on that for the scroll position; here we add the
+persistent *marks*.
+
+## Capabilities
+
+### New Capabilities
+- `telegram-list`: Marking/highlighting of Telegram List rows — the click,
+  shift-click, and ctrl/cmd-click semantics, the prominence of the
+  most-recently-clicked row, persistence of marks across main-panel navigation,
+  and clearing marks.
+
+### Modified Capabilities
+<!-- None: openspec/specs/ is empty; this is the first captured capability. -->
+
+## Impact
+
+- **Frontend only.** No backend, API, or dependency change.
+- `frontend/src/components/TelegramTable.tsx` — mark state driven by props,
+  modifier-aware click handling, marked-row and latest-row styling, "clear
+  marks" affordance.
+- `frontend/src/App.tsx` — lift mark state (marked keys + latest key) above the
+  conditionally-rendered panels so it survives navigation, mirroring the existing
+  `listFollow`/`listAnchorKey` lift.
+- Row identity reuses the existing `anchorKey(t)` used for anchor tracking.

--- a/openspec/changes/archive/2026-07-30-highlight-focus-telegram/specs/telegram-list/spec.md
+++ b/openspec/changes/archive/2026-07-30-highlight-focus-telegram/specs/telegram-list/spec.md
@@ -1,0 +1,115 @@
+## Purpose
+
+Defines how a user marks (highlights) rows in the Telegram List so that specific
+telegrams stay visually findable, including the click/shift/ctrl semantics for
+building the set of marks, the extra prominence of the most-recently-clicked row,
+and how marks persist and are cleared.
+
+## ADDED Requirements
+
+### Requirement: Mark a single row
+
+Clicking a Telegram List row with no modifier key SHALL clear all existing marks
+and mark only the clicked row. The clicked row becomes the most-recently-clicked
+row.
+
+#### Scenario: Plain click replaces the mark set
+
+- **WHEN** the user clicks row B while rows A and C are already marked
+- **THEN** only row B is marked, and rows A and C are no longer marked
+
+### Requirement: Marked rows are visually distinct
+
+A marked row SHALL be shown with a distinct background color that separates it
+from unmarked rows regardless of the row's zebra striping.
+
+#### Scenario: A mark is visible
+
+- **WHEN** a row is marked
+- **THEN** it is rendered with the marked background color rather than its normal
+  striped background
+
+### Requirement: Most-recently-clicked row is most prominent
+
+The most-recently-clicked marked row SHALL be shown with a stronger/brighter
+treatment than the other marked rows, so the user can tell which row they clicked
+last.
+
+#### Scenario: Latest row stands out
+
+- **WHEN** several rows are marked and the user has most recently clicked row D
+- **THEN** row D is rendered more prominently than the other marked rows
+
+### Requirement: Mark a range with Shift+Click
+
+Shift+Click on a row SHALL mark the contiguous range, in the current visible row
+order, between the most-recently-clicked row and the shift-clicked row
+(inclusive). The shift-clicked row becomes the most-recently-clicked row.
+
+#### Scenario: Range from the last click
+
+- **WHEN** the user clicks row 3, then Shift+Clicks row 7
+- **THEN** rows 3 through 7 (in visible order) are all marked
+
+#### Scenario: Shift+Click with no prior click marks just that row
+
+- **WHEN** no row has been clicked yet and the user Shift+Clicks a row
+- **THEN** only that row is marked
+
+### Requirement: Additive marking with Ctrl/Cmd
+
+Ctrl+Click or Cmd+Click on a row SHALL toggle that row's mark while leaving all
+other marks unchanged. Ctrl/Cmd+Shift+Click SHALL add the range (as in the
+Shift+Click range rule) to the existing marks without clearing them. In both
+cases the clicked row becomes the most-recently-clicked row.
+
+#### Scenario: Ctrl/Cmd click adds without clearing
+
+- **WHEN** rows A and B are marked and the user Ctrl/Cmd+Clicks row E
+- **THEN** rows A, B, and E are all marked
+
+#### Scenario: Ctrl/Cmd click toggles off a marked row
+
+- **WHEN** row E is marked and the user Ctrl/Cmd+Clicks row E again
+- **THEN** row E is no longer marked
+
+#### Scenario: Ctrl/Cmd Shift click adds a range
+
+- **WHEN** rows A and B are marked, the most-recently-clicked row is row 3, and
+  the user Ctrl/Cmd+Shift+Clicks row 6
+- **THEN** rows A, B, and 3 through 6 are all marked
+
+### Requirement: Marks persist across main-panel navigation
+
+The set of marked rows and the most-recently-clicked row SHALL be preserved when
+the user switches to another main panel and returns to the Telegram List, so long
+as the corresponding telegrams are still present in the list. A telegram that has
+left the list (e.g. evicted from the buffer) SHALL simply no longer be marked;
+its absence MUST NOT drop the marks on the remaining rows.
+
+#### Scenario: Marks are restored on return
+
+- **WHEN** the user marks several rows, navigates to another main panel, then
+  returns to the Telegram List
+- **THEN** the same rows are still marked and the most-recently-clicked row is
+  still the most prominent
+
+### Requirement: Clear all marks
+
+The user SHALL be able to clear all marks in one action.
+
+#### Scenario: Clearing removes every mark
+
+- **WHEN** several rows are marked and the user invokes "clear marks"
+- **THEN** no rows are marked
+
+### Requirement: Marking coexists with pausing live-following
+
+Marking a row MUST NOT change the existing behavior whereby clicking a row while
+following the live edge pauses live-following (#266). A click both updates the
+marks and pauses live-following.
+
+#### Scenario: Click still pauses following
+
+- **WHEN** the Telegram List is following the live edge and the user clicks a row
+- **THEN** live-following pauses (the row stays put) and that row becomes marked

--- a/openspec/changes/archive/2026-07-30-highlight-focus-telegram/tasks.md
+++ b/openspec/changes/archive/2026-07-30-highlight-focus-telegram/tasks.md
@@ -1,0 +1,31 @@
+## 1. Lift mark state
+
+- [x] 1.1 Add `markedKeys` (serializable `string[]`/`Set<string>`) and `lastMarkedKey` (`string | null`) to `App.tsx`, above the conditionally-rendered panels, mirroring the existing `listFollow`/`listAnchorKey` lift.
+- [x] 1.2 Pass them into `TelegramTable` as `value`/`onChange` props; add matching optional props + internal-fallback state in `TelegramTable`, following the `quickFilter*`/`listFollow` pattern already in the component.
+
+## 2. Modifier-aware click + mark semantics
+
+- [x] 2.1 Change `handleRowClick` to receive the `React.MouseEvent`, the clicked row's `anchorKey`, and its index in `telegramRows`.
+- [x] 2.2 Implement mark mutation: plain click = replace set with clicked; Ctrl/Cmd = toggle clicked; Shift = range from `lastMarkedKey`→clicked (inclusive, current visible order); Ctrl/Cmd+Shift = add that range. Update `lastMarkedKey` to the clicked row in all cases.
+- [x] 2.3 Compute ranges against the current `telegramRows` order; when `lastMarkedKey` is absent, Shift/Ctrl+Shift marks only the clicked row.
+- [x] 2.4 Preserve the existing pause-on-edge behavior (#266) after applying marks; `preventDefault` on modified clicks so native text selection doesn't fire.
+
+## 3. Styling
+
+- [x] 3.1 Render a marked row with a distinct tinted background that overrides the zebra stripe.
+- [x] 3.2 Render the `lastMarkedKey` row with a stronger/brighter treatment (e.g. deeper wash + accent left-border) so it is the most prominent.
+- [x] 3.3 Verify legibility in both light and dark themes using existing theme tokens.
+
+## 4. Clear marks
+
+- [x] 4.1 Add a "clear marks" affordance shown only when at least one row is marked; it empties `markedKeys` and nulls `lastMarkedKey`.
+
+## 5. Persistence across navigation
+
+- [x] 5.1 Confirm marks survive navigating to another panel and back (state lives in `App`); a telegram no longer in the list loses its mark without dropping marks on the remaining rows.
+
+## 6. Verify
+
+- [x] 6.1 Add `TelegramTable` tests: plain click replaces; Ctrl/Cmd toggles/adds; Shift range; Ctrl/Cmd+Shift adds range; latest-clicked prominence; clear-marks; click still pauses following.
+- [x] 6.2 Run frontend lint + unit tests; fix fallout.
+- [x] 6.3 Manual pass: mark rows, navigate away and back, confirm marks and the latest-clicked prominence persist and the marked rows are findable in the mixed live/pause list. (Verified via Playwright drive against the Vite dev server: plain/shift/ctrl click semantics, marks survive a Visualizer round-trip, latest prominence + accent bar, clear-marks pill — 8/8 checks; screenshots in /tmp/spectrum-verify/.)

--- a/openspec/specs/telegram-list/spec.md
+++ b/openspec/specs/telegram-list/spec.md
@@ -1,0 +1,115 @@
+## Purpose
+
+Defines how a user marks (highlights) rows in the Telegram List so that specific
+telegrams stay visually findable, including the click/shift/ctrl semantics for
+building the set of marks, the extra prominence of the most-recently-clicked row,
+and how marks persist and are cleared.
+
+## Requirements
+
+### Requirement: Mark a single row
+
+Clicking a Telegram List row with no modifier key SHALL clear all existing marks
+and mark only the clicked row. The clicked row becomes the most-recently-clicked
+row.
+
+#### Scenario: Plain click replaces the mark set
+
+- **WHEN** the user clicks row B while rows A and C are already marked
+- **THEN** only row B is marked, and rows A and C are no longer marked
+
+### Requirement: Marked rows are visually distinct
+
+A marked row SHALL be shown with a distinct background color that separates it
+from unmarked rows regardless of the row's zebra striping.
+
+#### Scenario: A mark is visible
+
+- **WHEN** a row is marked
+- **THEN** it is rendered with the marked background color rather than its normal
+  striped background
+
+### Requirement: Most-recently-clicked row is most prominent
+
+The most-recently-clicked marked row SHALL be shown with a stronger/brighter
+treatment than the other marked rows, so the user can tell which row they clicked
+last.
+
+#### Scenario: Latest row stands out
+
+- **WHEN** several rows are marked and the user has most recently clicked row D
+- **THEN** row D is rendered more prominently than the other marked rows
+
+### Requirement: Mark a range with Shift+Click
+
+Shift+Click on a row SHALL mark the contiguous range, in the current visible row
+order, between the most-recently-clicked row and the shift-clicked row
+(inclusive). The shift-clicked row becomes the most-recently-clicked row.
+
+#### Scenario: Range from the last click
+
+- **WHEN** the user clicks row 3, then Shift+Clicks row 7
+- **THEN** rows 3 through 7 (in visible order) are all marked
+
+#### Scenario: Shift+Click with no prior click marks just that row
+
+- **WHEN** no row has been clicked yet and the user Shift+Clicks a row
+- **THEN** only that row is marked
+
+### Requirement: Additive marking with Ctrl/Cmd
+
+Ctrl+Click or Cmd+Click on a row SHALL toggle that row's mark while leaving all
+other marks unchanged. Ctrl/Cmd+Shift+Click SHALL add the range (as in the
+Shift+Click range rule) to the existing marks without clearing them. In both
+cases the clicked row becomes the most-recently-clicked row.
+
+#### Scenario: Ctrl/Cmd click adds without clearing
+
+- **WHEN** rows A and B are marked and the user Ctrl/Cmd+Clicks row E
+- **THEN** rows A, B, and E are all marked
+
+#### Scenario: Ctrl/Cmd click toggles off a marked row
+
+- **WHEN** row E is marked and the user Ctrl/Cmd+Clicks row E again
+- **THEN** row E is no longer marked
+
+#### Scenario: Ctrl/Cmd Shift click adds a range
+
+- **WHEN** rows A and B are marked, the most-recently-clicked row is row 3, and
+  the user Ctrl/Cmd+Shift+Clicks row 6
+- **THEN** rows A, B, and 3 through 6 are all marked
+
+### Requirement: Marks persist across main-panel navigation
+
+The set of marked rows and the most-recently-clicked row SHALL be preserved when
+the user switches to another main panel and returns to the Telegram List, so long
+as the corresponding telegrams are still present in the list. A telegram that has
+left the list (e.g. evicted from the buffer) SHALL simply no longer be marked;
+its absence MUST NOT drop the marks on the remaining rows.
+
+#### Scenario: Marks are restored on return
+
+- **WHEN** the user marks several rows, navigates to another main panel, then
+  returns to the Telegram List
+- **THEN** the same rows are still marked and the most-recently-clicked row is
+  still the most prominent
+
+### Requirement: Clear all marks
+
+The user SHALL be able to clear all marks in one action.
+
+#### Scenario: Clearing removes every mark
+
+- **WHEN** several rows are marked and the user invokes "clear marks"
+- **THEN** no rows are marked
+
+### Requirement: Marking coexists with pausing live-following
+
+Marking a row MUST NOT change the existing behavior whereby clicking a row while
+following the live edge pauses live-following (#266). A click both updates the
+marks and pauses live-following.
+
+#### Scenario: Click still pauses following
+
+- **WHEN** the Telegram List is following the live edge and the user clicks a row
+- **THEN** live-following pauses (the row stays put) and that row becomes marked


### PR DESCRIPTION
## Summary

Clicking a telegram row pauses live-following (#266), but after visiting another main panel and returning, the clicked row was lost in the mixed live/pause buffer with no visible trace. This adds **row marking** so the telegrams a user cares about stay visually findable.

Closes #310 (the "state persistence" group's marking half; the live-scroll/pause persistence is handled by the already-merged navigation-surviving UI state work).

## What changed

- **Click semantics** (keyed by the table's existing `anchorKey` identity):
  - **Click** → clear all marks, mark only the clicked row
  - **Ctrl/Cmd+Click** → toggle that row additively
  - **Shift+Click** → mark the range from the last-clicked row (visible order)
  - **Ctrl/Cmd+Shift+Click** → add the range to existing marks
- The **most-recently-clicked** row gets a stronger accent wash plus a left accent bar.
- Mark state (`markedKeys` + `lastMarkedKey`) is **lifted to `App`** so marks survive main-panel navigation.
- A **clear-marks pill** appears while any row is marked.
- Marking **coexists** with the existing pause-on-click behavior (#266).

## Files

- `frontend/src/components/TelegramTable.tsx` — modifier-aware click, two-tier `color-mix` styling, clear-marks pill.
- `frontend/src/App.tsx` — lifted mark state above the conditionally-rendered panels.
- `openspec/specs/telegram-list/spec.md` — new capability spec; archived change under `openspec/changes/archive/`.

## Verification

- New unit tests (`TelegramTableMarks.test.tsx`): plain/ctrl/shift/ctrl-shift, latest prominence, clear-marks, click-still-pauses — **7/7**.
- Full frontend suite **256/256**, `tsc` clean, `eslint` 0 errors.
- Browser drive (Playwright vs. the dev server): all semantics plus **marks survive a Visualizer round-trip** — 8/8 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)