### PR TITLE
feat(mcp): add MCP server endpoint and release v2.0.0-beta.3

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -41,6 +41,7 @@ from knx_telegram_store.mcp import (
     query_telegrams as lib_query_telegrams,
 )
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import Field
 from xknx import mcp as xknx_mcp
 from xknxproject import mcp as xknxproject_mcp
@@ -122,9 +123,7 @@ def _require_project() -> Any:
     """
     project = knx_daemon.global_knx_project
     if project is None:
-        raise ValueError(
-            "No ETS project is loaded. Configure an ETS .knxproj to use project tools."
-        )
+        raise ValueError("No ETS project is loaded. Configure an ETS .knxproj to use project tools.")
     return project
 
 
@@ -171,7 +170,13 @@ def _build_server() -> FastMCP:
     # state to manage, which is all these read tools need and simplifies mounting.
     # streamable_http_path="/" so that mounting the app at "/mcp" serves the
     # endpoint at "/mcp" rather than the doubled-up "/mcp/mcp".
-    mcp = FastMCP("spectrum-knx", stateless_http=True, streamable_http_path="/")
+    # enable_dns_rebinding_protection=False allows remote network clients / custom Host headers.
+    mcp = FastMCP(
+        "spectrum-knx",
+        stateless_http=True,
+        streamable_http_path="/",
+        transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
+    )
 
     # ── Project resources (#335) ────────────────────────────────────────────────
     # Read-only snapshots of the loaded ETS project. All degrade to a stable
@@ -344,9 +349,7 @@ def _build_server() -> FastMCP:
         `dpts` are "main" or "main.sub" strings (e.g. "9.001")."""
         result = await xknxproject_mcp.list_group_addresses(
             _require_project(),
-            xknxproject_mcp.GroupAddressFilter(
-                text=text, dpts=dpts or [], limit=limit, offset=offset
-            ),
+            xknxproject_mcp.GroupAddressFilter(text=text, dpts=dpts or [], limit=limit, offset=offset),
         )
         return asdict(result)
 
@@ -358,9 +361,7 @@ def _build_server() -> FastMCP:
 
     @mcp.tool()
     @_describe(xknxproject_mcp.DeviceFilter)
-    async def list_devices(
-        text: str | None = None, limit: int = 100, offset: int = 0
-    ) -> dict[str, Any]:
+    async def list_devices(text: str | None = None, limit: int = 100, offset: int = 0) -> dict[str, Any]:
         """List project devices. `text` matches individual address/name/manufacturer."""
         result = await xknxproject_mcp.list_devices(
             _require_project(),
@@ -413,9 +414,7 @@ def _build_server() -> FastMCP:
         `space_id` restricts to a specific space/room."""
         result = await xknxproject_mcp.list_functions(
             _require_project(),
-            xknxproject_mcp.FunctionFilter(
-                text=text, space_id=space_id, limit=limit, offset=offset
-            ),
+            xknxproject_mcp.FunctionFilter(text=text, space_id=space_id, limit=limit, offset=offset),
         )
         return asdict(result)
 
@@ -437,9 +436,7 @@ def _build_server() -> FastMCP:
     ) -> dict[str, Any]:
         """List known KNX data point types. `main` restricts to a DPT main
         number; `text` matches the DPT number/value type/unit."""
-        result = await xknx_mcp.list_dpts(
-            xknx_mcp.DptFilter(main=main, text=text, limit=limit, offset=offset)
-        )
+        result = await xknx_mcp.list_dpts(xknx_mcp.DptFilter(main=main, text=text, limit=limit, offset=offset))
         return asdict(result)
 
     @mcp.tool()
@@ -459,9 +456,7 @@ def _build_server() -> FastMCP:
     async def encode_value(value: Any, value_type: str) -> dict[str, Any]:
         """Encode a value using a specific DPT into its raw payload bytes.
         `value` is the Python native value; `value_type` is DPT number (e.g. "9.001") or name."""
-        result = await xknx_mcp.encode_dpt_payload(
-            xknx_mcp.EncodeDptPayloadInput(value=value, value_type=value_type)
-        )
+        result = await xknx_mcp.encode_dpt_payload(xknx_mcp.EncodeDptPayloadInput(value=value, value_type=value_type))
         return asdict(result)
 
     @mcp.tool()
@@ -489,9 +484,7 @@ def _register_bus_tools(mcp: FastMCP) -> None:
 
     @mcp.tool()
     @_describe(xknx_mcp.GroupValueReadInput)
-    async def read_group_value(
-        group_address: str, value_type: str | None = None
-    ) -> dict[str, Any]:
+    async def read_group_value(group_address: str, value_type: str | None = None) -> dict[str, Any]:
         """Read a group address live from the bus (sends a GroupValueRead and
         waits). `value_type` is a DPT number ("9.001") or value type name
         ("temperature"); without it the raw payload is returned."""
@@ -522,9 +515,7 @@ def _register_bus_tools(mcp: FastMCP) -> None:
         6-bit payload and a list of ints as a byte array."""
         result = await xknx_mcp.send_group_value_write(
             _require_xknx(),
-            xknx_mcp.GroupValueWriteInput(
-                group_address=group_address, value=value, value_type=value_type
-            ),
+            xknx_mcp.GroupValueWriteInput(group_address=group_address, value=value, value_type=value_type),
         )
         return asdict(result)
 

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -466,4 +466,3 @@ async def test_encode_decode_value_tools(server):
 
     decoded_binary = await _structured(server, "decode_payload", {"payload": 1, "value_type": "1.001"})
     assert decoded_binary["value"] == "on"
-

--- a/frontend/src/components/TimeBrush.test.tsx
+++ b/frontend/src/components/TimeBrush.test.tsx
@@ -8,7 +8,7 @@ const initialVal: [number, number] = [minTime + 1000000, maxTime - 1000000];
 
 test('renders TimeBrush, handles middle click and drags to pan', () => {
   const onChangeMock = vi.fn();
-  
+
   const { container } = render(
     <TimeBrush
       minTime={minTime}
@@ -24,7 +24,7 @@ test('renders TimeBrush, handles middle click and drags to pan', () => {
   // Find container div that has clientWidth/getBoundingClientRect mocked
   const track = container.querySelector('div[style*="position: relative"]');
   expect(track).toBeTruthy();
-  
+
   // Mock bounding rect
   track!.getBoundingClientRect = () => ({
     width: 500,
@@ -43,10 +43,10 @@ test('renders TimeBrush, handles middle click and drags to pan', () => {
 
   // Trigger drag start
   fireEvent.mouseDown(middle!, { clientX: 200, button: 0 });
-  
+
   // Drag to the right
   fireEvent.mouseMove(window, { clientX: 250 });
-  
+
   // Assert onChange is called with increased range
   expect(onChangeMock).toHaveBeenCalled();
   const nextVal = onChangeMock.mock.calls[0][0];

--- a/frontend/src/components/TimeBrush.tsx
+++ b/frontend/src/components/TimeBrush.tsx
@@ -31,7 +31,7 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
     const bins = 60;
     const counts = new Array(bins).fill(0);
     if (range <= 0) return counts;
-    
+
     for (const t of telegrams) {
       const time = new Date(t.timestamp).getTime();
       const bin = Math.min(bins - 1, Math.max(0, Math.floor(((time - minTime) / range) * bins)));

--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0-beta.3
+
+### Fixed
+
+- **MCP Transport Security**: Configured FastMCP transport security settings to allow network clients and custom Host headers without 421 Misdirected Request errors.
+
 ## 2.0.0-beta.2
 
 ### Added

--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.0.0-beta.2
+
+### Added
+
+- **MCP Server Integration**: Introduces Model Context Protocol (MCP) server endpoints at `/mcp`. Allows external AI assistants to read and write to the KNX bus, explore ETS projects, filter telegrams, list group addresses, and query active data.
+- **Frontend Revamp App-Shell**: Implements a new five-panel layout switch for the frontend, providing a streamlined and modern navigation experience.
+- **Simplified Filter Pane**: Adds an edit/active toggle view to simplify filter configuration.
+- **DPT Override in Write-to-Bus**: Allows users to manually override Datapoint Types (DPT) directly in the Write-to-Bus panel.
+- **Session State Persistence**: Automatically persists the active session UI state across navigation and browser updates.
+- **Focused Telegram Highlighting**: Highlights/marks the focused rows in the telegram list for improved readability.
+- **Numerical Sorting**: Sorts group and physical addresses numerically in the Last Seen Values panel.
+- **Visualization Panel Header Controls**: Added a header close X control to the Visualization panel, and repurposed the Targets list X to clear targets.
+
+### Changed
+
+- **Visualization Chart Alignment**: Aligns chart borders, moves the timeline legend to the left, and prevents scale clipping when zooming or panning.
+- **Visualization Persistence**: Keeps charts on-screen automatically as the history/live buffer grows.
+- **Docker Build Optimization**: Bundles git within the backend Docker image to ensure `docker compose --build` runs successfully.
+- **xknx Update**: Upgraded xknx to 3.17.0.
+
+### Fixed
+
+- **History Load Cancellation**: Cancels any in-flight background history loading tasks when the buffer is cleared.
+- **History Buffer Gaps**: Fixed a bug where permanent time gaps could form in the async history buffer.
+- **History Search Timezone Offset**: Fixed timezone offset errors when specifying custom date ranges in history search.
+
 ## 1.16.2
 
 ### Added

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "2.0.0-beta.2"
+version: "2.0.0-beta.3"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "1.16.2"
+version: "2.0.0-beta.2"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0-beta.3
+
+### Fixed
+
+- **MCP Transport Security**: Configured FastMCP transport security settings to allow network clients and custom Host headers without 421 Misdirected Request errors.
+
 ## 2.0.0-beta.2
 
 ### Added

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 2.0.0-beta.2
+
+### Added
+
+- **MCP Server Integration**: Introduces Model Context Protocol (MCP) server endpoints at `/mcp`. Allows external AI assistants to read and write to the KNX bus, explore ETS projects, filter telegrams, list group addresses, and query active data.
+- **Frontend Revamp App-Shell**: Implements a new five-panel layout switch for the frontend, providing a streamlined and modern navigation experience.
+- **Simplified Filter Pane**: Adds an edit/active toggle view to simplify filter configuration.
+- **DPT Override in Write-to-Bus**: Allows users to manually override Datapoint Types (DPT) directly in the Write-to-Bus panel.
+- **Session State Persistence**: Automatically persists the active session UI state across navigation and browser updates.
+- **Focused Telegram Highlighting**: Highlights/marks the focused rows in the telegram list for improved readability.
+- **Numerical Sorting**: Sorts group and physical addresses numerically in the Last Seen Values panel.
+- **Visualization Panel Header Controls**: Added a header close X control to the Visualization panel, and repurposed the Targets list X to clear targets.
+
+### Changed
+
+- **Visualization Chart Alignment**: Aligns chart borders, moves the timeline legend to the left, and prevents scale clipping when zooming or panning.
+- **Visualization Persistence**: Keeps charts on-screen automatically as the history/live buffer grows.
+- **Docker Build Optimization**: Bundles git within the backend Docker image to ensure `docker compose --build` runs successfully.
+- **xknx Update**: Upgraded xknx to 3.17.0.
+
+### Fixed
+
+- **History Load Cancellation**: Cancels any in-flight background history loading tasks when the buffer is cleared.
+- **History Buffer Gaps**: Fixed a bug where permanent time gaps could form in the async history buffer.
+- **History Search Timezone Offset**: Fixed timezone offset errors when specifying custom date ranges in history search.
+
 ## 1.16.2
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "1.16.2"
+version: "2.0.0-beta.2"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "2.0.0-beta.2"
+version: "2.0.0-beta.3"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
## Summary

- **MCP Server Integration**: Exposes Model Context Protocol (MCP) endpoints at `/mcp` for external AI tools to query telegrams, store stats, DPT definitions, and ETS project topology/devices/group addresses.
- **Tool Descriptions**: Single-sourced parameter descriptions from library dataclass metadata via a signature decorator.
- **Transport Security**: Disabled DNS rebinding host restriction to allow remote network clients and custom `Host` headers without 421 errors.
- **Release**: Pre-release `v2.0.0-beta.3` with updated add-on manifests and changelogs.