### PR TITLE
feat: MCP project resources and canned prompts (#335)

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -15,6 +15,7 @@ Access is gated by ``MCP_MODE``:
   bus (live read, GroupValueRead, GroupValueWrite).
 """
 
+import json
 import os
 from dataclasses import asdict
 from typing import Any
@@ -47,6 +48,53 @@ from database import store
 
 MCP_MODE = os.getenv("MCP_MODE", "read-only").strip().lower()
 _VALID_MODES = ("off", "read-only", "read-write")
+
+# Raw parsed-project sections exposed as `knx://project/<section>` resources.
+_PROJECT_SECTIONS = ("group_addresses", "devices", "topology", "locations", "functions")
+
+# Shared domain primer prepended to the canned prompts so an agent has KNX context
+# even on a fresh conversation.
+_KNX_CONTEXT = """\
+You are working with a KNX building-automation installation via SpectrumKNX's MCP \
+tools and resources. Key concepts:
+- Group addresses (GAs, e.g. "1/2/3") are the communication endpoints; each carries a \
+Data Point Type (DPT, e.g. 9.001 = temperature in °C) defining its value format.
+- Devices have individual addresses (IAs, e.g. "1.1.5"); their communication objects \
+link to GAs.
+- Telegrams are bus messages (GroupValueWrite / GroupValueRead / GroupValueResponse).
+- The loaded ETS project defines the topology, locations and functions that group \
+related GAs.
+
+Read the `knx://project*` resources for installation structure, and use the query / \
+statistics / last-value tools for stored telegrams. Bus write tools exist only when \
+the server is configured in read-write mode."""
+
+
+def _project_overview() -> str:
+    """A compact index of the loaded ETS project: metadata + per-section counts.
+
+    Kept light so it is a cheap entry point; the per-section resources carry detail.
+    """
+    project = knx_daemon.global_knx_project
+    if not project:
+        return json.dumps({"status": "no_project_loaded"})
+    return json.dumps(
+        {
+            "status": "ok",
+            "info": project.get("info", {}),
+            "counts": {name: len(project.get(name) or {}) for name in _PROJECT_SECTIONS},
+        },
+        default=str,
+        sort_keys=True,
+    )
+
+
+def _project_section(section: str) -> str:
+    """A stable, read-only JSON view of one parsed-project section."""
+    project = knx_daemon.global_knx_project
+    if not project:
+        return json.dumps({"status": "no_project_loaded", section: {}})
+    return json.dumps({"status": "ok", section: project.get(section, {})}, default=str, sort_keys=True)
 
 
 def mcp_enabled() -> bool:
@@ -92,6 +140,88 @@ def _build_server() -> FastMCP:
     # streamable_http_path="/" so that mounting the app at "/mcp" serves the
     # endpoint at "/mcp" rather than the doubled-up "/mcp/mcp".
     mcp = FastMCP("spectrum-knx", stateless_http=True, streamable_http_path="/")
+
+    # ── Project resources (#335) ────────────────────────────────────────────────
+    # Read-only snapshots of the loaded ETS project. All degrade to a stable
+    # {"status": "no_project_loaded"} payload when no project is configured.
+
+    @mcp.resource(
+        "knx://project",
+        name="ETS project overview",
+        description="Loaded ETS project metadata and per-section object counts.",
+        mime_type="application/json",
+    )
+    def project_overview() -> str:
+        return _project_overview()
+
+    @mcp.resource(
+        "knx://project/group-addresses",
+        name="ETS group addresses",
+        description="Group addresses with their names, DPTs and metadata.",
+        mime_type="application/json",
+    )
+    def project_group_addresses() -> str:
+        return _project_section("group_addresses")
+
+    @mcp.resource(
+        "knx://project/devices",
+        name="ETS devices",
+        description="Devices keyed by KNX individual address.",
+        mime_type="application/json",
+    )
+    def project_devices() -> str:
+        return _project_section("devices")
+
+    @mcp.resource(
+        "knx://project/topology",
+        name="ETS topology",
+        description="Area and line topology.",
+        mime_type="application/json",
+    )
+    def project_topology() -> str:
+        return _project_section("topology")
+
+    @mcp.resource(
+        "knx://project/locations",
+        name="ETS locations",
+        description="Building and room structure.",
+        mime_type="application/json",
+    )
+    def project_locations() -> str:
+        return _project_section("locations")
+
+    @mcp.resource(
+        "knx://project/functions",
+        name="ETS functions",
+        description="Functions / functional blocks and their group-address roles.",
+        mime_type="application/json",
+    )
+    def project_functions() -> str:
+        return _project_section("functions")
+
+    # ── Canned prompts (#335) ───────────────────────────────────────────────────
+
+    @mcp.prompt()
+    def analyze_bus_traffic(hours: int = 1) -> str:
+        """Analyze recent KNX traffic for volume, noisy addresses and unusual values."""
+        return (
+            f"{_KNX_CONTEXT}\n\n"
+            f"Analyze KNX bus traffic from the last {hours} hour(s). Use `query_telegrams`, "
+            "`count_telegrams` and `get_store_stats`. Summarize traffic volume, the busiest "
+            "sources and destinations, repeated or unusual values, and actionable anomalies. "
+            "Do not send or modify bus values."
+        )
+
+    @mcp.prompt()
+    def find_group_addresses_without_dpts() -> str:
+        """Find ETS group addresses that have no assigned DPT."""
+        return (
+            f"{_KNX_CONTEXT}\n\n"
+            "Read the `knx://project/group-addresses` resource and list every group address "
+            "with no assigned DPT. Group the results by project range or function where that "
+            "metadata is available. Do not infer a DPT; suggest candidates separately and state "
+            "what evidence (e.g. observed telegram payloads) would confirm them."
+        )
 
     @mcp.tool()
     async def query_telegrams(

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -206,6 +207,69 @@ async def test_lists_read_only_tools(server):
         "encode_value",
         "decode_payload",
     } <= names
+
+
+# ── Project resources + canned prompts (#335) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lists_project_resources_and_prompts(server):
+    uris = {str(r.uri) for r in await server.list_resources()}
+    assert {
+        "knx://project",
+        "knx://project/group-addresses",
+        "knx://project/devices",
+        "knx://project/topology",
+        "knx://project/locations",
+        "knx://project/functions",
+    } <= uris
+
+    prompts = {p.name for p in await server.list_prompts()}
+    assert {"analyze_bus_traffic", "find_group_addresses_without_dpts"} <= prompts
+
+
+@pytest.mark.asyncio
+async def test_project_overview_and_sections(server, monkeypatch):
+    monkeypatch.setattr(knx_daemon, "global_knx_project", _sample_project())
+
+    overview = json.loads((await server.read_resource("knx://project"))[0].content)
+    assert overview["status"] == "ok"
+    assert overview["info"]["name"] == "Demo"
+    # Overview is a light index: counts, not the full section dumps.
+    assert overview["counts"]["group_addresses"] == 1
+    assert overview["counts"]["devices"] == 1
+    assert "group_addresses" not in overview  # detail lives in the section resource
+
+    gas = json.loads((await server.read_resource("knx://project/group-addresses"))[0].content)
+    assert gas["status"] == "ok"
+    # The section resource carries the raw parsed-project shape (dpt as {main, sub}).
+    assert gas["group_addresses"]["1/0/0"]["address"] == "1/0/0"
+    assert gas["group_addresses"]["1/0/0"]["dpt"] == {"main": 1, "sub": 1}
+
+
+@pytest.mark.asyncio
+async def test_project_resources_report_when_no_project_is_loaded(server, monkeypatch):
+    monkeypatch.setattr(knx_daemon, "global_knx_project", None)
+
+    overview = json.loads((await server.read_resource("knx://project"))[0].content)
+    assert overview == {"status": "no_project_loaded"}
+
+    locations = json.loads((await server.read_resource("knx://project/locations"))[0].content)
+    assert locations == {"status": "no_project_loaded", "locations": {}}
+
+
+@pytest.mark.asyncio
+async def test_canned_prompts_include_knx_context(server):
+    traffic = await server.get_prompt("analyze_bus_traffic", {"hours": "2"})
+    text = traffic.messages[0].content.text
+    assert "last 2 hour(s)" in text
+    assert "Do not send or modify bus values" in text
+    assert "Group addresses (GAs" in text  # shared KNX context primer is prepended
+
+    missing = await server.get_prompt("find_group_addresses_without_dpts")
+    missing_text = missing.messages[0].content.text
+    assert "knx://project/group-addresses" in missing_text
+    assert "Do not infer a DPT" in missing_text
 
 
 def test_endpoint_serves_at_mount_root_not_doubled():


### PR DESCRIPTION
Completes the KNX MCP epic (#328, sub-issue **#335**) — the last piece. A **fresh implementation** on the now-established MCP infrastructure; loosely modelled on the earlier draft #346 (which predated the infra), but rewritten to fit `_build_server()` and `knx_daemon.global_knx_project`.

## Resources (read-only)
All degrade to a stable `{"status": "no_project_loaded"}` payload when no ETS project is configured.

- `knx://project` — **light index**: project metadata (`info`) + per-section object counts (a cheap entry point, not a giant dump).
- `knx://project/group-addresses`, `/devices`, `/topology`, `/locations`, `/functions` — the raw parsed-project sections.

(Adds a `functions` resource over #346's five, since the function tools landed in #356.)

## Prompts
Each prepends a shared KNX domain primer so an agent has context on a fresh conversation:

- `analyze_bus_traffic(hours)` — steer a **read-only** traffic analysis across `query_telegrams` / `count_telegrams` / `get_store_stats`.
- `find_group_addresses_without_dpts` — audit GAs missing a DPT via the project resource, without guessing.

## Tests
Resource/prompt discovery, loaded vs. no-project reads, light-overview vs. raw-section shapes, and prompt context. **Backend suite: 195 passed**; `ruff check` clean.

Closes #335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)