### PR TITLE
feat(mcp): optimize context by removing high-cardinality project resources and release v2.0.0-beta.4

### DIFF
--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -52,15 +52,12 @@ from database import store
 MCP_MODE = os.getenv("MCP_MODE", "read-only").strip().lower()
 _VALID_MODES = ("off", "read-only", "read-write")
 
-# Raw parsed-project sections exposed as `knx://project/<section>` resources.
-_PROJECT_SECTIONS = ("group_addresses", "devices", "topology", "locations", "functions")
-
 # Shared domain primer prepended to the canned prompts so an agent has KNX context
 # even on a fresh conversation.
 _KNX_CONTEXT = """\
 You are working with a KNX building-automation installation via SpectrumKNX's MCP \
 tools and resources. Key concepts:
-- Group addresses (GAs, e.g. "1/2/3") are the communication endpoints; each carries a \
+- Group addresses (GAs, e.g. "1/2/3") are communication endpoints; each carries a \
 Data Point Type (DPT, e.g. 9.001 = temperature in °C) defining its value format.
 - Devices have individual addresses (IAs, e.g. "1.1.5"); their communication objects \
 link to GAs.
@@ -68,36 +65,31 @@ link to GAs.
 - The loaded ETS project defines the topology, locations and functions that group \
 related GAs.
 
-Read the `knx://project*` resources for installation structure, and use the query / \
-statistics / last-value tools for stored telegrams. Bus write tools exist only when \
-the server is configured in read-write mode."""
+Use the `knx://project` resource for a high-level project overview, and use discovery tools \
+for searching and inspecting details:
+- `list_group_addresses` and `describe_group_address` to find/inspect GAs.
+- `list_devices` and `list_communication_objects` for devices and hardware.
+- `list_locations`, `list_functions`, and `get_topology` for building structure & functions.
+- `list_dpts` and `describe_dpt` for DPT definitions.
+- `query_telegrams`, `get_store_stats`, `get_last_values` for stored bus telegrams.
+Bus write tools exist only when the server is configured in read-write mode."""
 
 
 def _project_overview() -> str:
-    """A compact index of the loaded ETS project: metadata + per-section counts.
-
-    Kept light so it is a cheap entry point; the per-section resources carry detail.
-    """
+    """A compact index of the loaded ETS project: metadata + per-section counts."""
     project = knx_daemon.global_knx_project
     if not project:
         return json.dumps({"status": "no_project_loaded"})
+    sections = ("group_addresses", "devices", "topology", "locations", "functions")
     return json.dumps(
         {
             "status": "ok",
             "info": project.get("info", {}),
-            "counts": {name: len(project.get(name) or {}) for name in _PROJECT_SECTIONS},
+            "counts": {name: len(project.get(name) or {}) for name in sections},
         },
         default=str,
         sort_keys=True,
     )
-
-
-def _project_section(section: str) -> str:
-    """A stable, read-only JSON view of one parsed-project section."""
-    project = knx_daemon.global_knx_project
-    if not project:
-        return json.dumps({"status": "no_project_loaded", section: {}})
-    return json.dumps({"status": "ok", section: project.get(section, {})}, default=str, sort_keys=True)
 
 
 def mcp_enabled() -> bool:
@@ -178,8 +170,8 @@ def _build_server() -> FastMCP:
         transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
     )
 
-    # ── Project resources (#335) ────────────────────────────────────────────────
-    # Read-only snapshots of the loaded ETS project. All degrade to a stable
+    # ── Project resource ────────────────────────────────────────────────────────
+    # A lightweight index overview of the loaded ETS project. Degrades to a stable
     # {"status": "no_project_loaded"} payload when no project is configured.
 
     @mcp.resource(
@@ -190,51 +182,6 @@ def _build_server() -> FastMCP:
     )
     def project_overview() -> str:
         return _project_overview()
-
-    @mcp.resource(
-        "knx://project/group-addresses",
-        name="ETS group addresses",
-        description="Group addresses with their names, DPTs and metadata.",
-        mime_type="application/json",
-    )
-    def project_group_addresses() -> str:
-        return _project_section("group_addresses")
-
-    @mcp.resource(
-        "knx://project/devices",
-        name="ETS devices",
-        description="Devices keyed by KNX individual address.",
-        mime_type="application/json",
-    )
-    def project_devices() -> str:
-        return _project_section("devices")
-
-    @mcp.resource(
-        "knx://project/topology",
-        name="ETS topology",
-        description="Area and line topology.",
-        mime_type="application/json",
-    )
-    def project_topology() -> str:
-        return _project_section("topology")
-
-    @mcp.resource(
-        "knx://project/locations",
-        name="ETS locations",
-        description="Building and room structure.",
-        mime_type="application/json",
-    )
-    def project_locations() -> str:
-        return _project_section("locations")
-
-    @mcp.resource(
-        "knx://project/functions",
-        name="ETS functions",
-        description="Functions / functional blocks and their group-address roles.",
-        mime_type="application/json",
-    )
-    def project_functions() -> str:
-        return _project_section("functions")
 
     # ── Canned prompts (#335) ───────────────────────────────────────────────────
 
@@ -254,10 +201,10 @@ def _build_server() -> FastMCP:
         """Find ETS group addresses that have no assigned DPT."""
         return (
             f"{_KNX_CONTEXT}\n\n"
-            "Read the `knx://project/group-addresses` resource and list every group address "
-            "with no assigned DPT. Group the results by project range or function where that "
-            "metadata is available. Do not infer a DPT; suggest candidates separately and state "
-            "what evidence (e.g. observed telegram payloads) would confirm them."
+            "Use the `list_group_addresses` tool to search and list group addresses in the project. "
+            "Find every group address with no assigned DPT. Group the results by project range or function "
+            "where that metadata is available. Do not infer a DPT; suggest candidates separately and state "
+            "what evidence (e.g. observed telegram payloads from `query_telegrams`) would confirm them."
         )
 
     @mcp.tool()

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -3,7 +3,6 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
-from knx_telegram_store import StoredTelegram
 from knx_telegram_store.backends.memory import MemoryStore
 from xknx import XKNX
 from xknx.dpt import DPTArray
@@ -11,6 +10,7 @@ from xknx.telegram import GroupAddress, Telegram, apci
 
 import knx_daemon
 import mcp_server
+from knx_telegram_store import StoredTelegram
 
 NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=UTC)
 
@@ -215,36 +215,23 @@ async def test_lists_read_only_tools(server):
 @pytest.mark.asyncio
 async def test_lists_project_resources_and_prompts(server):
     uris = {str(r.uri) for r in await server.list_resources()}
-    assert {
-        "knx://project",
-        "knx://project/group-addresses",
-        "knx://project/devices",
-        "knx://project/topology",
-        "knx://project/locations",
-        "knx://project/functions",
-    } <= uris
+    assert uris == {"knx://project"}
 
     prompts = {p.name for p in await server.list_prompts()}
     assert {"analyze_bus_traffic", "find_group_addresses_without_dpts"} <= prompts
 
 
 @pytest.mark.asyncio
-async def test_project_overview_and_sections(server, monkeypatch):
+async def test_project_overview(server, monkeypatch):
     monkeypatch.setattr(knx_daemon, "global_knx_project", _sample_project())
 
     overview = json.loads((await server.read_resource("knx://project"))[0].content)
     assert overview["status"] == "ok"
     assert overview["info"]["name"] == "Demo"
-    # Overview is a light index: counts, not the full section dumps.
+    # Overview is a light index: metadata and section counts.
     assert overview["counts"]["group_addresses"] == 1
     assert overview["counts"]["devices"] == 1
-    assert "group_addresses" not in overview  # detail lives in the section resource
-
-    gas = json.loads((await server.read_resource("knx://project/group-addresses"))[0].content)
-    assert gas["status"] == "ok"
-    # The section resource carries the raw parsed-project shape (dpt as {main, sub}).
-    assert gas["group_addresses"]["1/0/0"]["address"] == "1/0/0"
-    assert gas["group_addresses"]["1/0/0"]["dpt"] == {"main": 1, "sub": 1}
+    assert "group_addresses" not in overview
 
 
 @pytest.mark.asyncio
@@ -253,9 +240,6 @@ async def test_project_resources_report_when_no_project_is_loaded(server, monkey
 
     overview = json.loads((await server.read_resource("knx://project"))[0].content)
     assert overview == {"status": "no_project_loaded"}
-
-    locations = json.loads((await server.read_resource("knx://project/locations"))[0].content)
-    assert locations == {"status": "no_project_loaded", "locations": {}}
 
 
 @pytest.mark.asyncio
@@ -268,7 +252,7 @@ async def test_canned_prompts_include_knx_context(server):
 
     missing = await server.get_prompt("find_group_addresses_without_dpts")
     missing_text = missing.messages[0].content.text
-    assert "knx://project/group-addresses" in missing_text
+    assert "list_group_addresses" in missing_text
     assert "Do not infer a DPT" in missing_text
 
 

--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0-beta.4
+
+### Changed
+
+- **MCP Context Optimization**: Removed high-cardinality project resources (`group-addresses`, `devices`, `topology`, `locations`, `functions`) to prevent LLM context bloat. Kept lightweight `knx://project` overview index and updated canned prompts to instruct agents to use paginated discovery tools.
+
 ## 2.0.0-beta.3
 
 ### Fixed

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "2.0.0-beta.3"
+version: "2.0.0-beta.4"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0-beta.4
+
+### Changed
+
+- **MCP Context Optimization**: Removed high-cardinality project resources (`group-addresses`, `devices`, `topology`, `locations`, `functions`) to prevent LLM context bloat. Kept lightweight `knx://project` overview index and updated canned prompts to instruct agents to use paginated discovery tools.
+
 ## 2.0.0-beta.3
 
 ### Fixed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "2.0.0-beta.3"
+version: "2.0.0-beta.4"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
## Summary

- Removes high-cardinality project resources (`knx://project/group-addresses`, `devices`, `topology`, `locations`, `functions`) to eliminate LLM context bloat.
- Keeps the lightweight `knx://project` overview resource index (metadata + section counts).
- Updates domain primer context and canned prompts to explicitly guide AI agents to use paginated discovery tools (`list_group_addresses`, `list_devices`, `list_locations`, `list_functions`, `get_topology`, `describe_*`).
- Bumps version to `2.0.0-beta.4` across add-on manifests and updates changelogs.

## Testing & Verification

- Tested with `.venv/bin/pytest tests/test_mcp_server.py` (23/23 tests passed).
- Formatted and linted with `ruff`.