### PR TITLE
feat: allow DPT override in Write-to-Bus panel (#342)

### DIFF
--- a/frontend/src/components/WriteToBusPanel.test.tsx
+++ b/frontend/src/components/WriteToBusPanel.test.tsx
@@ -116,7 +116,7 @@ test('restores persisted rows on mount (#254)', () => {
   expect(gaInputs[1]).toHaveValue('4/5/6');
   expect(screen.getAllByPlaceholderText(/Value/)[0]).toHaveValue('21.5');
   expect(screen.getByDisplayValue('10')).toBeInTheDocument(); // "Every s" of row 2
-  expect(screen.getByText('DPT 9.001')).toBeInTheDocument();
+  expect(screen.getByDisplayValue('9.001')).toBeInTheDocument(); // editable DPT field of row 1
 });
 
 test('persists row edits so toggling the panel keeps them (#254)', async () => {

--- a/frontend/src/components/WriteToBusPanel.tsx
+++ b/frontend/src/components/WriteToBusPanel.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Send, Radio, X, Plus, AlertTriangle, CheckCircle2, Timer } from 'lucide-react';
+import { Send, Radio, X, Plus, AlertTriangle, CheckCircle2, Timer, RotateCcw } from 'lucide-react';
 
 import type { FilterOption } from '../types/filters';
 import {
   formatDpt,
+  parseDptMain,
   readTelegram,
   sendTelegram,
   startScheduledSend,
@@ -35,6 +36,14 @@ interface Row {
 
 const GA_RE = /^\d{1,2}\/\d{1,2}\/\d{1,3}$|^\d{1,2}\/\d{1,4}$|^\d{1,5}$/;
 const POLL_INTERVAL_MS = 1000;
+
+// Common DPTs offered as datalist hints when overriding a GA's type (#342).
+// The input stays free-text; these just guide the frequent cases.
+const COMMON_DPTS = [
+  '1.001', '1.002', '2.001', '3.007', '4.001', '5.001', '5.004', '5.010',
+  '6.010', '7.001', '8.001', '9.001', '9.004', '10.001', '11.001', '12.001',
+  '13.001', '14.056', '16.000', '17.001', '18.001', '19.001', '20.102', '232.600',
+];
 
 let rowSeq = 0;
 const newRow = (): Row => ({
@@ -109,6 +118,18 @@ export function WriteToBusPanel({ targets, onClose }: Props) {
     return m;
   }, [targets]);
 
+  // DPT hints for the editable DPT field (#342): common types plus every DPT
+  // present in the loaded project, sorted numerically by main then sub.
+  const dptOptions = useMemo(() => {
+    const set = new Set<string>(COMMON_DPTS);
+    for (const t of targets) if (t.main != null) set.add(formatDpt(t.main, t.sub));
+    return [...set].sort((a, b) => {
+      const [am, as = 0] = a.split('.').map(Number);
+      const [bm, bs = 0] = b.split('.').map(Number);
+      return am - bm || as - bs;
+    });
+  }, [targets]);
+
   const jobActive = job != null && (job.state === 'waiting' || job.state === 'running');
 
   // Pick up an already-active job (e.g. after a page reload) and clean up the poller.
@@ -145,6 +166,15 @@ export function WriteToBusPanel({ targets, onClose }: Props) {
       feedback: null,
       dpt: match && match.main != null ? formatDpt(match.main, match.sub) : '',
     });
+  };
+
+  // Editable DPT (#342): overriding the project default. When the DPT *main*
+  // changes the write widget switches (On/Off ↔ pickers ↔ free value), so a
+  // stale value must be cleared to avoid sending it to the new widget.
+  const onDptChange = (id: string, next: string) => {
+    const row = rows.find(r => r.id === id);
+    const mainChanged = row && parseDptMain(row.dpt) !== parseDptMain(next);
+    updateRow(id, { dpt: next, feedback: null, ...(mainChanged ? { value: '' } : {}) });
   };
 
   const write = async (row: Row, payload: boolean | number | string) => {
@@ -196,9 +226,18 @@ export function WriteToBusPanel({ targets, onClose }: Props) {
         </button>
       </div>
 
+      {/* DPT hints shared by every row's editable DPT field (#342) */}
+      <datalist id="wtb-dpt-options">
+        {dptOptions.map(d => <option key={d} value={d} />)}
+      </datalist>
+
       {rows.map(row => {
         const known = byAddress.get(row.address.trim());
-        const dptMain = known?.main ?? undefined;
+        // The write widget follows the row's *effective* (possibly overridden)
+        // DPT, not the project default (#342).
+        const dptMain = parseDptMain(row.dpt);
+        const projectDpt = known && known.main != null ? formatDpt(known.main, known.sub) : '';
+        const overridden = projectDpt !== '' && row.dpt.trim() !== projectDpt;
         const addressValid = GA_RE.test(row.address.trim());
         const scheduledDisabled = row.busy || !addressValid;
         return (
@@ -236,9 +275,34 @@ export function WriteToBusPanel({ targets, onClose }: Props) {
                   disabled={scheduledDisabled}
                 />
 
-                <span style={{ fontSize: '0.72rem', color: 'var(--text-dim)', fontFamily: "'JetBrains Mono', monospace", minWidth: '70px', display: 'inline-block' }}>
-                  DPT {row.dpt || '—'}
-                </span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                  <span style={{ fontSize: '0.72rem', color: 'var(--text-dim)' }}>DPT</span>
+                  <input
+                    className="glass-input"
+                    list="wtb-dpt-options"
+                    value={row.dpt}
+                    onChange={e => onDptChange(row.id, e.target.value)}
+                    placeholder="—"
+                    title={overridden ? `Overriding project DPT ${projectDpt}` : 'Datapoint type, e.g. 5.010 (defaults to the project DPT)'}
+                    style={{
+                      width: 78,
+                      padding: '0.2rem 0.35rem',
+                      fontFamily: "'JetBrains Mono', monospace",
+                      fontSize: '0.72rem',
+                      borderColor: overridden ? 'var(--accent-primary)' : undefined,
+                    }}
+                  />
+                  {overridden && (
+                    <button
+                      className="icon-button"
+                      onClick={() => updateRow(row.id, { dpt: projectDpt, value: '', feedback: null })}
+                      title={`Reset to project DPT ${projectDpt}`}
+                      style={{ color: 'var(--text-dim)', padding: '0.1rem' }}
+                    >
+                      <RotateCcw size={13} />
+                    </button>
+                  )}
+                </div>
 
                 <input
                   className="glass-input"

--- a/frontend/src/components/WriteToBusPanelDpt.test.tsx
+++ b/frontend/src/components/WriteToBusPanelDpt.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { WriteToBusPanel } from './WriteToBusPanel';
+
+// Editable DPT in the Send panel (#342).
+
+const IDLE = { state: 'idle' };
+
+// GA whose project DPT is 5.001 (0–100 %) — the #342 case: 128 is out of range
+// there, so the user must be able to override to 5.010 (0–255).
+const TARGETS = [{ address: '1/2/3', name: 'Dimmer', main: 5, sub: 1 }];
+
+function mockSend(routes: Record<string, unknown> = {}) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    void init;
+    if (url.includes('/api/knx/send/scheduled/status')) return { ok: true, json: async () => IDLE } as Response;
+    for (const [path, body] of Object.entries(routes)) {
+      if (url.includes(path)) return { ok: true, json: async () => body } as Response;
+    }
+    if (url.includes('/api/knx/send')) return { ok: true, json: async () => ({ status: 'sent' }) } as Response;
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+const dptInput = (c: HTMLElement) => c.querySelector('input[list="wtb-dpt-options"]') as HTMLInputElement;
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.stubGlobal('fetch', mockSend());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test('DPT prefills from the project when a GA is chosen', () => {
+  const { container } = render(<WriteToBusPanel targets={TARGETS} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  expect(dptInput(container)).toHaveValue('5.001');
+  // Not overridden yet → no reset affordance.
+  expect(screen.queryByTitle(/Reset to project DPT/)).not.toBeInTheDocument();
+});
+
+test('overriding the DPT changes the effective DPT and shows a reset affordance', () => {
+  const { container } = render(<WriteToBusPanel targets={TARGETS} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+
+  fireEvent.change(dptInput(container), { target: { value: '5.010' } });
+  expect(dptInput(container)).toHaveValue('5.010');
+  expect(screen.getByTitle('Reset to project DPT 5.001')).toBeInTheDocument();
+});
+
+test('the write widget follows the overridden DPT (main 5 → 1 renders On/Off)', () => {
+  const { container } = render(<WriteToBusPanel targets={TARGETS} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  // main 5 → free-value input
+  expect(screen.getByPlaceholderText(/Value/)).toBeInTheDocument();
+
+  fireEvent.change(dptInput(container), { target: { value: '1.001' } });
+  // main 1 → On/Off buttons, free-value input gone
+  expect(screen.getByRole('button', { name: /^On$/ })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /^Off$/ })).toBeInTheDocument();
+  expect(screen.queryByPlaceholderText(/Value/)).not.toBeInTheDocument();
+});
+
+test('changing the DPT main clears a stale value', () => {
+  const { container } = render(<WriteToBusPanel targets={TARGETS} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  fireEvent.change(screen.getByPlaceholderText(/Value/), { target: { value: '50' } });
+  expect(screen.getByPlaceholderText(/Value/)).toHaveValue('50');
+
+  // 5.001 → 9.001: main changes (5 → 9), still a free-value widget, value cleared.
+  fireEvent.change(dptInput(container), { target: { value: '9.001' } });
+  expect(screen.getByPlaceholderText(/Value/)).toHaveValue('');
+});
+
+test('sending uses the overridden DPT (the #342 case: 128 as 5.010)', async () => {
+  const fetchMock = mockSend({ '/api/knx/send': { status: 'sent' } });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { container } = render(<WriteToBusPanel targets={TARGETS} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  fireEvent.change(dptInput(container), { target: { value: '5.010' } });
+  fireEvent.change(screen.getByPlaceholderText(/Value/), { target: { value: '128' } });
+  fireEvent.click(screen.getByRole('button', { name: /Write/ }));
+
+  await waitFor(() => expect(screen.getByText(/Sent 128 to 1\/2\/3/)).toBeInTheDocument());
+  const sendCall = fetchMock.mock.calls.find(
+    ([u]) => String(u).includes('/api/knx/send') && !String(u).includes('scheduled'),
+  );
+  const body = JSON.parse((sendCall![1] as RequestInit).body as string);
+  expect(body).toMatchObject({ address: '1/2/3', payload: 128, dpt: '5.010' });
+});
+
+test('an unknown DPT surfaces the backend error inline', async () => {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/knx/send/scheduled/status')) return { ok: true, json: async () => IDLE } as Response;
+    if (url.includes('/api/knx/send')) {
+      return { ok: false, status: 400, json: async () => ({ detail: 'Unknown DPT type: 5.999' }) } as Response;
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal('fetch', fetchMock);
+
+  const { container } = render(<WriteToBusPanel targets={TARGETS} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  fireEvent.change(dptInput(container), { target: { value: '5.999' } });
+  fireEvent.change(screen.getByPlaceholderText(/Value/), { target: { value: '1' } });
+  fireEvent.click(screen.getByRole('button', { name: /Write/ }));
+
+  await waitFor(() => expect(screen.getByText(/Unknown DPT type: 5\.999/)).toBeInTheDocument());
+});
+
+test('reset restores the project DPT and drops the override', () => {
+  const { container } = render(<WriteToBusPanel targets={TARGETS} onClose={() => {}} />);
+  fireEvent.change(screen.getByPlaceholderText(/Group address/), { target: { value: '1/2/3' } });
+  fireEvent.change(dptInput(container), { target: { value: '5.010' } });
+
+  fireEvent.click(screen.getByTitle('Reset to project DPT 5.001'));
+  expect(dptInput(container)).toHaveValue('5.001');
+  expect(screen.queryByTitle(/Reset to project DPT/)).not.toBeInTheDocument();
+});

--- a/frontend/src/utils/knxSend.test.ts
+++ b/frontend/src/utils/knxSend.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { parseDptMain, formatDpt } from './knxSend';
+
+describe('parseDptMain', () => {
+  test('parses a full main.sub DPT', () => {
+    expect(parseDptMain('5.010')).toBe(5);
+    expect(parseDptMain('1.001')).toBe(1);
+    expect(parseDptMain('232.600')).toBe(232);
+  });
+
+  test('parses a bare main DPT', () => {
+    expect(parseDptMain('1')).toBe(1);
+    expect(parseDptMain('9')).toBe(9);
+  });
+
+  test('tolerates surrounding whitespace', () => {
+    expect(parseDptMain('  5.010 ')).toBe(5);
+  });
+
+  test('returns undefined for empty or malformed input', () => {
+    expect(parseDptMain('')).toBeUndefined();
+    expect(parseDptMain('   ')).toBeUndefined();
+    expect(parseDptMain('abc')).toBeUndefined();
+    expect(parseDptMain('5.')).toBeUndefined();
+    expect(parseDptMain('.1')).toBeUndefined();
+    expect(parseDptMain('5.x')).toBeUndefined();
+  });
+
+  test('is the inverse of formatDpt for the main part', () => {
+    expect(parseDptMain(formatDpt(5, 10))).toBe(5);
+    expect(parseDptMain(formatDpt(1))).toBe(1);
+  });
+});

--- a/frontend/src/utils/knxSend.ts
+++ b/frontend/src/utils/knxSend.ts
@@ -18,6 +18,17 @@ export function formatDpt(main?: number | null, sub?: number | null): string {
   return sub == null ? String(main) : `${main}.${String(sub).padStart(3, '0')}`;
 }
 
+/**
+ * Parse the main number out of a DPT string ("5.010" -> 5, "1" -> 1).
+ * Returns undefined for an empty or malformed value. Inverse of `formatDpt`;
+ * used to pick the write widget from the (possibly overridden) DPT (#342).
+ */
+export function parseDptMain(dpt: string): number | undefined {
+  const m = dpt.trim().match(/^(\d+)(?:\.\d+)?$/);
+  if (!m) return undefined;
+  return Number(m[1]);
+}
+
 async function post<T = unknown>(endpoint: string, body?: unknown): Promise<T> {
   const res = await fetch(apiUrl(endpoint), {
     method: 'POST',

--- a/openspec/changes/archive/2026-07-30-allow-change-of-dpt/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-allow-change-of-dpt/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-allow-change-of-dpt/design.md
+++ b/openspec/changes/archive/2026-07-30-allow-change-of-dpt/design.md
@@ -1,0 +1,96 @@
+## Context
+
+See `proposal.md` — Why. Current wiring in `WriteToBusPanel.tsx`:
+
+- Each `Row` already has a `dpt: string` field, persisted to localStorage and
+  passed to `sendTelegram(address, payload, row.dpt.trim() || undefined)` /
+  `startScheduledSend(...)`. **The send already uses `row.dpt`.**
+- `onAddressChange` prefills `row.dpt` from the project via
+  `formatDpt(match.main, match.sub)`.
+- The DPT is rendered read-only: `<span>DPT {row.dpt || '—'}</span>`.
+- `WriteControls` picks its widget from `dptMain`, but the panel passes
+  `dptMain={known?.main}` (the **project** main) and `dptKey={row.dpt || null}`.
+
+Backend (`_encode_payload` in `knx_daemon.py`) transcodes with `parse_transcoder(dpt)`
+using the caller's DPT verbatim and never consults the project. No backend change
+is needed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `row.dpt` user-editable and make the whole row (widget + send) driven by
+  it, with the project DPT as the default and a reset affordance.
+- Keep `WriteControls` untouched — feed it the effective DPT.
+
+**Non-Goals:**
+- Changing the DPT anywhere it is stored (project file, DB). The override is a
+  transient, per-row send-time choice only.
+- Other send surfaces (`SendToGaPopover`, Last Seen Values). Main panel only.
+- A DPT registry/validation UI. Validation stays where it is: the backend rejects
+  unknown DPTs and the panel shows the error inline.
+
+## Decisions
+
+### Decision 1: Derive the widget DPT from `row.dpt`, not the project main
+
+Replace `dptMain={known?.main}` with `dptMain={parseDptMain(row.dpt)}` and keep
+`dptKey={row.dpt || null}`. Add a small inverse-of-`formatDpt` helper:
+`parseDptMain("5.010") -> 5`, `parseDptMain("") -> undefined`. This makes the
+On/Off / time / date / free-value widget follow the override automatically, with
+zero change to `WriteControls`.
+
+- **Alternative considered:** thread a separate `effectiveDpt` prop. Rejected —
+  `row.dpt` already *is* the effective DPT once it's editable; a second source of
+  truth invites drift.
+
+### Decision 2: DPT editor is a free-text input with suggestions
+
+Replace the read-only DPT span with a small text input bound to `row.dpt`
+(`updateRow(id, { dpt, feedback: null })`), backed by a `<datalist>` of known
+DPTs assembled from `filterOptions.dpts` (and the common ones) for
+autocomplete-style hints.
+
+- **Why free text, not a fixed dropdown:** the valid DPT set is large and the
+  backend is the authority; a text input lets power users type any `main.sub`
+  while the datalist still guides the common cases. Typos fail loudly on send
+  (Decision 3), which is acceptable for a quick-test feature.
+- **Format hint only:** light client-side shape check (`^\d{1,3}(\.\d{1,3})?$`)
+  may style an obviously malformed entry, but MUST NOT block sending — the
+  backend remains the transcoding authority.
+
+### Decision 3: No client-side DPT validation gate
+
+When `row.dpt` is unknown/empty, do not pre-empt the send. Let the request go and
+render the backend's existing `400` detail in the row's `feedback` (the current
+error path already does this). This keeps one source of truth for what's
+transcodable and matches today's behavior for a mistyped value.
+
+### Decision 4: Reset via an affordance shown only when overridden
+
+Track the project default per row (already available as `known?.main/sub` →
+`formatDpt`). Show a small "reset to project DPT" control (e.g. a ↺ icon next to
+the DPT input) only when `row.dpt` differs from the project default and a project
+default exists. Reset sets `row.dpt` back to the project string.
+
+- "Overridden" is derived (`row.dpt !== projectDpt`), not a stored flag — no new
+  persisted state, and it survives reload correctly because both sides are
+  recomputed from `row.dpt` + `targets`.
+
+### Decision 5: Value handling when the widget type changes
+
+Changing the DPT can switch the widget (e.g. free-value → On/Off, or → time
+picker), leaving a now-meaningless `value`. On a DPT edit, clear `row.value` when
+the DPT *main* changes, so a stale string can't be sent to the new widget. Same
+row, same feedback-clear pattern already used elsewhere.
+
+## Risks / Trade-offs
+
+- **User enters a DPT that transcodes but is semantically wrong** → out of scope
+  to catch; this is a power-user quick-test tool, and the bus/device behavior is
+  the user's responsibility. The project default and reset make the safe path the
+  default.
+- **Datalist DPT list is incomplete** → it is a hint, not a constraint; free text
+  still accepts anything, so completeness is non-critical.
+- **Persisted override surprises a later user** → overrides already persist like
+  every other row input (#254); the visible reset affordance and the always-shown
+  project name make an override discoverable.

--- a/openspec/changes/archive/2026-07-30-allow-change-of-dpt/proposal.md
+++ b/openspec/changes/archive/2026-07-30-allow-change-of-dpt/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The DPT a GA carries in the ETS project is sometimes wrong. When it is, the Send
+panel prefills that wrong DPT, shows it read-only, and every send uses it — so a
+GA whose project DPT is `5.001` (0–100 %) rejects a value like `128`, and there
+is no way to send it. Today the only workaround is to fix the DPT in ETS, export
+the `.knxproj`, and re-import it into SpectrumKNX just for a quick test (#342).
+
+The wire path already supports this: `/api/knx/send` transcodes with exactly the
+DPT string the frontend sends and never re-consults the project. The project DPT
+is only used frontend-side to prefill the field. So the fix is purely a frontend
+one — make that prefilled DPT editable.
+
+## What Changes
+
+- In the main Send panel ("Write to bus"), the per-row **DPT becomes editable**.
+  The GA's project DPT remains the default; the user can override it for that row.
+- The write **input widget follows the effective (possibly overridden) DPT**, not
+  the project DPT: overriding to DPT 1 shows On/Off, DPT 10/11/19 show the
+  time/date pickers, others show the free-value input — matching how the panel
+  already adapts to a GA's DPT.
+- The send (immediate and scheduled) uses the **effective DPT**. An unknown/empty
+  DPT surfaces the backend's existing validation error inline, as today.
+- The override is per-row and persists with the existing row persistence; a way
+  to **reset a row back to its project DPT** is provided.
+
+## Capabilities
+
+### New Capabilities
+- `bus-write`: How the Send ("Write to bus") panel resolves the DPT used to
+  transcode a value — project default, user override, effect on the input widget,
+  and reset — plus the send behavior that already exists around it.
+
+### Modified Capabilities
+<!-- None: openspec/specs/ is empty; this is the first captured capability. -->
+
+## Impact
+
+- **Frontend only. No backend, API, or dependency change** — `/api/knx/send` and
+  `/api/knx/send/scheduled` already accept and honor an arbitrary `dpt` string.
+- `frontend/src/components/WriteToBusPanel.tsx` — replace the read-only DPT label
+  with an editable DPT control; derive the widget DPT from the row's DPT; add
+  reset-to-project.
+- `frontend/src/components/WriteControls.tsx` — no behavior change; it already
+  selects the widget from `dptMain`. It will simply receive the effective DPT.
+- Small DPT-string→main parse helper (inverse of `formatDpt`) in
+  `frontend/src/utils/knxSend.ts` (or `utils/dpt.ts`).
+- Out of scope: the other send surfaces (`SendToGaPopover`, Last Seen Values
+  write controls). This change targets the main Send panel only, per #342.

--- a/openspec/changes/archive/2026-07-30-allow-change-of-dpt/specs/bus-write/spec.md
+++ b/openspec/changes/archive/2026-07-30-allow-change-of-dpt/specs/bus-write/spec.md
@@ -1,0 +1,88 @@
+## Purpose
+
+Defines how the main Send ("Write to bus") panel determines the datapoint type
+(DPT) used to transcode a value before it is written to the KNX bus: the project
+default, the user's per-GA override, its effect on the value input, and how to
+return to the project default.
+
+## ADDED Requirements
+
+### Requirement: Project DPT is the default
+
+When a group address is chosen in a Send-panel row, the panel SHALL prefill the
+row's DPT from the loaded project's DPT for that group address, when the project
+defines one.
+
+#### Scenario: Prefill from project
+
+- **WHEN** the user selects a group address that has a DPT in the loaded project
+- **THEN** the row's DPT field shows that project DPT as its value
+
+#### Scenario: No project DPT
+
+- **WHEN** the user selects or types a group address that has no DPT in the
+  project
+- **THEN** the row's DPT field is empty and the user may enter one
+
+### Requirement: DPT is editable per row
+
+The Send panel SHALL let the user edit the DPT of a row, overriding the project
+default for that row. The effective DPT of a row is the user's override when set,
+otherwise the project default.
+
+#### Scenario: Override the project DPT
+
+- **WHEN** a row prefilled with project DPT `5.001` has its DPT changed to `5.010`
+- **THEN** the row's effective DPT is `5.010`
+
+#### Scenario: Override persists with the row
+
+- **WHEN** the user has overridden a row's DPT and the panel is toggled closed
+  and reopened
+- **THEN** the row's overridden DPT is still shown (it persists with the row's
+  other inputs)
+
+### Requirement: Input widget follows the effective DPT
+
+The row's value input widget SHALL be selected from the row's effective DPT, not
+the project DPT: DPT main 1 SHALL offer On/Off, DPT main 10/11/19 SHALL offer the
+time/date pickers, and any other (or empty) DPT SHALL offer the free-value input.
+
+#### Scenario: Widget switches when DPT is overridden
+
+- **WHEN** a row's DPT is changed from `5.010` to `1.001`
+- **THEN** the value control changes to the On/Off buttons for DPT 1
+
+#### Scenario: Widget reflects a date/time override
+
+- **WHEN** a row's DPT is set to `10.001`
+- **THEN** the value control becomes the time picker
+
+### Requirement: Send uses the effective DPT
+
+An immediate or scheduled send from a row SHALL transcode the value using the
+row's effective DPT. When the effective DPT is unknown or empty, the send SHALL
+surface the backend's validation error to the user inline, without silently
+falling back to the project DPT.
+
+#### Scenario: Send with an overridden DPT succeeds
+
+- **WHEN** the user overrides a GA's DPT to `5.010`, enters `128`, and writes
+- **THEN** the panel sends the value transcoded as DPT `5.010` (a value the
+  project's `5.001` would have rejected)
+
+#### Scenario: Unknown DPT reports an error
+
+- **WHEN** the user enters a DPT the backend cannot transcode and writes
+- **THEN** the row shows the backend's error message and no value is written
+
+### Requirement: Reset to the project DPT
+
+When a row's DPT has been overridden and the group address has a project DPT, the
+panel SHALL offer a way to reset the row's DPT back to the project default.
+
+#### Scenario: Reset restores the project DPT
+
+- **WHEN** the user resets a row whose DPT was overridden from project `5.001`
+- **THEN** the row's DPT field shows `5.001` again and the row is no longer
+  overridden

--- a/openspec/changes/archive/2026-07-30-allow-change-of-dpt/tasks.md
+++ b/openspec/changes/archive/2026-07-30-allow-change-of-dpt/tasks.md
@@ -1,0 +1,27 @@
+## 1. DPT parse helper
+
+- [x] 1.1 Add `parseDptMain(dpt: string): number | undefined` (inverse of `formatDpt`) in `frontend/src/utils/knxSend.ts` — `"5.010" -> 5`, `"1" -> 1`, `"" -> undefined`.
+- [x] 1.2 Unit-test `parseDptMain` (valid `main.sub`, bare main, empty, malformed).
+
+## 2. Editable DPT in the Send panel
+
+- [x] 2.1 In `WriteToBusPanel.tsx`, replace the read-only `DPT {row.dpt || '—'}` span with a text input bound to `row.dpt` via `updateRow(id, { dpt, feedback: null })`.
+- [x] 2.2 Add a `<datalist>` of known DPTs (from `filterOptions.dpts` plus common ones) to guide entry; keep input free-text (no hard gate).
+- [x] 2.3 On a DPT edit that changes the DPT *main*, clear `row.value` so a stale value can't be sent to the switched widget.
+- [x] 2.4 Pass `filterOptions`/`targets` DPT context into the panel as needed for the datalist.
+
+## 3. Drive the widget from the effective DPT
+
+- [x] 3.1 Change the `WriteControls` props from `dptMain={known?.main}` to `dptMain={parseDptMain(row.dpt)}`, keeping `dptKey={row.dpt || null}`. No change to `WriteControls` itself.
+- [x] 3.2 Verify On/Off (DPT 1), time/date pickers (10/11/19), and free-value (others) all follow an overridden `row.dpt`.
+
+## 4. Reset to project DPT
+
+- [x] 4.1 Compute the row's project DPT string from `known?.main/sub` via `formatDpt`; treat the row as "overridden" when `row.dpt !== projectDpt` and a project default exists.
+- [x] 4.2 Show a "reset to project DPT" affordance only when overridden; clicking it sets `row.dpt` back to the project string.
+
+## 5. Verify
+
+- [x] 5.1 Extend/add `WriteToBusPanel` tests: prefill from project; override changes effective DPT + widget; send posts the overridden DPT; unknown DPT surfaces the backend error inline; reset restores the project DPT.
+- [x] 5.2 Run frontend lint + unit tests; fix fallout.
+- [x] 5.3 Manual pass against the #342 case: GA with project DPT `5.001`, override to `5.010`, send `128`, confirm it is accepted.

--- a/openspec/specs/bus-write/spec.md
+++ b/openspec/specs/bus-write/spec.md
@@ -1,0 +1,88 @@
+## Purpose
+
+Defines how the main Send ("Write to bus") panel determines the datapoint type
+(DPT) used to transcode a value before it is written to the KNX bus: the project
+default, the user's per-GA override, its effect on the value input, and how to
+return to the project default.
+
+## Requirements
+
+### Requirement: Project DPT is the default
+
+When a group address is chosen in a Send-panel row, the panel SHALL prefill the
+row's DPT from the loaded project's DPT for that group address, when the project
+defines one.
+
+#### Scenario: Prefill from project
+
+- **WHEN** the user selects a group address that has a DPT in the loaded project
+- **THEN** the row's DPT field shows that project DPT as its value
+
+#### Scenario: No project DPT
+
+- **WHEN** the user selects or types a group address that has no DPT in the
+  project
+- **THEN** the row's DPT field is empty and the user may enter one
+
+### Requirement: DPT is editable per row
+
+The Send panel SHALL let the user edit the DPT of a row, overriding the project
+default for that row. The effective DPT of a row is the user's override when set,
+otherwise the project default.
+
+#### Scenario: Override the project DPT
+
+- **WHEN** a row prefilled with project DPT `5.001` has its DPT changed to `5.010`
+- **THEN** the row's effective DPT is `5.010`
+
+#### Scenario: Override persists with the row
+
+- **WHEN** the user has overridden a row's DPT and the panel is toggled closed
+  and reopened
+- **THEN** the row's overridden DPT is still shown (it persists with the row's
+  other inputs)
+
+### Requirement: Input widget follows the effective DPT
+
+The row's value input widget SHALL be selected from the row's effective DPT, not
+the project DPT: DPT main 1 SHALL offer On/Off, DPT main 10/11/19 SHALL offer the
+time/date pickers, and any other (or empty) DPT SHALL offer the free-value input.
+
+#### Scenario: Widget switches when DPT is overridden
+
+- **WHEN** a row's DPT is changed from `5.010` to `1.001`
+- **THEN** the value control changes to the On/Off buttons for DPT 1
+
+#### Scenario: Widget reflects a date/time override
+
+- **WHEN** a row's DPT is set to `10.001`
+- **THEN** the value control becomes the time picker
+
+### Requirement: Send uses the effective DPT
+
+An immediate or scheduled send from a row SHALL transcode the value using the
+row's effective DPT. When the effective DPT is unknown or empty, the send SHALL
+surface the backend's validation error to the user inline, without silently
+falling back to the project DPT.
+
+#### Scenario: Send with an overridden DPT succeeds
+
+- **WHEN** the user overrides a GA's DPT to `5.010`, enters `128`, and writes
+- **THEN** the panel sends the value transcoded as DPT `5.010` (a value the
+  project's `5.001` would have rejected)
+
+#### Scenario: Unknown DPT reports an error
+
+- **WHEN** the user enters a DPT the backend cannot transcode and writes
+- **THEN** the row shows the backend's error message and no value is written
+
+### Requirement: Reset to the project DPT
+
+When a row's DPT has been overridden and the group address has a project DPT, the
+panel SHALL offer a way to reset the row's DPT back to the project default.
+
+#### Scenario: Reset restores the project DPT
+
+- **WHEN** the user resets a row whose DPT was overridden from project `5.001`
+- **THEN** the row's DPT field shows `5.001` again and the row is no longer
+  overridden


### PR DESCRIPTION
The Send panel's DPT field was read-only, preventing users from sending telegrams with a DPT different from the project's default. This forced workarounds when the project file specified an incorrect DPT.

### Changes

- Make the per-row DPT field **editable** with a free-text input backed by a `<datalist>` of known DPTs from the project and common types
- Add `parseDptMain()` utility to extract the main number from a DPT string so `WriteControls` renders the correct widget for the effective DPT
- Clear the value when the DPT main number changes to prevent stale values being sent to the wrong widget type
- Show a **reset-to-project-DPT** affordance when the DPT has been overridden
- Surface backend validation errors inline for unknown DPTs
- Add comprehensive tests covering prefill, override, widget switching, send with overridden DPT, error surfacing, and reset

No backend changes required — `POST /api/knx/send` already accepts any DPT.

Closes #342