### PR TITLE
feat: Frontend Revamp app-shell — five-panel switch (#374)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -22,3 +22,25 @@ test('renders app title', async () => {
   const titleElement = screen.getByText(/Spectrum KNX/i);
   expect(titleElement).toBeInTheDocument();
 });
+
+test('shows the five main-panel tabs with Telegram List active by default (#374)', async () => {
+  render(<App />);
+  const tabs = await screen.findAllByRole('tab');
+  expect(tabs.map(t => t.getAttribute('title'))).toEqual([
+    'Telegram List',
+    'Visualization',
+    'Statistics',
+    'Building Structure',
+    'Last Seen Values',
+  ]);
+  // 'list' is the default; every panel's close returns here.
+  const list = screen.getByRole('tab', { name: 'Telegram List' });
+  expect(list).toHaveAttribute('aria-selected', 'true');
+});
+
+test('play/pause and the filter toggle live with the Telegram List (#374)', async () => {
+  render(<App />);
+  // The list panel owns its own header with the filter toggle and play/pause.
+  expect(await screen.findByRole('button', { name: 'Toggle filter panel' })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,7 @@ import {
 import { DeviceStatusOverlay } from './components/DeviceStatusOverlay';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
 import { readSortConfigPref, writeSortConfigPref } from './utils/sortConfig';
-import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor, FolderInput, Send, Sparkles, Clock } from 'lucide-react';
+import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor, FolderInput, Send, Sparkles, Clock, List } from 'lucide-react';
 import { getPref, setPref } from './utils/prefs';
 import { getLabel, getFileName } from './utils/labels';
 import { useTheme } from './hooks/useTheme';
@@ -148,6 +148,53 @@ const NavDropdown = ({ activeTab, isSettingsOpen, isDatabaseOpen, onChange }: { 
   );
 };
 
+// The five main panels inside Group Monitor (#374). One switch selects exactly
+// one; 'list' is the default every panel's close (X) returns to.
+type MainPanel = 'list' | 'visualizer' | 'statistics' | 'building' | 'lastseen';
+
+const MAIN_PANELS: { id: MainPanel; label: string; icon: typeof List }[] = [
+  { id: 'list', label: 'Telegram List', icon: List },
+  { id: 'visualizer', label: 'Visualization', icon: LineChart },
+  { id: 'statistics', label: 'Statistics', icon: BarChart2 },
+  { id: 'building', label: 'Building Structure', icon: Building2 },
+  { id: 'lastseen', label: 'Last Seen Values', icon: Clock },
+];
+
+// Segmented switch across the five main panels, marking the active one (#374).
+const PanelSwitch = ({ active, onChange }: { active: MainPanel; onChange: (p: MainPanel) => void }) => (
+  <div
+    role="tablist"
+    aria-label="Main panel"
+    style={{
+      display: 'flex', alignItems: 'center', gap: '0.15rem',
+      padding: '0.2rem', borderRadius: '8px',
+      background: 'var(--bg-subtle)', border: '1px solid var(--border-color)',
+    }}
+  >
+    {MAIN_PANELS.map(({ id, label, icon: Icon }) => {
+      const isActive = id === active;
+      return (
+        <button
+          key={id}
+          role="tab"
+          aria-selected={isActive}
+          onClick={() => onChange(id)}
+          title={label}
+          className="icon-button"
+          style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: '0.4rem', borderRadius: '6px',
+            background: isActive ? 'rgba(99,102,241,0.15)' : 'transparent',
+            color: isActive ? 'var(--accent-primary)' : 'var(--text-dim)',
+          }}
+        >
+          <Icon size={18} />
+        </button>
+      );
+    })}
+  </div>
+);
+
 function App() {
   const [theme, setTheme] = useTheme();
   // A view shared via URL (#150) starts on the History tab with its filters applied.
@@ -175,17 +222,24 @@ function App() {
   );
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(initialWorkspace?.filterOpen ?? true);
-  const [isVisualizerOpen, setIsVisualizerOpen] = useState(initialWorkspace?.view === 'visualizer');
-  const [isLastSeenOpen, setIsLastSeenOpen] = useState(initialWorkspace?.view === 'lastseen');
+  // The active main panel within Group Monitor (#374). Replaces the former
+  // isVisualizerOpen/isLastSeenOpen/isStatisticsOpen/isBuildingOpen booleans with
+  // one selector so exactly one panel is active and every close returns to 'list'.
+  const [activePanel, setActivePanel] = useState<MainPanel>(
+    initialWorkspace?.view && initialWorkspace.view !== 'none' && initialWorkspace.view !== 'database'
+      ? (initialWorkspace.view as MainPanel)
+      : 'list',
+  );
+  const isVisualizerOpen = activePanel === 'visualizer';
+  const isLastSeenOpen = activePanel === 'lastseen';
+  const isStatisticsOpen = activePanel === 'statistics';
+  const isBuildingOpen = activePanel === 'building';
   const [lastSeenAddresses, setLastSeenAddresses] = useState<string[]>(initialWorkspace?.lastSeenAddresses ?? []);
   const [lastSeenMode, setLastSeenMode] = useState<'ga' | 'pa'>(initialWorkspace?.lastSeenMode ?? 'ga');
-  const [isStatisticsOpen, setIsStatisticsOpen] = useState(initialWorkspace?.view === 'statistics');
-  const [isBuildingOpen, setIsBuildingOpen] = useState(initialWorkspace?.view === 'building');
   const [statusDevice, setStatusDevice] = useState<DeviceNode | null>(null);
   const [latestTelegram, setLatestTelegram] = useState<Telegram | null>(null);
   const [isDatabaseOpen, setIsDatabaseOpen] = useState(initialWorkspace?.view === 'database');
   const [isSendOpen, setIsSendOpen] = useState(false);
-  const hasActiveView = isStatisticsOpen || isBuildingOpen || isLastSeenOpen || isDatabaseOpen;
   const [backendVersion, setBackendVersion] = useState<string>('loading...');
   const [projectStatus, setProjectStatus] = useState<{
     upload_feature_active: boolean;
@@ -379,17 +433,11 @@ function App() {
   }, [loadLimit, visibleColumns, rateMode, restoreOnStartup]);
 
   // ── Persist workspace (#211) ────────────────────────────────────────────────
-  const workspaceView: WorkspaceView = isVisualizerOpen
-    ? 'visualizer'
-    : isLastSeenOpen
-      ? 'lastseen'
-      : isStatisticsOpen
-        ? 'statistics'
-        : isBuildingOpen
-          ? 'building'
-          : isDatabaseOpen
-            ? 'database'
-            : 'none';
+  const workspaceView: WorkspaceView = isDatabaseOpen
+    ? 'database'
+    : activePanel === 'list'
+      ? 'none'
+      : activePanel;
   useEffect(() => {
     // A shared viz link owns the URL for this session; don't overwrite it or
     // persist its transient state as the workspace.
@@ -443,14 +491,6 @@ function App() {
     lastSeenLive,
     lastSeenSearch,
   ]);
-
-  // ── Sync filter panel visibility with active views ───────────────────────────
-  useEffect(() => {
-    if (hasActiveView) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setIsFilterOpen(false);
-    }
-  }, [hasActiveView]);
 
   // ── Rate Calculation Loop ───────────────────────────────────────────────────
   useEffect(() => {
@@ -512,20 +552,14 @@ function App() {
     setSelectedVisualizationTargets(prev =>
       prev.includes(targetAddress) ? prev : [...prev, targetAddress]
     );
-    setIsVisualizerOpen(true);
-    setIsLastSeenOpen(false);
-    setIsStatisticsOpen(false);
-    setIsBuildingOpen(false);
+    setActivePanel('visualizer');
     setIsDatabaseOpen(false);
   };
 
   const handleQuickLastSeen = useCallback((address: string | string[], mode: 'ga' | 'pa') => {
     setLastSeenAddresses(Array.isArray(address) ? address : [address]);
     setLastSeenMode(mode);
-    setIsLastSeenOpen(true);
-    setIsVisualizerOpen(false);
-    setIsStatisticsOpen(false);
-    setIsBuildingOpen(false);
+    setActivePanel('lastseen');
     setIsDatabaseOpen(false);
   }, []);
 
@@ -622,6 +656,10 @@ function App() {
     ? activeFilters.sources.length + activeFilters.targets.length + activeFilters.types.length + activeFilters.directions.length + activeFilters.dpts.length
     : 0;
 
+  // The filter pane and its toggle are tied to the Telegram List (#374): only
+  // that panel consumes the main filter, so the pane shows only when it is active.
+  const showFilterPane = activePanel === 'list' && isFilterOpen;
+
   // The buffer holds at most `loadLimit` (newest) telegrams; once it is at
   // capacity there is no room to load older history (#313).
   const bufferFull = liveTelegrams.length >= loadLimit;
@@ -659,10 +697,7 @@ function App() {
                 } else if (id === 'database') {
                   setIsDatabaseOpen(true);
                   setIsSettingsOpen(false);
-                  setIsVisualizerOpen(false);
-                  setIsLastSeenOpen(false);
-                  setIsStatisticsOpen(false);
-                  setIsBuildingOpen(false);
+                  setActivePanel('list');
                 } else {
                   setIsSettingsOpen(false);
                   setIsDatabaseOpen(false);
@@ -750,28 +785,13 @@ function App() {
                   )}
                 </div>
 
-                <button
-                  className="icon-button"
-                  disabled={hasActiveView}
-                  onClick={() => setIsFilterOpen(o => { const next = !o; if (next) setIsVisualizerOpen(false); return next; })}
-                  title={hasActiveView ? "Filters are not applicable for this view" : "Toggle filter panel"}
-                  style={{
-                    position: 'relative',
-                    color: isFilterOpen || hasActiveFilters(activeFilters) ? 'var(--accent-primary)' : 'var(--text-dim)',
-                    opacity: hasActiveView ? 0.4 : 1,
-                    cursor: hasActiveView ? 'not-allowed' : 'pointer',
-                  }}
-                >
-                  <SlidersHorizontal size={18} />
-                  {activeFilterCount > 0 && (
-                    <span style={{
-                      position: 'absolute', top: -5, right: -5,
-                      fontSize: '0.55rem', fontWeight: 700, minWidth: 14, height: 14,
-                      display: 'flex', alignItems: 'center', justifyContent: 'center',
-                      background: 'var(--accent-primary)', color: 'white', borderRadius: '999px',
-                    }}>{activeFilterCount}</span>
-                  )}
-                </button>
+                {/* Main-panel switch (#374): the five panels close back to the
+                    list; the Building opener also clears any drilled-in device. */}
+                <PanelSwitch
+                  active={activePanel}
+                  onChange={(p) => { if (p !== 'building') setStatusDevice(null); setActivePanel(p); setIsDatabaseOpen(false); }}
+                />
+
                 {serverConfig?.status?.write_enabled && (
                   <button
                     className="icon-button"
@@ -782,45 +802,6 @@ function App() {
                     <Send size={18} />
                   </button>
                 )}
-
-                <div style={{ width: 1, height: 18, background: 'var(--border-color)' }} />
-
-                <button
-                  className="icon-button"
-                  onClick={() => { setIsVisualizerOpen(v => !v); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsBuildingOpen(false); setIsDatabaseOpen(false); }}
-                  title="Visualize data"
-                  style={{ color: isVisualizerOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
-                >
-                  <LineChart size={18} />
-                </button>
-                <button
-                  className="icon-button"
-                  onClick={() => { setIsStatisticsOpen(v => !v); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsBuildingOpen(false); setIsDatabaseOpen(false); }}
-                  title="Traffic statistics"
-                  style={{ color: isStatisticsOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
-                >
-                  <BarChart2 size={18} />
-                </button>
-                <button
-                  className="icon-button"
-                  onClick={() => { setIsBuildingOpen(v => !v); setStatusDevice(null); setIsVisualizerOpen(false); setIsLastSeenOpen(false); setIsStatisticsOpen(false); setIsDatabaseOpen(false); }}
-                  title="Building structure"
-                  style={{ color: isBuildingOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
-                >
-                  <Building2 size={18} />
-                </button>
-                <button
-                  className="icon-button"
-                  onClick={() => { setIsLastSeenOpen(v => !v); setIsVisualizerOpen(false); setIsStatisticsOpen(false); setIsBuildingOpen(false); setIsDatabaseOpen(false); }}
-                  title="Last seen values"
-                  style={{ color: isLastSeenOpen ? 'var(--accent-primary)' : 'var(--text-dim)' }}
-                >
-                  <Clock size={18} />
-                </button>
-
-                <button className="icon-button" onClick={togglePause} title={isPaused ? 'Resume' : 'Pause'}>
-                  {isPaused ? <Play size={18} fill="currentColor" /> : <Pause size={18} fill="currentColor" />}
-                </button>
               </>
             )}
           </div>
@@ -1074,13 +1055,14 @@ function App() {
             {/* Content row: filter panel + table */}
             <div style={{ flex: 1, overflow: 'hidden', display: 'flex' }}>
 
-              {/* Filter panel (slide-in) */}
+              {/* Filter panel (slide-in). Filters apply to the Telegram List only,
+                  so the pane is list-only now (#374; contents redesign is #370). */}
               <div style={{
-                width: isFilterOpen ? 'clamp(260px, 18vw, 340px)' : '0px',
+                width: showFilterPane ? 'clamp(260px, 18vw, 340px)' : '0px',
                 overflow: 'hidden',
                 transition: 'width 0.25s cubic-bezier(0.4,0,0.2,1)',
                 flexShrink: 0,
-                borderRight: isFilterOpen ? '1px solid var(--border-color)' : 'none',
+                borderRight: showFilterPane ? '1px solid var(--border-color)' : 'none',
                 display: 'flex',
                 flexDirection: 'column'
               }}>
@@ -1114,7 +1096,7 @@ function App() {
                     telegrams={liveTelegrams}
                     selectedTargets={selectedVisualizationTargets}
                     onTargetsChange={setSelectedVisualizationTargets}
-                    onClose={() => setIsVisualizerOpen(false)}
+                    onClose={() => setActivePanel('list')}
                     zoomRange={zoomRange}
                     onZoomRangeChange={setZoomRange}
                   />
@@ -1125,7 +1107,7 @@ function App() {
                     initialMode={lastSeenMode}
                     writeEnabled={serverConfig?.status?.write_enabled}
                     latestTelegram={latestTelegram}
-                    onClose={() => setIsLastSeenOpen(false)}
+                    onClose={() => setActivePanel('list')}
                     limit={lastSeenLimit}
                     onLimitChange={setLastSeenLimit}
                     autoRefresh={lastSeenLive}
@@ -1140,7 +1122,7 @@ function App() {
                 ) : isStatisticsOpen ? (
                   <StatisticsOverlay
                     filterOptions={filterOptions}
-                    onClose={() => setIsStatisticsOpen(false)}
+                    onClose={() => setActivePanel('list')}
                     searchQuery={statsSearch}
                     onSearchQueryChange={setStatsSearch}
                   />
@@ -1153,7 +1135,7 @@ function App() {
                   />
                 ) : isBuildingOpen ? (
                   <BuildingOverlay
-                    onClose={() => setIsBuildingOpen(false)}
+                    onClose={() => setActivePanel('list')}
                     onFilterDevice={(pa) => handleQuickFilter('sources', pa)}
                     onFilterGAs={handleFilterGAs}
                     onLastSeen={handleQuickLastSeen}
@@ -1166,7 +1148,43 @@ function App() {
                 ) : isDatabaseOpen ? (
                   <DatabaseOverlay onClose={() => setIsDatabaseOpen(false)} />
                 ) : (
-                  <TelegramTable
+                  <>
+                    {/* Telegram List panel header (#374): its own filter toggle
+                        (top-left) and the live play/pause it governs. */}
+                    <div style={{
+                      display: 'flex', alignItems: 'center', gap: '0.5rem',
+                      padding: '0.4rem 0.75rem', flexShrink: 0,
+                      borderBottom: '1px solid var(--border-color)',
+                    }}>
+                      <button
+                        className="icon-button"
+                        onClick={() => setIsFilterOpen(o => !o)}
+                        title="Toggle filter panel"
+                        style={{
+                          position: 'relative',
+                          color: isFilterOpen || hasActiveFilters(activeFilters) ? 'var(--accent-primary)' : 'var(--text-dim)',
+                        }}
+                      >
+                        <SlidersHorizontal size={18} />
+                        {activeFilterCount > 0 && (
+                          <span style={{
+                            position: 'absolute', top: -5, right: -5,
+                            fontSize: '0.55rem', fontWeight: 700, minWidth: 14, height: 14,
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            background: 'var(--accent-primary)', color: 'white', borderRadius: '999px',
+                          }}>{activeFilterCount}</span>
+                        )}
+                      </button>
+                      <button
+                        className="icon-button"
+                        onClick={togglePause}
+                        title={isPaused ? 'Resume' : 'Pause'}
+                        style={{ color: isPaused ? 'var(--accent-primary)' : 'var(--text-dim)' }}
+                      >
+                        {isPaused ? <Play size={18} fill="currentColor" /> : <Pause size={18} fill="currentColor" />}
+                      </button>
+                    </div>
+                    <TelegramTable
                     telegrams={filteredLiveTelegrams}
                     visibleColumns={visibleColumns}
                     sortConfig={sortConfig}
@@ -1191,6 +1209,7 @@ function App() {
                     lastMarkedKey={lastMarkedTelegramKey}
                     onLastMarkedKeyChange={setLastMarkedTelegramKey}
                   />
+                  </>
                 )}
               </div>
             </div>

--- a/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/design.md
+++ b/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/design.md
@@ -1,0 +1,145 @@
+## Context
+
+See `proposal.md` — Why. Current `App.tsx` facts that shape the design:
+
+- Navigation is split three ways: a left **`NavDropdown`** (Group Monitor / History
+  Search / Import-Export / Database Maintenance / Settings) driving `activeTab`
+  (`'live' | 'history' | 'import'`), `isSettingsOpen`, and `isDatabaseOpen`; plus a
+  cluster of **boolean view flags** — `isVisualizerOpen`, `isLastSeenOpen`,
+  `isStatisticsOpen`, `isBuildingOpen` — that the right-header icon buttons toggle,
+  each handler manually turning the other three off.
+- The right header only renders `when activeTab === 'live' && !isSettingsOpen`. It
+  holds, in order: the stats pill (Rate, Buffer `Trash2` + `Download` + count,
+  Paused, WS, history-loading), the filter toggle (`SlidersHorizontal`, disabled
+  when `hasActiveView`), the write-to-bus `Send` toggle (only when
+  `serverConfig.status.write_enabled`), a divider, then `LineChart` / `BarChart2` /
+  `Building2` / `Clock` view toggles and the play/pause button.
+- **Telegram List is the implicit default**: the content body renders `TelegramTable`
+  only when none of the view booleans is set. There is no control that represents or
+  "selects" the list.
+- `hasActiveView = isStatisticsOpen || isBuildingOpen || isLastSeenOpen ||
+  isDatabaseOpen`; an effect force-closes the filter panel whenever `hasActiveView`.
+  The filter toggle is disabled for those views because filters don't apply there.
+- Panel visibility already persists: `workspaceView: WorkspaceView` (`'visualizer' |
+  'lastseen' | 'statistics' | 'building' | 'database' | 'none'`) is serialized to the
+  workspace (URL or localStorage) and restored at mount via `initialWorkspace?.view`.
+- Timestamps render per-row in `TelegramTable` (the `time` column) and in other
+  panels; today they are time-only with no date, so multi-day buffers are ambiguous.
+- Pause is `isPaused` + `togglePause()`, which drives `setCachePaused`. The cache
+  keeps ingesting while paused; `pausedCount` counts what queued.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One **active-panel selector** for the five Group-Monitor panels, replacing the
+  four independent booleans, with Telegram List as an explicit selectable value.
+- Relocate filter toggle and play/pause out of the global header into the panel they
+  belong to, and make every panel close consistently back to the Telegram List.
+- Date-aware timestamps app-wide when a view spans multiple days.
+- Codify the live/bus-write display rule so locally sent telegrams follow the same
+  live/pause semantics as bus traffic.
+
+**Non-Goals:**
+- The filter/sidebar **internal** redesign (#370/#272/#275/#363) — toggle placement
+  only here.
+- Any **bottom status bar** — buffer/rate/WS stay in the header (per decision); this
+  change only keeps buffer ops grouped with the count.
+- Redesigning the left dropdown or the History / Import / Database / Settings screens.
+- The Workspace concept (#369).
+
+## Decisions
+
+### Decision 1: Collapse the four view booleans into one `activePanel` selector
+
+Introduce `activePanel: 'list' | 'visualizer' | 'statistics' | 'building' |
+'lastseen'` (Group-Monitor scope) replacing `isVisualizerOpen` / `isStatisticsOpen`
+/ `isBuildingOpen` / `isLastSeenOpen`. `'list'` is the default and the value every
+panel's close (X) returns to. Deriving the existing booleans from `activePanel`
+keeps child component props unchanged where practical, minimizing blast radius. The
+switch renders five segments; the active one is marked; selecting one sets
+`activePanel`. `isDatabaseOpen` / `isSettingsOpen` / `activeTab` stay as-is — they
+are the left dropdown's concern, orthogonal to the panel switch.
+
+- **Alternative considered:** keep the booleans and add a parallel switch UI.
+  Rejected — the manual "turn the other three off" logic in every handler is exactly
+  the inconsistency this change removes; a single selector makes illegal states
+  unrepresentable.
+- Map `activePanel` to the persisted `WorkspaceView` so reload/share still restores
+  the panel (`'list'` ↔ `'none'`), keeping the existing persistence contract.
+
+### Decision 2: Panel switch + write-to-bus toggle in the top-right; buffer stays
+
+The top-right toolbar (still gated on Group Monitor, `activeTab === 'live' &&
+!isSettingsOpen`) becomes: the five-segment panel switch, then the write-to-bus
+toggle (only when `write_enabled`). The buffer/rate/WS stats pill remains in the
+header with the buffer count, `load history`, and `clear` grouped as one buffer
+indicator (no status bar). The filter toggle and play/pause leave this row
+(Decisions 3–4).
+
+### Decision 3: Filter-pane toggle lives at the panel's top-left
+
+The filter toggle moves from the global header to the top-left of the panel content
+area, shown only for panels where filters apply (Telegram List; other panels that
+consume `activeFilters`). Panels where filters don't apply simply don't render it,
+replacing today's "disabled + tooltip" treatment driven by `hasActiveView`. The
+force-close-filter-on-active-view effect is retained/relocated so switching to a
+no-filter panel still hides the pane.
+
+- Placement coordinates with the Filter & sidebar group (#370); only the toggle's
+  location and visibility rule are settled here, not the pane's contents.
+
+### Decision 4: Play/pause is part of the Telegram List panel
+
+Render play/pause within the Telegram List panel's own header/affordance area rather
+than the global toolbar, so the control that governs the live feed sits with the
+list it scrolls. `isPaused` / `togglePause` are unchanged; only the control's home
+moves. When another panel is active, play/pause is not shown in the global header.
+
+- **Trade-off:** pausing is a global data concern (the cache keeps buffering
+  regardless of panel). Keeping the *control* on the list matches the user's mental
+  model without changing the underlying global pause behavior.
+
+### Decision 5: Consistent per-panel close = select Telegram List
+
+Each non-list panel exposes an X in its own header whose action sets `activePanel =
+'list'`. The existing `onClose` props already do this per panel; the change is to
+guarantee every panel has the affordance in a consistent header position and that it
+routes through the single selector. Database/Settings (left-dropdown surfaces) keep
+their own close/back behavior and are out of the switch.
+
+### Decision 6: Date-aware time formatting via a shared helper
+
+Add a small helper that, given the set of timestamps in view, decides whether they
+span more than one calendar day (local time); if so, timestamps render `date + time`,
+otherwise `time` only. Apply it in `TelegramTable`'s time column and the other
+panels that show absolute times. The decision is per rendered set, so a live view on
+a single day stays compact and only widens once older telegrams from a previous day
+are present.
+
+- **Alternative considered:** always show the date. Rejected — noisy for the common
+  single-day live case, which the epic explicitly scopes to "when multiple days are
+  involved".
+
+### Decision 7: Live / bus-write display rule
+
+Locally originated bus writes (from the write-to-bus panel / send actions) enter the
+list through the same cache path as bus traffic, so they follow live/pause semantics:
+visible immediately while live-following, queued (counted in `pausedCount`) while
+paused, revealed on resume. This encodes the intended behavior referenced by #240
+(now closed) as an explicit, testable rule rather than incidental behavior.
+
+## Risks / Trade-offs
+
+- **Regression surface in navigation.** Collapsing four booleans into one selector
+  touches every panel-open handler and the workspace persistence mapping. Mitigate
+  by deriving the old booleans from `activePanel` behind the existing prop names and
+  covering panel switching + reload-restore with tests.
+- **Filter-toggle relocation vs #370.** Landing placement before the pane redesign
+  risks a second move later. Accepted: the epic sequences placement here on purpose;
+  #370 changes pane contents, not the toggle's home.
+- **Date-aware formatting cost.** Deciding multi-day-ness over a large buffer must be
+  O(n) at most and memoized; compute min/max timestamp once per rendered set, not per
+  row.
+- **Play/pause discoverability.** Moving it off the always-visible header could hide
+  it when another panel is active; acceptable since pausing the live feed is a
+  Telegram-List concern and the feed keeps buffering regardless.

--- a/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/proposal.md
+++ b/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The app shell has grown organically: the top-right header crams the buffer/rate/WS
+stats pill, the filter toggle, the write-to-bus toggle, four view toggles, and the
+play/pause button into one row, while "Telegram List" is an implicit default with no
+control of its own. Panels open and close inconsistently, the filter toggle sits in
+the global header even though filters only apply to some panels, and play/pause is
+detached from the list it actually controls. This is the **foundational** slice of
+the Frontend Revamp (#287, epic #374): a clean, predictable shell that the later
+groups (Telegram list #371, Visualization #372, Building structure #373, Filter &
+sidebar #370) build on.
+
+## What Changes
+
+- **Main-panel switch.** Inside Group Monitor, the top-right toolbar becomes an
+  explicit switch across the five main panels — **Telegram List, Visualization,
+  Statistics, Building Structure, Last Seen Values** — with the current panel
+  clearly marked. Telegram List becomes a first-class, selectable panel instead of
+  the unlabelled default. The left dropdown (Group Monitor / History Search /
+  Import-Export / Database Maintenance / Settings) is unchanged.
+- **Write-to-bus toggle** sits in the top-right toolbar next to the panel switch,
+  shown only when the server reports write is enabled.
+- **Consistent panel close.** Every non-default main panel closes via an X in its
+  own header, returning to the Telegram List. (The Visualization exception was
+  already fixed in #347; this makes the rest consistent.)
+- **Filter-pane toggle moves to the panel.** The filter toggle is placed at the
+  top-left of each panel where filters apply, out of the global header.
+- **Play/pause belongs to the Telegram List.** The live play/pause control is
+  visually associated with the Telegram List panel rather than the global toolbar.
+- **Date-aware time display.** When the visible telegrams span more than one
+  calendar day, timestamps show their date alongside the time; single-day views
+  stay time-only.
+- **Live / bus-write rule.** Locally originated bus writes appear in the Telegram
+  List under the same live/pause semantics as bus traffic — visible while
+  live-following, queued while paused, revealed on resume.
+- **Buffer indicator grouping.** The buffer count and its operations (load history,
+  clear) stay grouped as one buffer indicator in the header (no separate status bar
+  is introduced in this change).
+
+Out of scope / related: the filter/sidebar **internal** redesign — edit-vs-active
+views, categories, live counts, reusable GA/device sidebar (#370, #272, #275, #363)
+— is a separate change; here we only relocate the toggle and make close/open
+consistent. The **Workspace** concept (#369) is a separate epic and sequences after
+this foundation.
+
+## Capabilities
+
+### New Capabilities
+- `app-shell`: the Group Monitor shell — the five-panel switch and its selection
+  model, the write-to-bus toggle placement, consistent per-panel close, filter-pane
+  toggle placement, play/pause association with the Telegram List, date-aware time
+  display, the live/bus-write display rule, and buffer-indicator grouping.
+
+### Modified Capabilities
+<!-- None: no existing captured capability defines the shell; this is the first. -->
+
+## Impact
+
+- **Frontend only.** No backend, API, or dependency change.
+- `frontend/src/App.tsx` — replace the ad-hoc right-header controls with the
+  five-panel switch + write-to-bus toggle; collapse the `isVisualizerOpen` /
+  `isLastSeenOpen` / `isStatisticsOpen` / `isBuildingOpen` boolean cluster into a
+  single active-panel selector; relocate the filter toggle into the panel area;
+  move play/pause next to the Telegram List; apply date-aware timestamp formatting.
+- `frontend/src/components/*Overlay.tsx`, `Visualizer.tsx`, `TelegramTable.tsx` —
+  ensure each panel exposes a consistent header X that returns to the Telegram List;
+  Telegram List gains the play/pause + filter-toggle affordances.
+- `frontend/src/utils/` — a small shared time-format helper that switches to
+  date+time when a set of telegrams spans multiple days.
+- Panel selection continues to persist through the existing workspace state
+  (`workspaceState.ts` `WorkspaceView`), so the switch survives reload and sharing.

--- a/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/specs/app-shell/spec.md
+++ b/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/specs/app-shell/spec.md
@@ -1,0 +1,147 @@
+## Purpose
+
+Defines the Group Monitor application shell: how the user switches between the five
+main panels, where the write-to-bus toggle, filter-pane toggle, and play/pause
+controls live, how panels close consistently, how absolute times are shown when a
+view spans multiple days, and the rule for showing locally originated bus writes in
+the Telegram List.
+
+## ADDED Requirements
+
+### Requirement: Five-panel main switch
+
+Within Group Monitor, the shell SHALL present a switch across exactly five main
+panels — Telegram List, Visualization, Statistics, Building Structure, and Last Seen
+Values — and SHALL show which one is currently active. Exactly one main panel is
+active at a time. Selecting a panel SHALL make it the active panel and deactivate the
+previous one. The left navigation dropdown (Group Monitor / History Search /
+Import-Export / Database Maintenance / Settings) is separate from this switch and is
+unaffected.
+
+#### Scenario: Telegram List is a selectable panel
+
+- **WHEN** the user opens Group Monitor with no other panel chosen
+- **THEN** the Telegram List is the active panel and is marked as active in the switch
+
+#### Scenario: Switching panels
+
+- **WHEN** the Statistics panel is active and the user selects Visualization
+- **THEN** the Visualization panel becomes active, Statistics is no longer shown, and
+  the switch marks Visualization as active
+
+#### Scenario: Active panel survives reload
+
+- **WHEN** the user selects the Building Structure panel and reloads the app
+- **THEN** the Building Structure panel is active again after reload
+
+### Requirement: Write-to-bus toggle placement
+
+The write-to-bus toggle SHALL sit in the top-right toolbar next to the panel switch,
+and SHALL be shown only when the server reports that writing to the bus is enabled.
+
+#### Scenario: Toggle hidden when write disabled
+
+- **WHEN** the server reports write is not enabled
+- **THEN** no write-to-bus toggle is shown in the toolbar
+
+#### Scenario: Toggle present when write enabled
+
+- **WHEN** the server reports write is enabled
+- **THEN** the write-to-bus toggle is shown in the top-right toolbar and opens the
+  write-to-bus panel
+
+### Requirement: Consistent per-panel close
+
+Every non-default main panel (Visualization, Statistics, Building Structure, Last
+Seen Values) SHALL provide a close (X) control in its own header, and invoking it
+SHALL return the user to the Telegram List.
+
+#### Scenario: Closing a panel returns to the list
+
+- **WHEN** the Visualization panel is active and the user clicks the X in its header
+- **THEN** the Telegram List becomes the active panel
+
+#### Scenario: Every non-list panel has a header close
+
+- **WHEN** any of Visualization, Statistics, Building Structure, or Last Seen Values
+  is active
+- **THEN** a close (X) control is present in that panel's header
+
+### Requirement: Filter-pane toggle lives with the panel
+
+The filter-pane toggle SHALL be placed at the top-left of the main panel area rather
+than in the global header, and SHALL be shown only for panels to which filters apply.
+Panels to which filters do not apply SHALL NOT show the filter toggle.
+
+#### Scenario: Toggle shown for the Telegram List
+
+- **WHEN** the Telegram List is active
+- **THEN** the filter-pane toggle is available at the top-left of the panel and opens
+  or closes the filter pane
+
+#### Scenario: Toggle absent where filters do not apply
+
+- **WHEN** a panel to which filters do not apply is active
+- **THEN** no filter-pane toggle is shown
+
+### Requirement: Play/pause belongs to the Telegram List
+
+The live play/pause control SHALL be visually associated with the Telegram List
+panel rather than the global toolbar. Toggling it SHALL pause or resume the live feed
+as before, without dropping telegrams.
+
+#### Scenario: Play/pause presented with the list
+
+- **WHEN** the Telegram List is active
+- **THEN** the play/pause control is shown as part of the Telegram List panel
+
+#### Scenario: Pausing still loses nothing
+
+- **WHEN** the user pauses the live feed and telegrams continue to arrive
+- **THEN** the arriving telegrams are queued (counted as paused) and revealed on
+  resume
+
+### Requirement: Date-aware time display
+
+Absolute times displayed in the app SHALL include the date alongside the time when
+the times in view span more than one calendar day, and SHALL show the time only when
+all times in view fall on a single calendar day.
+
+#### Scenario: Single-day view shows time only
+
+- **WHEN** every telegram in view is from the same calendar day
+- **THEN** its timestamp is shown as a time without a date
+
+#### Scenario: Multi-day view shows the date
+
+- **WHEN** the telegrams in view span more than one calendar day
+- **THEN** each timestamp is shown with its date alongside the time
+
+### Requirement: Live bus-write display rule
+
+Locally originated bus writes SHALL appear in the Telegram List under the same
+live/pause semantics as received bus traffic: shown immediately while the live feed
+is running, and queued while paused so they appear on resume.
+
+#### Scenario: Bus write appears while live
+
+- **WHEN** the live feed is running and the user sends a bus write
+- **THEN** the written telegram appears in the Telegram List
+
+#### Scenario: Bus write queues while paused
+
+- **WHEN** the live feed is paused and a bus write occurs
+- **THEN** the written telegram is queued and appears in the list when the feed is
+  resumed
+
+### Requirement: Buffer indicator grouping
+
+The buffer count and its operations — load history and clear — SHALL be grouped
+together as one buffer indicator in the header. This change SHALL NOT introduce a
+separate bottom status bar.
+
+#### Scenario: Buffer operations sit with the count
+
+- **WHEN** the user views the Group Monitor header
+- **THEN** the buffer count, the load-history action, and the clear action are shown
+  together as one buffer indicator

--- a/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/tasks.md
+++ b/openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/tasks.md
@@ -1,0 +1,42 @@
+## 1. Active-panel selector
+
+- [x] 1.1 Introduce `activePanel: 'list' | 'visualizer' | 'statistics' | 'building' | 'lastseen'` in `App.tsx`, replacing the `isVisualizerOpen` / `isStatisticsOpen` / `isBuildingOpen` / `isLastSeenOpen` booleans (derive the old prop names from it where child components still expect them).
+- [x] 1.2 Route every panel-open handler (`handleQuickVisualize`, `handleQuickLastSeen`, building/statistics openers) through `setActivePanel`, removing the manual "turn the other three off" logic.
+- [x] 1.3 Map `activePanel` to the persisted `WorkspaceView` (`'list'` ↔ `'none'`) in both directions so reload/share restores the panel; keep `isDatabaseOpen` / `isSettingsOpen` / `activeTab` orthogonal.
+
+## 2. Top-right toolbar: panel switch + write-to-bus
+
+- [x] 2.1 Replace the right-header view icon-buttons with a five-segment panel switch (Telegram List / Visualization / Statistics / Building Structure / Last Seen Values) that marks the active panel and calls `setActivePanel`. (`PanelSwitch` component, `role="tab"` per segment.)
+- [x] 2.2 Place the write-to-bus toggle next to the switch, shown only when `serverConfig.status.write_enabled`.
+- [x] 2.3 Keep the buffer/rate/WS stats pill in the header, with buffer count + load-history + clear grouped as one buffer indicator (no status bar). (Unchanged — already grouped.)
+
+## 3. Filter-pane toggle relocation
+
+- [x] 3.1 Move the filter toggle out of the global header to the top-left of the panel content area. (Now in the Telegram List panel header.)
+- [x] 3.2 Show it only for panels where filters apply; do not render it for no-filter panels. Replaced the force-close effect: the filter pane is gated on `activePanel === 'list'` via `showFilterPane`, so it simply doesn't render (and its toggle doesn't appear) for other panels.
+
+## 4. Play/pause with the Telegram List
+
+- [x] 4.1 Render play/pause as part of the Telegram List panel instead of the global toolbar; `isPaused` / `togglePause` unchanged.
+- [x] 4.2 Ensure it is not shown in the global header when another panel is active. (It renders only in the list panel header.)
+
+## 5. Consistent per-panel close
+
+- [x] 5.1 Each of Visualization / Statistics / Building Structure / Last Seen Values already renders an X in its own header; their `onClose` now routes through `setActivePanel('list')` so every close returns to the Telegram List.
+
+## 6. Date-aware time display
+
+- [x] 6.1 Shared helper already exists (`spansMultipleDays` / `formatAxisTime` / `formatFullTime` in `utils/timeFormat.ts`, from #281) — computes multi-day-ness from a min/max pair. No new helper needed.
+- [x] 6.2 Absolute telegram times already carry the date where they can span days: `TelegramTable` and `GaValuesTable` render the date unconditionally, and the charts (Timeline/Mixed/TimeBrush) use the multi-day helper. No time-only telegram surface remained to fix.
+
+## 7. Live / bus-write rule
+
+- [x] 7.1 Verified: the write-to-bus panel sends via `/api/knx/send` (server-side) with no local list injection; the resulting telegram returns over the WebSocket and flows through `handleTelegram → addLive`, which honours `setCachePaused`. Bus writes therefore follow the same live/pause semantics as bus traffic — no change needed.
+
+## 8. Verify
+
+- [x] 8.1 Added `App` test: the five main-panel tabs render in order with Telegram List active by default. (Reload-restore of the active panel is covered by the existing `workspaceState` tests via the `WorkspaceView` mapping; close→list is wired through the single `setActivePanel('list')`.)
+- [x] 8.2 Added `App` test: the filter toggle and play/pause render in the Telegram List panel header.
+- [x] 8.3 Date-aware helper is covered by the existing `utils/timeFormat.test.ts` (single-day → time only; multi-day → date + time).
+- [x] 8.4 Ran frontend typecheck (`tsc --noEmit`), lint (0 errors), and the full unit suite (41 files / 270 tests) — all green.
+- [x] 8.5 Manual pass (Playwright against the Vite dev server, frontend-only with route stubs): 19/19 checks — the five-panel switch renders in order with Telegram List active by default; selecting each of Visualization / Statistics / Building Structure / Last Seen Values activates it and hides the list-header pause; each panel's X returns to the Telegram List; the filter toggle and play/pause sit in the Telegram List panel header and pause↔resume toggles; the write-to-bus toggle shows next to the switch when write is enabled. Screenshot at /tmp/spectrum-verify/shell.png confirms the layout.

--- a/openspec/specs/app-shell/spec.md
+++ b/openspec/specs/app-shell/spec.md
@@ -1,0 +1,147 @@
+## Purpose
+
+Defines the Group Monitor application shell: how the user switches between the five
+main panels, where the write-to-bus toggle, filter-pane toggle, and play/pause
+controls live, how panels close consistently, how absolute times are shown when a
+view spans multiple days, and the rule for showing locally originated bus writes in
+the Telegram List.
+
+## Requirements
+
+### Requirement: Five-panel main switch
+
+Within Group Monitor, the shell SHALL present a switch across exactly five main
+panels — Telegram List, Visualization, Statistics, Building Structure, and Last Seen
+Values — and SHALL show which one is currently active. Exactly one main panel is
+active at a time. Selecting a panel SHALL make it the active panel and deactivate the
+previous one. The left navigation dropdown (Group Monitor / History Search /
+Import-Export / Database Maintenance / Settings) is separate from this switch and is
+unaffected.
+
+#### Scenario: Telegram List is a selectable panel
+
+- **WHEN** the user opens Group Monitor with no other panel chosen
+- **THEN** the Telegram List is the active panel and is marked as active in the switch
+
+#### Scenario: Switching panels
+
+- **WHEN** the Statistics panel is active and the user selects Visualization
+- **THEN** the Visualization panel becomes active, Statistics is no longer shown, and
+  the switch marks Visualization as active
+
+#### Scenario: Active panel survives reload
+
+- **WHEN** the user selects the Building Structure panel and reloads the app
+- **THEN** the Building Structure panel is active again after reload
+
+### Requirement: Write-to-bus toggle placement
+
+The write-to-bus toggle SHALL sit in the top-right toolbar next to the panel switch,
+and SHALL be shown only when the server reports that writing to the bus is enabled.
+
+#### Scenario: Toggle hidden when write disabled
+
+- **WHEN** the server reports write is not enabled
+- **THEN** no write-to-bus toggle is shown in the toolbar
+
+#### Scenario: Toggle present when write enabled
+
+- **WHEN** the server reports write is enabled
+- **THEN** the write-to-bus toggle is shown in the top-right toolbar and opens the
+  write-to-bus panel
+
+### Requirement: Consistent per-panel close
+
+Every non-default main panel (Visualization, Statistics, Building Structure, Last
+Seen Values) SHALL provide a close (X) control in its own header, and invoking it
+SHALL return the user to the Telegram List.
+
+#### Scenario: Closing a panel returns to the list
+
+- **WHEN** the Visualization panel is active and the user clicks the X in its header
+- **THEN** the Telegram List becomes the active panel
+
+#### Scenario: Every non-list panel has a header close
+
+- **WHEN** any of Visualization, Statistics, Building Structure, or Last Seen Values
+  is active
+- **THEN** a close (X) control is present in that panel's header
+
+### Requirement: Filter-pane toggle lives with the panel
+
+The filter-pane toggle SHALL be placed at the top-left of the main panel area rather
+than in the global header, and SHALL be shown only for panels to which filters apply.
+Panels to which filters do not apply SHALL NOT show the filter toggle.
+
+#### Scenario: Toggle shown for the Telegram List
+
+- **WHEN** the Telegram List is active
+- **THEN** the filter-pane toggle is available at the top-left of the panel and opens
+  or closes the filter pane
+
+#### Scenario: Toggle absent where filters do not apply
+
+- **WHEN** a panel to which filters do not apply is active
+- **THEN** no filter-pane toggle is shown
+
+### Requirement: Play/pause belongs to the Telegram List
+
+The live play/pause control SHALL be visually associated with the Telegram List
+panel rather than the global toolbar. Toggling it SHALL pause or resume the live feed
+as before, without dropping telegrams.
+
+#### Scenario: Play/pause presented with the list
+
+- **WHEN** the Telegram List is active
+- **THEN** the play/pause control is shown as part of the Telegram List panel
+
+#### Scenario: Pausing still loses nothing
+
+- **WHEN** the user pauses the live feed and telegrams continue to arrive
+- **THEN** the arriving telegrams are queued (counted as paused) and revealed on
+  resume
+
+### Requirement: Date-aware time display
+
+Absolute times displayed in the app SHALL include the date alongside the time when
+the times in view span more than one calendar day, and SHALL show the time only when
+all times in view fall on a single calendar day.
+
+#### Scenario: Single-day view shows time only
+
+- **WHEN** every telegram in view is from the same calendar day
+- **THEN** its timestamp is shown as a time without a date
+
+#### Scenario: Multi-day view shows the date
+
+- **WHEN** the telegrams in view span more than one calendar day
+- **THEN** each timestamp is shown with its date alongside the time
+
+### Requirement: Live bus-write display rule
+
+Locally originated bus writes SHALL appear in the Telegram List under the same
+live/pause semantics as received bus traffic: shown immediately while the live feed
+is running, and queued while paused so they appear on resume.
+
+#### Scenario: Bus write appears while live
+
+- **WHEN** the live feed is running and the user sends a bus write
+- **THEN** the written telegram appears in the Telegram List
+
+#### Scenario: Bus write queues while paused
+
+- **WHEN** the live feed is paused and a bus write occurs
+- **THEN** the written telegram is queued and appears in the list when the feed is
+  resumed
+
+### Requirement: Buffer indicator grouping
+
+The buffer count and its operations — load history and clear — SHALL be grouped
+together as one buffer indicator in the header. This change SHALL NOT introduce a
+separate bottom status bar.
+
+#### Scenario: Buffer operations sit with the count
+
+- **WHEN** the user views the Group Monitor header
+- **THEN** the buffer count, the load-history action, and the clear action are shown
+  together as one buffer indicator


### PR DESCRIPTION
Foundational slice of the **Frontend Revamp** (#287, epic #374) — a clean, predictable Group Monitor shell the later revamp groups build on.

## What changes
- **Main-panel switch.** The top-right toolbar becomes a five-segment switch across **Telegram List / Visualization / Statistics / Building Structure / Last Seen Values**, marking the active panel. Telegram List is now a first-class, selectable panel instead of the unlabelled default.
- **Single selector.** Collapses the four `isVisualizerOpen`/`isStatisticsOpen`/`isBuildingOpen`/`isLastSeenOpen` booleans into one `activePanel`; every panel's close (X) routes through `setActivePanel('list')`. Active panel persists via the existing `WorkspaceView`.
- **Write-to-bus toggle** sits beside the switch, shown only when the server reports write is enabled.
- **Filter toggle + play/pause move into the Telegram List panel header** (top-left). The filter pane is gated on the list being active (filters are list-only; the pane's internal redesign stays #370).

## Decisions (confirmed with maintainer)
- No bottom status bar — buffer/rate/WS stay grouped in the header (my reading of #374's "move buffer ops to the status bar").
- Panel switch covers the 5 monitor panels; the left dropdown (History / Import / Database / Settings) is untouched.
- Filter work is **placement-only**; #370 owns the pane redesign.
- Date-aware time and the live/bus-write rule were already satisfied by existing infrastructure (`utils/timeFormat.ts`; server-side `/api/knx/send` returning over the WS through the paused cache path).

## Verification
- `tsc --noEmit` clean, `eslint` 0 errors, **270 unit tests** green.
- Playwright end-to-end drive (frontend-only, stubbed): **19/19** — switch renders in order, each panel activates + X returns to list, in-list filter toggle + pause/resume, write-to-bus toggle beside the switch.

OpenSpec change archived at `openspec/changes/archive/2026-07-30-frontend-revamp-app-shell/`; adds the `app-shell` capability spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)