### PR TITLE
refactor: remove unused minTime and maxTime props from charts

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -6,8 +6,6 @@ import type { ChartBucket } from '../hooks/useChartData';
 
 interface MixedChartProps {
   bucket: ChartBucket;
-  minTime: number | null;
-  maxTime: number | null;
 }
 
 // Generate simple distinct colors for series

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -6,8 +6,6 @@ import type { ChartBucket } from '../hooks/useChartData';
 
 interface TimelineChartProps {
   bucket: ChartBucket;
-  minTime: number | null;
-  maxTime: number | null;
 }
 
 const syncCursor = uPlot.sync('knx-time-axis');

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -16,7 +16,7 @@ interface VisualizerProps {
 export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTargets, onTargetsChange, onClose }) => {
 
   const chartWrapperRef = useRef<HTMLDivElement>(null);
-  const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets);
+  const { buckets } = useChartData(telegrams, selectedTargets);
 
   const exportPng = () => {
     // A quick hack: uPlot naturally renders to canvas
@@ -65,9 +65,9 @@ export const Visualizer: React.FC<VisualizerProps> = ({ telegrams, selectedTarge
           <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: '1.5rem' }}>
             {buckets.map(b => (
               b.isBinary ? (
-                <TimelineChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} />
+                <TimelineChart key={b.unit} bucket={b} />
               ) : (
-                <MixedChart key={b.unit} bucket={b} minTime={minTime} maxTime={maxTime} />
+                <MixedChart key={b.unit} bucket={b} />
               )
             ))}
 

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -16,14 +16,12 @@ export interface ChartBucket {
 
 export interface ChartDataResult {
   buckets: ChartBucket[];
-  minTime: number | null;
-  maxTime: number | null;
 }
 
 export function useChartData(telegrams: Telegram[], selectedTargets: string[]): ChartDataResult {
   return useMemo(() => {
     if (selectedTargets.length === 0 || telegrams.length === 0) {
-      return { buckets: [], minTime: null, maxTime: null };
+      return { buckets: [] };
     }
 
     // 1. Filter out only relevant telegrams and parse timestamps
@@ -40,11 +38,8 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
       .sort((a, b) => a.ts - b.ts);
 
     if (relevant.length === 0) {
-      return { buckets: [], minTime: null, maxTime: null };
+      return { buckets: [] };
     }
-
-    const minTime = relevant[0].ts;
-    const maxTime = relevant[relevant.length - 1].ts;
 
     // 2. Group into physical units / buckets
     // We treat DPT1 (boolean/binary) as a special bucket called 'binary'
@@ -106,6 +101,6 @@ export function useChartData(telegrams: Telegram[], selectedTargets: string[]): 
       });
     }
 
-    return { buckets, minTime, maxTime };
+    return { buckets };
   }, [telegrams, selectedTargets]);
 }


### PR DESCRIPTION
Removed unused `minTime` and `maxTime` props from `TimelineChart` and `MixedChart` components. Updated `Visualizer` and `useChartData` hook to stop generating and passing these values, as they are no longer used for chart scaling or synchronization.