### PR TITLE
feat: simplify filter pane with edit/active toggle view (#348)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -217,6 +217,9 @@ function App() {
   const [lastSeenLimit, setLastSeenLimit] = useState(initialUiState.lastSeenLimit);
   const [lastSeenLive, setLastSeenLive] = useState(initialUiState.lastSeenLive);
   const [lastSeenSearch, setLastSeenSearch] = useState(initialUiState.lastSeenSearch);
+  // Master enable/disable of the filter set (#370): when off the list shows all
+  // telegrams while activeFilters is preserved.
+  const [filtersEnabled, setFiltersEnabled] = useState(initialUiState.filtersEnabled);
   const [activeTab, setActiveTab] = useState<'live' | 'history' | 'import'>(
     initialView ? 'history' : initialWorkspace?.tab ?? 'live',
   );
@@ -475,6 +478,7 @@ function App() {
         lastSeenLimit,
         lastSeenLive,
         lastSeenSearch,
+        filtersEnabled,
       });
     }, 500);
     return () => clearTimeout(handle);
@@ -490,6 +494,7 @@ function App() {
     lastSeenLimit,
     lastSeenLive,
     lastSeenSearch,
+    filtersEnabled,
   ]);
 
   // ── Rate Calculation Loop ───────────────────────────────────────────────────
@@ -595,12 +600,14 @@ function App() {
   // ── In-memory filtering (live view) ────────────────────────────────────────
   const filteredLiveTelegrams = useMemo(() => {
     const f = activeFilters;
+    // Master toggle off (#370): show everything, keep the filter set intact.
     const noFilter =
-      f.sources.length === 0 &&
+      !filtersEnabled ||
+      (f.sources.length === 0 &&
       f.targets.length === 0 &&
       f.types.length === 0 &&
       f.directions.length === 0 &&
-      f.dpts.length === 0;
+      f.dpts.length === 0);
 
     // Step 1: mark each row as matching / not-matching
     const matches = sortedLiveTelegrams.map(t =>
@@ -627,7 +634,7 @@ function App() {
         (ts >= mts - f.deltaBeforeMs) && (ts <= mts + f.deltaAfterMs)
       );
     });
-  }, [sortedLiveTelegrams, activeFilters]);
+  }, [sortedLiveTelegrams, activeFilters, filtersEnabled]);
 
   // ── Count bubbles (live only) ───────────────────────────────────────────────
   const filterCounts = useMemo((): FilterCounts => {
@@ -1077,6 +1084,8 @@ function App() {
                     projectLoaded={projectStatus?.project_loaded}
                     onUploadProject={() => setIsSettingsOpen(true)}
                     writeEnabled={serverConfig?.status?.write_enabled}
+                    filtersEnabled={filtersEnabled}
+                    onFiltersEnabledChange={setFiltersEnabled}
                   />
                 </div>
               </div>
@@ -1162,7 +1171,7 @@ function App() {
                         title="Toggle filter panel"
                         style={{
                           position: 'relative',
-                          color: isFilterOpen || hasActiveFilters(activeFilters) ? 'var(--accent-primary)' : 'var(--text-dim)',
+                          color: isFilterOpen || (hasActiveFilters(activeFilters) && filtersEnabled) ? 'var(--accent-primary)' : 'var(--text-dim)',
                         }}
                       >
                         <SlidersHorizontal size={18} />
@@ -1171,7 +1180,8 @@ function App() {
                             position: 'absolute', top: -5, right: -5,
                             fontSize: '0.55rem', fontWeight: 700, minWidth: 14, height: 14,
                             display: 'flex', alignItems: 'center', justifyContent: 'center',
-                            background: 'var(--accent-primary)', color: 'white', borderRadius: '999px',
+                            background: filtersEnabled ? 'var(--accent-primary)' : 'var(--text-dim)',
+                            color: 'white', borderRadius: '999px',
                           }}>{activeFilterCount}</span>
                         )}
                       </button>

--- a/frontend/src/components/FilterPanel.test.tsx
+++ b/frontend/src/components/FilterPanel.test.tsx
@@ -80,11 +80,12 @@ test('active target rows offer send-to-GA and last-seen actions (#214)', () => {
     />
   );
 
-  const active = screen.getByText('Active Filters').parentElement!;
+  // Active rows live in the "Active filters" view (#370), not shown by default.
+  fireEvent.click(screen.getByRole('button', { name: 'Active filters' }));
   // One send trigger: the active GA target row (sources are PAs — no send).
-  expect(within(active).getAllByTitle('Send to this GA')).toHaveLength(1);
+  expect(screen.getAllByTitle('Send to this GA')).toHaveLength(1);
 
-  const lastSeen = within(active).getAllByTitle('Show last seen values');
+  const lastSeen = screen.getAllByTitle('Show last seen values');
   expect(lastSeen).toHaveLength(2); // source (PA) + target (GA)
   fireEvent.click(lastSeen[0]);
   expect(onQuickLastSeen).toHaveBeenCalledWith('1.2.3', 'pa');
@@ -104,9 +105,9 @@ test('hides the send action on active rows when writes are disabled', () => {
       onQuickLastSeen={() => {}}
     />
   );
-  const active = screen.getByText('Active Filters').parentElement!;
-  expect(within(active).queryByTitle('Send to this GA')).not.toBeInTheDocument();
-  expect(within(active).getAllByTitle('Show last seen values')).toHaveLength(2);
+  fireEvent.click(screen.getByRole('button', { name: 'Active filters' }));
+  expect(screen.queryByTitle('Send to this GA')).not.toBeInTheDocument();
+  expect(screen.getAllByTitle('Show last seen values')).toHaveLength(2);
 });
 
 test('opens the quick-send popover from an active target row', async () => {
@@ -124,12 +125,74 @@ test('opens the quick-send popover from an active target row', async () => {
       writeEnabled={true}
     />
   );
-  const active = screen.getByText('Active Filters').parentElement!;
-  fireEvent.click(within(active).getByTitle('Send to this GA'));
+  fireEvent.click(screen.getByRole('button', { name: 'Active filters' }));
+  fireEvent.click(screen.getByTitle('Send to this GA'));
   // The popover shows the last value and the write/read controls.
   expect(await screen.findByText(/Last value/)).toBeInTheDocument();
   expect(screen.getByTitle('Send a GroupValueRead')).toBeInTheDocument();
   vi.unstubAllGlobals();
+});
+
+// ── Edit ↔ Active view + all-AND + master toggle (#370) ──────────────────────
+
+test('toggles Edit ↔ Active views, keeps the count badge, and has no AND/OR control', () => {
+  render(
+    <FilterPanel
+      options={GA_OPTIONS}
+      activeFilters={ACTIVE}
+      onFiltersChange={() => {}}
+      mode="live"
+      projectLoaded={true}
+      writeEnabled={true}
+      onQuickLastSeen={() => {}}
+    />
+  );
+  const header = screen.getByText('Filter').parentElement!;
+
+  // Default = Edit view: category sections shown, active rows hidden.
+  expect(screen.getByText('Direction')).toBeInTheDocument();
+  expect(screen.queryByTitle('Send to this GA')).not.toBeInTheDocument();
+  expect(within(header).getByText('2')).toBeInTheDocument();
+  // All filters AND now — no combination control (#275).
+  expect(screen.queryByText(/Combine as/i)).not.toBeInTheDocument();
+  expect(screen.queryByRole('button', { name: 'OR' })).not.toBeInTheDocument();
+
+  // Switch to Active view: rows appear, category sections gone, badge stays.
+  fireEvent.click(screen.getByRole('button', { name: 'Active filters' }));
+  expect(screen.getByTitle('Send to this GA')).toBeInTheDocument();
+  expect(screen.queryByText('Direction')).not.toBeInTheDocument();
+  expect(within(header).getByText('2')).toBeInTheDocument();
+});
+
+test('master toggle disables the whole set (live only, #370)', () => {
+  const onFiltersEnabledChange = vi.fn();
+  const { rerender } = render(
+    <FilterPanel
+      options={GA_OPTIONS}
+      activeFilters={ACTIVE}
+      onFiltersChange={() => {}}
+      mode="live"
+      projectLoaded={true}
+      filtersEnabled={true}
+      onFiltersEnabledChange={onFiltersEnabledChange}
+    />
+  );
+  fireEvent.click(screen.getByTitle('Disable all filters (keeps them)'));
+  expect(onFiltersEnabledChange).toHaveBeenCalledWith(false);
+
+  // Not offered in history mode (there the filter is the query).
+  rerender(
+    <FilterPanel
+      options={GA_OPTIONS}
+      activeFilters={ACTIVE}
+      onFiltersChange={() => {}}
+      mode="history"
+      projectLoaded={true}
+      filtersEnabled={true}
+      onFiltersEnabledChange={onFiltersEnabledChange}
+    />
+  );
+  expect(screen.queryByTitle(/Disable all filters|Enable filters/)).not.toBeInTheDocument();
 });
 
 test('hides the notice when a project is loaded', () => {

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { Search, ChevronDown, ChevronRight, SlidersHorizontal, X, Clock, FolderInput, AlertTriangle } from 'lucide-react';
+import { Search, ChevronDown, ChevronRight, SlidersHorizontal, X, Clock, FolderInput, AlertTriangle, Power } from 'lucide-react';
 import {
   type FilterOptions,
   type ActiveFilters,
@@ -52,6 +52,14 @@ interface FilterPanelProps {
   /** Opens the project upload flow (Settings). Enables the notice's CTA button. */
   onUploadProject?: () => void;
   writeEnabled?: boolean;
+  /**
+   * Master enable/disable of the whole filter set (live mode only, #370). When
+   * `false` the list shows all telegrams while `activeFilters` is preserved. Absent
+   * behaves as enabled; the toggle renders only when `onFiltersEnabledChange` is
+   * provided and `mode === 'live'`.
+   */
+  filtersEnabled?: boolean;
+  onFiltersEnabledChange?: (enabled: boolean) => void;
 }
 
 interface SectionProps {
@@ -200,8 +208,15 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
   projectLoaded,
   onUploadProject,
   writeEnabled,
+  filtersEnabled = true,
+  onFiltersEnabledChange,
 }) => {
   const [search, setSearch] = useState('');
+  // The pane shows one of two views (#370): Edit filters (category controls) or
+  // Active filters (the current set). No auto-inserted active block, so editing
+  // never repositions entries (#87).
+  const [view, setView] = useState<'edit' | 'active'>('edit');
+  const showMasterToggle = mode === 'live' && !!onFiltersEnabledChange;
 
   // Source/target/DPT options come from the ETS project. Without one, those
   // filters are empty and searching them turns up nothing — surface why.
@@ -275,40 +290,81 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           {activeCount > 0 && (
             <span style={{
               fontSize: '0.65rem', fontWeight: 700, padding: '0.1rem 0.45rem',
-              borderRadius: '999px', background: 'var(--accent-primary)', color: 'white',
+              borderRadius: '999px',
+              background: filtersEnabled ? 'var(--accent-primary)' : 'var(--text-dim)',
+              color: 'white',
             }}>
               {activeCount}
             </span>
           )}
         </div>
-        {activeCount > 0 && (
-          <button
-            onClick={() => onFiltersChange(DEFAULT_FILTERS)}
-            title="Clear all filters"
-            style={{
-              background: 'transparent', border: 'none', cursor: 'pointer',
-              color: 'var(--text-dim)', display: 'flex', alignItems: 'center',
-              padding: '0.2rem', borderRadius: '4px', transition: 'color 0.15s',
-            }}
-            onMouseEnter={e => (e.currentTarget.style.color = 'var(--text-main)')}
-            onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
-          >
-            <X size={14} />
-          </button>
-        )}
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+          {/* Master enable/disable — keeps the set, hides its effect (#370) */}
+          {showMasterToggle && (
+            <button
+              onClick={() => onFiltersEnabledChange!(!filtersEnabled)}
+              title={filtersEnabled ? 'Disable all filters (keeps them)' : 'Enable filters'}
+              style={{
+                background: 'transparent', border: 'none', cursor: 'pointer',
+                color: filtersEnabled ? 'var(--accent-primary)' : 'var(--text-dim)',
+                display: 'flex', alignItems: 'center', padding: '0.2rem', borderRadius: '4px',
+              }}
+            >
+              <Power size={14} />
+            </button>
+          )}
+          {activeCount > 0 && (
+            <button
+              onClick={() => onFiltersChange(DEFAULT_FILTERS)}
+              title="Clear all filters"
+              style={{
+                background: 'transparent', border: 'none', cursor: 'pointer',
+                color: 'var(--text-dim)', display: 'flex', alignItems: 'center',
+                padding: '0.2rem', borderRadius: '4px', transition: 'color 0.15s',
+              }}
+              onMouseEnter={e => (e.currentTarget.style.color = 'var(--text-main)')}
+              onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
       </div>
 
-      {/* Active filters */}
-      {activeCount > 0 && (
-        <div style={{
-          padding: '0.5rem 0.75rem',
-          borderBottom: '1px solid var(--border-color)',
-          background: 'var(--bg-subtle)',
-          flexShrink: 0,
-          overflowY: 'auto',
-          maxHeight: '40%',
-        }}>
-          <div style={{ fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.4rem', paddingLeft: '0.25rem' }}>Active Filters</div>
+      {/* View toggle: Edit filters ↔ Active filters (#370) */}
+      <div style={{
+        display: 'flex', gap: '0.25rem', padding: '0.5rem 0.75rem',
+        borderBottom: '1px solid var(--border-color)', flexShrink: 0,
+      }}>
+        {(['edit', 'active'] as const).map(v => {
+          const isActive = view === v;
+          return (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              style={{
+                flex: 1, padding: '0.35rem 0.5rem', borderRadius: '6px',
+                fontSize: '0.75rem', fontWeight: 600, cursor: 'pointer',
+                border: '1px solid',
+                borderColor: isActive ? 'var(--accent-primary)' : 'var(--border-color)',
+                background: isActive ? 'rgba(99,102,241,0.15)' : 'transparent',
+                color: isActive ? 'var(--accent-primary)' : 'var(--text-dim)',
+              }}
+            >
+              {v === 'edit' ? 'Edit filters' : 'Active filters'}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Active filters view */}
+      {view === 'active' && (
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0.5rem 0.75rem' }}>
+          {activeCount === 0 && (
+            <div style={{ fontSize: '0.78rem', color: 'var(--text-dim)', padding: '0.5rem 0.25rem', lineHeight: 1.5 }}>
+              No active filters. Switch to <strong>Edit filters</strong> to add some.
+            </div>
+          )}
           {activeFilters.sources.map(s => {
             const name = options.sources.find(opt => opt.address === s)?.name;
             return (
@@ -324,23 +380,6 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               />
             );
           })}
-          {activeFilters.sources.length > 0 && activeFilters.targets.length > 0 && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', padding: '0.2rem 0.25rem' }}>
-              {(['AND', 'OR'] as const).map(m => (
-                <button
-                  key={m}
-                  onClick={() => update({ sourceTargetRelation: m })}
-                  style={{
-                    padding: '0.1rem 0.45rem', borderRadius: '4px', fontSize: '0.65rem',
-                    fontWeight: 600, cursor: 'pointer', border: '1px solid',
-                    borderColor: activeFilters.sourceTargetRelation === m ? 'var(--accent-primary)' : 'var(--border-color)',
-                    background: activeFilters.sourceTargetRelation === m ? 'rgba(99,102,241,0.15)' : 'transparent',
-                    color: activeFilters.sourceTargetRelation === m ? 'var(--accent-primary)' : 'var(--text-dim)',
-                  }}
-                >{m}</button>
-              ))}
-            </div>
-          )}
           {activeFilters.targets.map(t => {
             const opt = options.targets.find(o => o.address === t);
             return (
@@ -406,6 +445,8 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         </div>
       )}
 
+      {/* Edit filters view: search + category sections */}
+      {view === 'edit' && (<>
       {/* Search bar */}
       <div style={{ padding: '0.75rem', borderBottom: '1px solid var(--border-color)', flexShrink: 0 }}>
         <div style={{
@@ -492,31 +533,6 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
               writeEnabled={writeEnabled}
             />
           </Section>
-        )}
-
-        {/* AND / OR relation toggle — shown only when both sides have active selections */}
-        {activeFilters.sources.length > 0 && activeFilters.targets.length > 0 && (
-          <div style={{ padding: '0.4rem 1rem', borderBottom: '1px solid var(--border-color)', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-            <span style={{ fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', flexShrink: 0 }}>Combine as</span>
-            {(['AND', 'OR'] as const).map(mode => (
-              <button
-                key={mode}
-                onClick={() => update({ sourceTargetRelation: mode })}
-                title={mode === 'AND'
-                  ? 'Show telegrams matching a selected source AND a selected target'
-                  : 'Show telegrams matching any selected source OR any selected target'}
-                style={{
-                  padding: '0.15rem 0.55rem', borderRadius: '4px', fontSize: '0.7rem',
-                  fontWeight: 600, cursor: 'pointer', border: '1px solid',
-                  borderColor: activeFilters.sourceTargetRelation === mode ? 'var(--accent-primary)' : 'var(--border-color)',
-                  background: activeFilters.sourceTargetRelation === mode ? 'rgba(99,102,241,0.15)' : 'transparent',
-                  color: activeFilters.sourceTargetRelation === mode ? 'var(--accent-primary)' : 'var(--text-dim)',
-                }}
-              >
-                {mode}
-              </button>
-            ))}
-          </div>
         )}
 
         {/* Target */}
@@ -640,6 +656,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
         </Section>
 
       </div>
+      </>)}
     </div>
   );
 };

--- a/frontend/src/types/filters.test.ts
+++ b/frontend/src/types/filters.test.ts
@@ -72,3 +72,20 @@ describe('matchesTelegram direction filtering (#194)', () => {
     expect(matchesTelegram(undirected, { ...DEFAULT_FILTERS, directions: ['Incoming'] })).toBe(false);
   });
 });
+
+describe('matchesTelegram source/target combination (#275)', () => {
+  const t = { source_address: '1.2.3', target_address: '0/1/2', simplified_type: 'Write' };
+
+  test('source and target always combine with AND', () => {
+    const f = { ...DEFAULT_FILTERS, sources: ['1.2.3'], targets: ['0/1/2'] };
+    expect(matchesTelegram(t, f)).toBe(true);
+    expect(matchesTelegram({ ...t, target_address: '9/9/9' }, f)).toBe(false);
+    expect(matchesTelegram({ ...t, source_address: '9.9.9' }, f)).toBe(false);
+  });
+
+  test('legacy sourceTargetRelation="OR" is ignored and applied as AND', () => {
+    const legacy = { ...DEFAULT_FILTERS, sources: ['1.2.3'], targets: ['0/1/2'], sourceTargetRelation: 'OR' as const };
+    expect(matchesTelegram({ ...t, target_address: '9/9/9' }, legacy)).toBe(false);
+    expect(matchesTelegram(t, legacy)).toBe(true);
+  });
+});

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -32,19 +32,10 @@ export interface ActiveFilters {
   /** ms after a matching telegram to also include (0 = disabled) */
   deltaAfterMs: number;
   /**
-   * Controls how Source and Target filters combine when both are active.
-   *
-   * AND (default): a telegram must match a selected source AND a selected target.
-   *   Use when diagnosing traffic between specific devices and group addresses.
-   *
-   * OR: a telegram matches if it matches any selected source OR any selected target.
-   *   Use when you want to see everything from a device alongside everything sent
-   *   to a particular group address, regardless of which side triggered it.
-   *
-   * Within each category (multiple sources, multiple targets) the logic is always OR.
-   * OR mode requires two backend queries for history (one per side) whose results are
-   * merged client-side, because the knx-telegram-store library does not support
-   * cross-category OR natively.
+   * @deprecated All active filters combine with AND (#275); this no longer affects
+   * matching. Retained only so old shared links / workspaces carrying `rel_st=OR`
+   * still parse without error — they load and apply as AND. Cross-category OR returns
+   * later as multiple filter instances (#370). Do not read this for matching.
    */
   sourceTargetRelation: 'AND' | 'OR';
 }
@@ -101,11 +92,10 @@ export function matchesTelegram(t: FilterableTelegram, f: ActiveFilters): boolea
   const dirOk = f.directions.length === 0 || f.directions.includes(t.direction ?? '');
   const dptOk = f.dpts.length === 0 || matchesDpt(f.dpts, t.dpt_main, t.dpt_sub);
 
-  const srcTgtOk = f.sources.length > 0 && f.targets.length > 0
-    ? (f.sourceTargetRelation === 'OR' ? (srcMatch || tgtMatch) : (srcOk && tgtOk))
-    : (srcOk && tgtOk);
-
-  return srcTgtOk && typeOk && dirOk && dptOk;
+  // All active filters combine with AND (#275). `sourceTargetRelation` is retained
+  // on the type only for backward-compatible parsing of old `rel_st=OR` links; it no
+  // longer affects matching. OR returns later as multiple filter instances (#370).
+  return srcOk && tgtOk && typeOk && dirOk && dptOk;
 }
 
 export function hasActiveFilters(f: ActiveFilters): boolean {

--- a/frontend/src/utils/historyLoad.ts
+++ b/frontend/src/utils/historyLoad.ts
@@ -69,8 +69,7 @@ export function rangeToMs(range: LoadedRange, nowMs = Date.now()): { startMs: nu
 
 /**
  * Fetches history telegrams for a range with server-side filters applied.
- * OR source/target relation is handled with two queries merged client-side,
- * because the knx-telegram-store library only supports AND across the two.
+ * All active filters combine with AND (#275), so a single query suffices.
  */
 export async function loadHistoryTelegrams(
   range: LoadedRange,
@@ -78,34 +77,6 @@ export async function loadHistoryTelegrams(
   filters?: ActiveFilters,
 ): Promise<{ telegrams: Telegram[]; metadata: HistoryMetadata }> {
   const baseUrl = buildHistoryUrl(range, limit);
-  const isOrMode = filters?.sourceTargetRelation === 'OR'
-    && (filters.sources.length > 0)
-    && (filters.targets.length > 0);
-
-  if (isOrMode) {
-    const srcFilters = { ...filters, targets: [], sourceTargetRelation: 'AND' as const };
-    const tgtFilters = { ...filters, sources: [], sourceTargetRelation: 'AND' as const };
-    const [srcRes, tgtRes] = await Promise.all([
-      fetch(applyFilterParams(baseUrl, srcFilters)),
-      fetch(applyFilterParams(baseUrl, tgtFilters)),
-    ]);
-    if (!srcRes.ok || !tgtRes.ok) throw new Error(`Server error: ${srcRes.ok ? tgtRes.status : srcRes.status}`);
-    const [srcData, tgtData] = await Promise.all([srcRes.json(), tgtRes.json()]);
-
-    const seen = new Set<string>();
-    const merged: Telegram[] = [];
-    for (const t of [...(srcData.telegrams || []), ...(tgtData.telegrams || [])]) {
-      if (!seen.has(t.timestamp)) {
-        seen.add(t.timestamp);
-        merged.push(t);
-      }
-    }
-    // Re-sort descending (both halves arrive sorted but interleaved)
-    merged.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
-    const limitReached = (srcData.metadata?.limit_reached || tgtData.metadata?.limit_reached) ?? false;
-    return { telegrams: merged, metadata: { total_count: merged.length, limit_reached: limitReached } };
-  }
-
   const res = await fetch(applyFilterParams(baseUrl, filters));
   if (!res.ok) throw new Error(`Server error: ${res.status}`);
   const data = await res.json();

--- a/frontend/src/utils/uiState.test.ts
+++ b/frontend/src/utils/uiState.test.ts
@@ -27,6 +27,7 @@ test('round-trip save/load works correctly', () => {
     lastSeenLimit: 50,
     lastSeenLive: false,
     lastSeenSearch: 'lastseen',
+    filtersEnabled: false,
   };
 
   saveUiState(state);

--- a/frontend/src/utils/uiState.ts
+++ b/frontend/src/utils/uiState.ts
@@ -12,6 +12,8 @@ export interface UiSessionState {
   lastSeenLimit: number;
   lastSeenLive: boolean;
   lastSeenSearch: string;
+  /** Master enable/disable of the filter set (#370); absent → enabled. */
+  filtersEnabled: boolean;
 }
 
 export const DEFAULT_UI_STATE: UiSessionState = {
@@ -28,6 +30,7 @@ export const DEFAULT_UI_STATE: UiSessionState = {
   lastSeenLimit: 20,
   lastSeenLive: true,
   lastSeenSearch: '',
+  filtersEnabled: true,
 };
 
 export const UI_STORAGE_KEY = 'spectrum-knx-ui';
@@ -85,5 +88,6 @@ function sanitize(p: Partial<StoredUiState>): UiSessionState {
     lastSeenLimit: typeof p.lastSeenLimit === 'number' ? p.lastSeenLimit : 20,
     lastSeenLive: typeof p.lastSeenLive === 'boolean' ? p.lastSeenLive : true,
     lastSeenSearch: typeof p.lastSeenSearch === 'string' ? p.lastSeenSearch : '',
+    filtersEnabled: typeof p.filtersEnabled === 'boolean' ? p.filtersEnabled : true,
   };
 }

--- a/frontend/src/utils/viewUrl.test.ts
+++ b/frontend/src/utils/viewUrl.test.ts
@@ -57,7 +57,9 @@ describe('buildViewUrl', () => {
         dpts: ['9.001'],
         deltaBeforeMs: 250,
         deltaAfterMs: 0,
-        sourceTargetRelation: 'OR' as const,
+        // All filters combine with AND now (#275); `rel_st` is no longer written,
+        // so only AND round-trips. Old OR links are covered separately below.
+        sourceTargetRelation: 'AND' as const,
       },
       range: { kind: 'relative' as const, seconds: 6 * 3600 },
       limit: 10000,

--- a/frontend/src/utils/viewUrl.ts
+++ b/frontend/src/utils/viewUrl.ts
@@ -101,7 +101,8 @@ export function buildViewUrl(state: {
   if (f.dpts.length > 0) p.set('dpt', f.dpts.join(','));
   if (f.deltaBeforeMs > 0) p.set('before', String(f.deltaBeforeMs));
   if (f.deltaAfterMs > 0) p.set('after', String(f.deltaAfterMs));
-  if (f.sourceTargetRelation === 'OR') p.set('rel_st', 'OR');
+  // `rel_st` is no longer written — all filters combine with AND (#275). Old links
+  // carrying rel_st=OR are still parsed above and load (harmlessly) as AND.
   if (state.range.kind === 'relative') {
     p.set('rel', formatRel(state.range.seconds));
   } else {

--- a/frontend/src/utils/workspaceState.test.ts
+++ b/frontend/src/utils/workspaceState.test.ts
@@ -24,7 +24,8 @@ const sampleWorkspace = (): WorkspaceState => ({
     dpts: ['1.001', '9'],
     deltaBeforeMs: 500,
     deltaAfterMs: 1000,
-    sourceTargetRelation: 'OR',
+    // Only AND round-trips now — `rel_st` is no longer written (#275).
+    sourceTargetRelation: 'AND',
   },
   plot: ['0/1/2'],
   lastSeenAddresses: ['0/1/2'],

--- a/frontend/src/utils/workspaceState.ts
+++ b/frontend/src/utils/workspaceState.ts
@@ -131,7 +131,8 @@ export function buildMonitorSearch(state: WorkspaceState): string {
   if (f.dpts.length > 0) p.set('dpt', f.dpts.join(','));
   if (f.deltaBeforeMs > 0) p.set('before', String(f.deltaBeforeMs));
   if (f.deltaAfterMs > 0) p.set('after', String(f.deltaAfterMs));
-  if (f.sourceTargetRelation === 'OR') p.set('rel_st', 'OR');
+  // `rel_st` is no longer written — all filters combine with AND (#275). Old links
+  // carrying rel_st=OR are still parsed above and load (harmlessly) as AND.
   if (state.plot.length > 0) p.set('plot', state.plot.join(','));
   if (state.lastSeenAddresses.length > 0) p.set('ls', state.lastSeenAddresses.join(','));
   if (state.lastSeenMode !== 'ga') p.set('lsm', state.lastSeenMode);

--- a/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-30

--- a/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/design.md
+++ b/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/design.md
@@ -1,0 +1,103 @@
+## Context
+
+See `proposal.md` — Why. Current `FilterPanel.tsx` facts that shape the design:
+
+- The pane renders a **Header** ("Filter" + active-count badge + a clear-all X shown
+  when `activeCount > 0`), then an **Active Filters** block rendered inline whenever
+  `activeCount > 0` (`maxHeight: 40%`, its own scroll), then the **Edit** category
+  `Section`s (Source / Target / Type / Direction / DPT / Time-Delta). The active
+  block is what shifts the layout as filters change.
+- Combination is `sourceTargetRelation: 'AND' | 'OR'` on `ActiveFilters`. It is used
+  in `matchesTelegram` (types/filters.ts:105), split into two queries for OR in
+  `historyLoad.ts` (81–87), written/read as `rel_st` in `viewUrl.ts` and
+  `workspaceState.ts`, and toggled by two UI blocks in `FilterPanel.tsx` (≈329 for
+  the live active block, ≈504 for the history edit view).
+- The panel is shared by two modes: `mode: 'live'` (Telegram List) and `mode:
+  'history'` (History Search). Counts (`counts`) are live-only.
+- The app already has the pattern for a "temporarily disabled but preserved"
+  toggle: `quickFilterEnabled` (App state, persisted in `uiState`, mirrored into
+  `TelegramTable`). The master filter toggle follows it.
+- After #374 the filter pane is list-only and its open/close toggle lives in the
+  Telegram List panel header; the list-header filter badge reads `activeFilterCount`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the auto-populating active block; make Edit vs Active an explicit,
+  user-controlled view so filter entries stop moving (#87).
+- Always-AND combination; delete the AND/OR UI without breaking old shared links.
+- A master enable/disable that preserves the set, mirroring quick-filter enabled.
+
+**Non-Goals:**
+- Multiple filter instances / OR tab strip (#275), categories + counts + resizable
+  sub-panes (#272), the reusable sidebar (#363), and cross-panel reuse (#275 B/C).
+- Any change to which panels see the filter (still list + history only, per #374).
+- Removing `sourceTargetRelation` from the type/URL wholesale (kept, neutralized).
+
+## Decisions
+
+### Decision 1: Header view toggle drives one pane body; no inline active block
+
+Add `view: 'edit' | 'active'` local state to `FilterPanel`, defaulting to `'edit'`.
+A segmented control in the pane header switches it. The body renders **either** the
+Edit `Section`s **or** the Active view (the current active-block markup, moved out of
+its auto-inserted position). The active block is no longer rendered above Edit, so
+editing never reflows the entries. The header keeps the active-count badge and the
+clear-all X.
+
+- **Alternative considered:** keep both stacked but pin the active block's height.
+  Rejected — it still reflows and still splits attention; #272/#275 ask to dismiss
+  it, not shrink it.
+- The toggle sits in the header (not by the search line) because there is no single
+  search line today and the header is the stable, always-present anchor #275
+  describes ("in the 'Filter' Header").
+
+### Decision 2: All-AND matching; neutralize `sourceTargetRelation`
+
+`matchesTelegram` always requires source AND target (drop the `=== 'OR'` branch).
+`historyLoad.ts` always issues the single AND query (remove the OR split). Remove
+both AND/OR toggle UI blocks. Keep the `sourceTargetRelation` field on `ActiveFilters`
+(default `'AND'`) so `viewUrl`/`workspaceState` still parse old `rel_st=OR` links
+without error — the value is simply ignored by matching, so such links load as AND.
+Stop writing `rel_st` going forward.
+
+- **Alternative considered:** delete the field entirely. Rejected for this slice —
+  it ripples through URL/workspace parsing and offers no user benefit now; a clean
+  removal can ride along with the multi-instance work that reshapes the filter model.
+
+### Decision 3: Master enable/disable = a `filtersEnabled` flag lifted to App
+
+Model the master toggle as `filtersEnabled: boolean` (default `true`) in `App`,
+persisted in `uiState` next to `quickFilter.enabled`. `filteredLiveTelegrams` treats
+`!filtersEnabled` as the no-filter path (show everything) without clearing
+`activeFilters`. `FilterPanel` receives `filtersEnabled` + `onFiltersEnabledChange`
+and renders the toggle (an "(in)active" control, matching the quick-filter idiom).
+The list-header filter badge/accent reflects "has filters AND enabled".
+
+- Scope: **live mode only.** In history mode the filter *is* the query, so a
+  "show all history" master switch is out of place; the toggle is hidden (or inert)
+  when `mode === 'history'`. The Edit/Active view toggle still applies to both modes.
+- Reuse `matchesTelegram` untouched; gating happens where `filteredLiveTelegrams`
+  already computes `noFilter`, so no matching-path duplication.
+
+### Decision 4: Active view content unchanged per entry
+
+The Active view keeps the existing per-entry rows (label, sublabel, count, remove,
+quick actions like Last-Seen / SendToGa). Only its placement and trigger change. The
+AND/OR relation row between sources and targets is deleted (Decision 2).
+
+## Risks / Trade-offs
+
+- **Old OR-mode links silently become AND.** Acceptable and documented; OR returns as
+  multiple instances later. No error, no data loss — just a wider result set than the
+  original author intended, which the user can re-narrow.
+- **Two-mode component.** The master toggle must be correctly gated to live mode so
+  History Search behavior is unchanged. Covered by keeping the toggle behind
+  `mode === 'live'` and by tests for both modes.
+- **Discoverability of the Active view.** Removing the always-on block hides the
+  active set behind a toggle; mitigate with the persistent active-count badge in the
+  header so the user still sees *that* filters are active and can one-click to view
+  them.
+- **Persistence shape drift.** Adding `filtersEnabled` to `uiState` must be
+  backward-compatible (absent → default `true`); follow the existing `DEFAULT_UI_STATE`
+  merge so older stored state loads cleanly.

--- a/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/proposal.md
+++ b/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+The filter pane's "Active Filters" block auto-populates above the edit sections the
+moment a filter is toggled, so the edit controls and filter entries shift under the
+user's cursor while they work (#87). It is, in #272's words, "so distracting." The
+pane also carries a source/target **AND / OR** toggle that #275 explicitly wants
+gone — filters should always be AND'd, with OR reserved for a later multi-instance
+design. And there is no way to see everything again briefly without tearing the
+filter set down and rebuilding it.
+
+This is slice A — the "core UX change" — of the Filter & sidebar redesign (#370),
+which is the second foundational epic of the Frontend Revamp (#287) after the app
+shell (#374). It stands alone and unblocks the later reuse slices.
+
+## What Changes
+
+- **One pane, two views.** The auto-populating "Active Filters" block is removed. A
+  control in the pane's "Filter" header toggles the pane body between an **Edit
+  filters** view (the category sections) and an **Active filters** view (the current
+  filter set, each entry removable / individually toggleable). Filter entries no
+  longer move around as filters are edited.
+- **All-AND semantics.** The source/target AND / OR toggle is removed from the UI and
+  no longer affects matching — all active filters are combined with AND. Shared links
+  and saved workspaces that carry the old `rel_st=OR` parameter still load, degrading
+  gracefully to AND (OR returns later as multiple filter instances, a deferred #370
+  slice).
+- **Master enable/disable.** A "filters active / inactive" toggle temporarily
+  disables the whole filter set without clearing it, mirroring the quick-filter
+  enabled toggle; while disabled the Telegram List shows all telegrams and the set is
+  preserved for re-enabling.
+- **Per-filter control retained.** Removing or toggling an individual filter from the
+  Active view works as before.
+
+Out of scope / deferred to later #370 slices: the multiple-filter-instance OR'd tab
+strip (#275); source/target filter categories, resizable sub-panes, and live
+hierarchical counts (#272, slice B); the reusable Visualizer / Last-Seen sidebar
+component (#363, slice C); and cross-panel filter reuse that would revert #241
+(#275 B/C, slice D). Filters remain list-only per #374.
+
+## Capabilities
+
+### New Capabilities
+- `filter-pane`: the Telegram List filter pane — its Edit ↔ Active view toggle, the
+  removal of the auto-populating active block, all-AND combination semantics with
+  backward-compatible `rel_st` parsing, the master enable/disable toggle, and
+  per-filter control in the Active view.
+
+### Modified Capabilities
+<!-- None captured yet: no prior spec describes the filter pane; this is the first. -->
+
+## Impact
+
+- **Frontend only.** No backend or API change.
+- `frontend/src/components/FilterPanel.tsx` — replace the always-rendered active
+  block with a header view toggle and an Active view; remove both source/target
+  AND/OR toggle UIs.
+- `frontend/src/types/filters.ts` — `matchesTelegram` always ANDs source/target
+  (drop the `sourceTargetRelation === 'OR'` branch); the field is retained but
+  neutral for backward compatibility.
+- `frontend/src/utils/historyLoad.ts` — remove the OR-mode query split; always the
+  single AND query.
+- `frontend/src/App.tsx` — add a `filtersEnabled` UI-session flag (default on),
+  passed to `FilterPanel` and applied so `filteredLiveTelegrams` shows everything
+  when disabled; the list-header filter badge reflects the enabled state.
+- `frontend/src/utils/uiState.ts` — persist `filtersEnabled` alongside the other
+  session state (`quickFilter.enabled` is the model to follow).
+- `viewUrl.ts` / `workspaceState.ts` — keep reading `rel_st` for old links but stop
+  writing it; behavior is AND regardless.

--- a/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/specs/filter-pane/spec.md
+++ b/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/specs/filter-pane/spec.md
@@ -1,0 +1,91 @@
+## Purpose
+
+Defines the Telegram List filter pane's structure and semantics: the toggle between
+an Edit-filters view and an Active-filters view, the removal of the auto-populating
+active block, all-AND combination of active filters, the master enable/disable of the
+whole filter set, and per-filter control in the Active view.
+
+## ADDED Requirements
+
+### Requirement: Edit and Active views toggle in one pane
+
+The filter pane SHALL present its body as one of two views — an Edit-filters view
+(the filter category controls) or an Active-filters view (the set of currently active
+filters) — and SHALL provide a control in the pane header to switch between them. The
+pane SHALL NOT render the active filters above the edit controls automatically, so
+editing filters does not reposition existing filter entries.
+
+#### Scenario: Switching to the Active view
+
+- **WHEN** the pane is showing the Edit view and the user activates the view toggle
+- **THEN** the pane shows the Active-filters view listing the currently active filters
+
+#### Scenario: Editing does not move entries
+
+- **WHEN** the user toggles a filter on or off in the Edit view
+- **THEN** the edit controls stay in place and no active-filters block appears above
+  them
+
+#### Scenario: Active count remains visible
+
+- **WHEN** one or more filters are active
+- **THEN** the pane header shows the count of active filters regardless of the current
+  view
+
+### Requirement: Active filters are combined with AND
+
+All active filters SHALL be combined with AND when determining whether a telegram
+matches; there SHALL be no user control to combine source and target filters with OR.
+
+#### Scenario: Source and target both required
+
+- **WHEN** a source filter and a target filter are both active
+- **THEN** only telegrams matching the source AND the target are shown
+
+#### Scenario: No AND/OR control is present
+
+- **WHEN** the user views the filter pane
+- **THEN** there is no control to switch source/target combination between AND and OR
+
+### Requirement: Legacy OR links load as AND
+
+A shared link or saved workspace that carries the legacy source/target OR parameter
+SHALL load without error, and its filters SHALL be applied with AND.
+
+#### Scenario: Old OR link degrades to AND
+
+- **WHEN** the user opens a link whose parameters request source/target OR combination
+- **THEN** the app loads the link's filters and applies them with AND
+
+### Requirement: Master enable/disable of the filter set
+
+The filter pane SHALL provide a control to temporarily disable the entire active
+filter set without clearing it, and to re-enable it. While the set is disabled, the
+Telegram List SHALL show all telegrams, and the active filters SHALL be preserved so
+that re-enabling restores the previous result.
+
+#### Scenario: Disabling shows everything
+
+- **WHEN** filters are active and the user disables the filter set
+- **THEN** the Telegram List shows all telegrams and the filters are not cleared
+
+#### Scenario: Re-enabling restores the filtered result
+
+- **WHEN** the filter set has been disabled and the user re-enables it
+- **THEN** the Telegram List again shows only telegrams matching the preserved filters
+
+#### Scenario: Disabled state persists across navigation
+
+- **WHEN** the user disables the filter set and navigates away and back to the
+  Telegram List
+- **THEN** the filter set is still disabled and still preserved
+
+### Requirement: Per-filter control in the Active view
+
+From the Active-filters view, the user SHALL be able to remove or toggle an individual
+active filter, leaving the other active filters unchanged.
+
+#### Scenario: Removing one active filter
+
+- **WHEN** several filters are active and the user removes one from the Active view
+- **THEN** that filter is no longer active and the remaining filters stay active

--- a/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/tasks.md
+++ b/openspec/changes/archive/2026-07-31-filter-pane-edit-active-view/tasks.md
@@ -1,0 +1,28 @@
+## 1. Edit ↔ Active view toggle
+
+- [x] 1.1 Add `view: 'edit' | 'active'` local state to `FilterPanel` (default `'edit'`) and a segmented toggle in the pane header.
+- [x] 1.2 Move the existing active-filters markup out of its auto-inserted position; render it as the Active view body, and render the Edit `Section`s as the Edit view body — one or the other, never stacked.
+- [x] 1.3 Keep the header active-count badge and clear-all X visible in both views.
+
+## 2. All-AND semantics
+
+- [x] 2.1 In `types/filters.ts` `matchesTelegram`, always require source AND target (drop the `sourceTargetRelation === 'OR'` branch).
+- [x] 2.2 In `utils/historyLoad.ts`, remove the OR-mode query split; always issue the single AND query.
+- [x] 2.3 Remove both source/target AND/OR toggle UI blocks from `FilterPanel` (the live active block and the history edit view).
+- [x] 2.4 Keep the `sourceTargetRelation` field (default `'AND'`) so `viewUrl`/`workspaceState` still parse old `rel_st=OR` links; stop writing `rel_st` going forward.
+
+## 3. Master enable/disable
+
+- [x] 3.1 Add `filtersEnabled` state to `App` (default `true`); persist it in `uiState` alongside `quickFilter.enabled`, with absent → `true` on load.
+- [x] 3.2 Apply it where `filteredLiveTelegrams` computes `noFilter`: when `!filtersEnabled`, show all telegrams without clearing `activeFilters`.
+- [x] 3.3 Pass `filtersEnabled` + `onFiltersEnabledChange` into `FilterPanel`; render the enable/disable control (matching the quick-filter "(in)active" idiom). Gate it to `mode === 'live'`.
+- [x] 3.4 Make the list-header filter badge/accent reflect "has active filters AND enabled".
+
+## 4. Verify
+
+- [x] 4.1 `FilterPanel` tests: header toggle switches Edit ↔ Active; editing in the Edit view does not render an active block above it; active-count badge shows in both views; no AND/OR control exists; per-filter remove works from the Active view.
+- [x] 4.2 `matchesTelegram` tests: source+target always AND (including a fixture that previously set OR now behaving as AND).
+- [x] 4.3 App/uiState tests: `filtersEnabled=false` shows all telegrams while preserving `activeFilters`; state persists via `uiState`; absent value defaults to enabled.
+- [x] 4.4 Backward-compat test: a URL/workspace with `rel_st=OR` loads and applies filters as AND.
+- [x] 4.5 Run frontend typecheck, lint, and the full unit suite; fix fallout.
+- [x] 4.6 Manual pass (Playwright against the Vite dev server): toggle Edit ↔ Active, confirm entries don't reflow while editing, disable/enable the whole set and confirm the list widens/narrows while filters persist, and confirm no AND/OR control remains.

--- a/openspec/specs/filter-pane/spec.md
+++ b/openspec/specs/filter-pane/spec.md
@@ -1,0 +1,91 @@
+## Purpose
+
+Defines the Telegram List filter pane's structure and semantics: the toggle between
+an Edit-filters view and an Active-filters view, the removal of the auto-populating
+active block, all-AND combination of active filters, the master enable/disable of the
+whole filter set, and per-filter control in the Active view.
+
+## Requirements
+
+### Requirement: Edit and Active views toggle in one pane
+
+The filter pane SHALL present its body as one of two views — an Edit-filters view
+(the filter category controls) or an Active-filters view (the set of currently active
+filters) — and SHALL provide a control in the pane header to switch between them. The
+pane SHALL NOT render the active filters above the edit controls automatically, so
+editing filters does not reposition existing filter entries.
+
+#### Scenario: Switching to the Active view
+
+- **WHEN** the pane is showing the Edit view and the user activates the view toggle
+- **THEN** the pane shows the Active-filters view listing the currently active filters
+
+#### Scenario: Editing does not move entries
+
+- **WHEN** the user toggles a filter on or off in the Edit view
+- **THEN** the edit controls stay in place and no active-filters block appears above
+  them
+
+#### Scenario: Active count remains visible
+
+- **WHEN** one or more filters are active
+- **THEN** the pane header shows the count of active filters regardless of the current
+  view
+
+### Requirement: Active filters are combined with AND
+
+All active filters SHALL be combined with AND when determining whether a telegram
+matches; there SHALL be no user control to combine source and target filters with OR.
+
+#### Scenario: Source and target both required
+
+- **WHEN** a source filter and a target filter are both active
+- **THEN** only telegrams matching the source AND the target are shown
+
+#### Scenario: No AND/OR control is present
+
+- **WHEN** the user views the filter pane
+- **THEN** there is no control to switch source/target combination between AND and OR
+
+### Requirement: Legacy OR links load as AND
+
+A shared link or saved workspace that carries the legacy source/target OR parameter
+SHALL load without error, and its filters SHALL be applied with AND.
+
+#### Scenario: Old OR link degrades to AND
+
+- **WHEN** the user opens a link whose parameters request source/target OR combination
+- **THEN** the app loads the link's filters and applies them with AND
+
+### Requirement: Master enable/disable of the filter set
+
+The filter pane SHALL provide a control to temporarily disable the entire active
+filter set without clearing it, and to re-enable it. While the set is disabled, the
+Telegram List SHALL show all telegrams, and the active filters SHALL be preserved so
+that re-enabling restores the previous result.
+
+#### Scenario: Disabling shows everything
+
+- **WHEN** filters are active and the user disables the filter set
+- **THEN** the Telegram List shows all telegrams and the filters are not cleared
+
+#### Scenario: Re-enabling restores the filtered result
+
+- **WHEN** the filter set has been disabled and the user re-enables it
+- **THEN** the Telegram List again shows only telegrams matching the preserved filters
+
+#### Scenario: Disabled state persists across navigation
+
+- **WHEN** the user disables the filter set and navigates away and back to the
+  Telegram List
+- **THEN** the filter set is still disabled and still preserved
+
+### Requirement: Per-filter control in the Active view
+
+From the Active-filters view, the user SHALL be able to remove or toggle an individual
+active filter, leaving the other active filters unchanged.
+
+#### Scenario: Removing one active filter
+
+- **WHEN** several filters are active and the user removes one from the Active view
+- **THEN** that filter is no longer active and the remaining filters stay active


### PR DESCRIPTION
Redesign the Telegram List filter pane to address layout shift, redundant active filter displays, and complex AND/OR logic.

### Changes

- Replace auto-populating active filter block above category controls with an explicit **Edit / Active view toggle** in the pane header.
- Add **active filter badge count** to the header.
- Simplify filter combination logic to **strictly AND** for all active filters.
- Add **master enable/disable toggle switch** to disable filtering without clearing filters.
- Allow **individual filter removal** directly from the Active view.
- Maintain backwards compatibility by loading legacy OR links/workspaces as AND.

Closes #348