### PR TITLE
feat: postgres-readonly companion mode with LISTEN/NOTIFY live updates

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,9 +46,11 @@ Key variables:
 - `APP_IMAGE`: Docker image to use for production stacks.
 - `VITE_BACKEND_URL`: (Frontend only) The URL of the backend API (default: `http://localhost:8765`).
 
-Companion mode (read an external telegram store instead of running the KNX daemon):
-- `STORE_MODE`: `standalone` (default) or `external-readonly` — read a sqlite store owned and written by another process (e.g. Home Assistant's KNX integration). Requires a `sqlite+aiosqlite://` `DATABASE_URL`; the KNX daemon is not started, and purge/optimize are disabled.
-- `LIVE_SOURCE`: Live-feed source in companion mode: `ha_websocket` (default — subscribe to HA's `knx/subscribe_telegrams`), `poll` (interval-poll the store; no HA required) or `none`.
+Companion modes (read an external telegram store instead of writing our own):
+- `STORE_MODE`: `standalone` (default), `external-readonly`, or `postgres-readonly`.
+  - `external-readonly` reads a sqlite store owned and written by another process (e.g. Home Assistant's KNX integration). Requires a `sqlite+aiosqlite://` `DATABASE_URL`; the KNX daemon is not started, and purge/optimize are disabled.
+  - `postgres-readonly` reads a shared PostgreSQL database owned and written by another process. Requires a `postgresql+asyncpg://` `DATABASE_URL` pointing at that database. Unlike `external-readonly`, our own KNX daemon still starts and connects to the bus (for outbound writes via the API/MCP tools) — it just never writes telegrams itself, since the writer already does. Live updates come from PostgreSQL `LISTEN`/`NOTIFY` (requires `knx-telegram-store>=0.12`), not `LIVE_SOURCE`/polling.
+- `LIVE_SOURCE`: Live-feed source in `external-readonly` mode: `ha_websocket` (default — subscribe to HA's `knx/subscribe_telegrams`), `poll` (interval-poll the store; no HA required) or `none`. Not used by `postgres-readonly`, which always uses `LISTEN`/`NOTIFY`.
 - `HA_WS_URL`: Home Assistant websocket URL (default `ws://supervisor/core/websocket`; for local dev e.g. `ws://localhost:8123/api/websocket`).
 - `HA_TOKEN` / `SUPERVISOR_TOKEN`: Access token for the HA websocket (a long-lived token in dev; the Supervisor injects `SUPERVISOR_TOKEN` in the add-on). Without a token, `ha_websocket` falls back to polling.
 - `LIVE_POLL_INTERVAL`: Poll interval in seconds for `LIVE_SOURCE=poll` (default `1.0`).
@@ -66,11 +68,17 @@ docker-compose up -d db
 export DATABASE_URL="sqlite+aiosqlite:///spectrum_knx.db"
 ```
 
-**External read-only (companion mode):** Point at a sqlite store written by another process — no database of our own, no KNX daemon. Useful for developing against a copy of Home Assistant's `.storage/knx/telegrams.db`:
+**External read-only (sqlite companion mode):** Point at a sqlite store written by another process — no database of our own, no KNX daemon. Useful for developing against a copy of Home Assistant's `.storage/knx/telegrams.db`:
 ```bash
 export STORE_MODE="external-readonly"
 export DATABASE_URL="sqlite+aiosqlite:////path/to/telegrams.db"
 export LIVE_SOURCE="poll"   # or ha_websocket + HA_WS_URL + HA_TOKEN
+```
+
+**Shared PostgreSQL (postgres-readonly companion mode):** Point at a PostgreSQL database written by another process (e.g. Home Assistant with `telegram_db_backend: postgres`). Our own KNX daemon still connects to the bus for outbound writes; live updates come from `LISTEN`/`NOTIFY`, no polling:
+```bash
+export STORE_MODE="postgres-readonly"
+export DATABASE_URL="postgresql+asyncpg://user:pass@host/db"
 ```
 
 ### 4. Running the Backend

--- a/backend/api.py
+++ b/backend/api.py
@@ -20,7 +20,7 @@ import knx_daemon  # import global config
 import telegram_export
 import telegram_import
 import update_check
-from database import READ_ONLY, engine, store
+from database import READ_ONLY, STORE_MODE, engine, store
 from parsers import (
     format_dpt_name,
     format_value_nicely,
@@ -379,8 +379,13 @@ class KnxReadRequest(BaseModel):
 
 
 def _require_bus_write() -> None:
-    """Guard for the send/read endpoints: standalone mode, connected, and allowed."""
-    if READ_ONLY or not knx_daemon.ALLOW_WRITE:
+    """Guard for the send/read endpoints: a live bus connection and writing not forbidden.
+
+    external-readonly never starts a daemon, so is_connected() is always
+    False there without needing a separate check; postgres-readonly's daemon
+    can be connected and write, even though its telegram store is read-only.
+    """
+    if not knx_daemon.ALLOW_WRITE:
         raise HTTPException(status_code=403, detail="Sending to the KNX bus is disabled")
     if not knx_daemon.is_connected():
         raise HTTPException(status_code=409, detail="Not connected to the KNX bus")
@@ -913,8 +918,10 @@ async def export_telegrams(
 @router.websocket("/ws/telegrams")
 async def websocket_endpoint(websocket: WebSocket):
     await manager.connect(websocket)
-    if not READ_ONLY:
-        # Initial state so (re)connecting clients don't have to wait for a change
+    if STORE_MODE != "external-readonly":
+        # A daemon (and thus a bus connection state) exists in both standalone
+        # and postgres-readonly mode. Initial state so (re)connecting clients
+        # don't have to wait for a change.
         connected = knx_daemon.is_connected()
         await websocket.send_json(
             {

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,5 +1,6 @@
 import os
 
+from knx_telegram_store.backends.postgres import PostgresStore
 from knx_telegram_store.backends.sqlite import SqliteStore
 from knx_telegram_store.buffered import BufferedPostgresStore, BufferedSqliteStore
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -15,15 +16,27 @@ DB_PORT = os.getenv("POSTGRES_PORT", "5432")
 # Prioritize full DATABASE_URL, otherwise build it from components
 DATABASE_URL = os.getenv("DATABASE_URL", f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}")
 
-# standalone (default): own KNX daemon writes telegrams to our own database.
-# external-readonly: companion mode — read a sqlite store owned and written by
-# another process (e.g. Home Assistant's KNX integration); no daemon, no writes.
+# standalone (default): own KNX daemon writes telegrams to our own database
+#   (sqlite or postgres).
+# external-readonly: sqlite companion mode — read a sqlite store owned and
+#   written by another process (e.g. Home Assistant's KNX integration); no
+#   daemon, no writes.
+# postgres-readonly: shared-Postgres companion mode — read a Postgres
+#   database owned and written by another process, with live updates via
+#   LISTEN/NOTIFY (knx_telegram_store>=0.12). Unlike external-readonly, our
+#   own KNX daemon still connects to the bus for outbound writes; it never
+#   persists telegrams itself in this mode, since the writer already does —
+#   see knx_daemon.py.
 STORE_MODE = os.getenv("STORE_MODE", "standalone")
-READ_ONLY = STORE_MODE == "external-readonly"
+READ_ONLY = STORE_MODE in ("external-readonly", "postgres-readonly")
 
 _SQLITE_PREFIX = "sqlite+aiosqlite:///"
 
-if DATABASE_URL.startswith(_SQLITE_PREFIX):
+if STORE_MODE == "postgres-readonly":
+    if DATABASE_URL.startswith(_SQLITE_PREFIX):
+        raise RuntimeError("STORE_MODE=postgres-readonly requires a postgres DATABASE_URL")
+    store = PostgresStore(DATABASE_URL, read_only=True)
+elif DATABASE_URL.startswith(_SQLITE_PREFIX):
     # Strip the URL scheme to get the file path (absolute paths keep their leading /)
     _db_path = DATABASE_URL[len(_SQLITE_PREFIX) :]
     if READ_ONLY:
@@ -37,7 +50,15 @@ elif READ_ONLY:
 else:
     store = BufferedPostgresStore(DATABASE_URL, flush_interval=1.0)
 
-engine = create_async_engine(DATABASE_URL, echo=False)
+# For postgres-readonly, the store's own engine already rejects mutations
+# (PostgresStore(read_only=True)). This is defense-in-depth for the separate
+# raw engine below, used directly by e.g. /api/statistics: it can never write
+# either, even via raw SQL that bypasses the store's guard.
+_connect_args = {}
+if STORE_MODE == "postgres-readonly":
+    _connect_args["server_settings"] = {"default_transaction_read_only": "on"}
+
+engine = create_async_engine(DATABASE_URL, echo=False, connect_args=_connect_args)
 
 AsyncSessionLocal = async_sessionmaker(bind=engine, expire_on_commit=False)
 

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -5,6 +5,7 @@ import os
 from datetime import UTC, datetime
 from typing import Any
 
+from knx_telegram_store import StoredTelegram
 from xknx import XKNX
 from xknx.core import XknxConnectionState
 from xknx.dpt import DPTArray, DPTBase, DPTBinary
@@ -14,8 +15,7 @@ from xknx.telegram import TelegramDirection
 from xknx.telegram.address import GroupAddress, IndividualAddress
 from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
 
-from database import READ_ONLY, store
-from knx_telegram_store import StoredTelegram
+from database import STORE_MODE, store
 from parsers import format_dpt_name, get_simplified_type, parse_telegram_payload
 from ws_manager import manager
 
@@ -225,6 +225,13 @@ async def _watch_files():
 
 
 async def process_telegram_async(telegram: XknxTelegram):
+    if STORE_MODE == "postgres-readonly":
+        # The daemon is connected only to enable outbound bus writes here; the
+        # telegram store is a shared, read-only view of what the writer (e.g.
+        # Home Assistant) already persists. Recording it again would duplicate
+        # rows in a store we must not write to, and the live feed is driven by
+        # pg_listen_bridge (LISTEN/NOTIFY on the writer's inserts) instead.
+        return
     try:
         ts = datetime.now(UTC)
 
@@ -413,10 +420,12 @@ def is_connected() -> bool:
 def write_enabled() -> bool:
     """Whether outbound telegrams (send/read) can be sent to the bus right now.
 
-    Requires standalone mode (our own live connection), an active connection,
-    and that writing has not been forbidden via KNX_ALLOW_WRITE=false.
+    Requires a live daemon connection (standalone or postgres-readonly mode;
+    external-readonly never starts a daemon) and that writing has not been
+    forbidden via KNX_ALLOW_WRITE=false. Independent of whether the telegram
+    store itself is read-only — see database.STORE_MODE.
     """
-    return ALLOW_WRITE and not READ_ONLY and is_connected()
+    return ALLOW_WRITE and is_connected()
 
 
 def _encode_payload(payload: Any, dpt: str | None) -> DPTArray | DPTBinary:
@@ -519,11 +528,12 @@ def get_server_config() -> dict:
         if os.path.exists(default_file):
             ets_project_file = default_file
 
-    if READ_ONLY:
-        # Companion mode: Home Assistant owns the bus connection and the
-        # telegram store — reporting the daemon's (nonexistent) bus connection
-        # as "Disconnected" here was misleading (#184). Report the live-feed
-        # state instead and drop the gateway/security settings that don't apply.
+    if STORE_MODE == "external-readonly":
+        # Sqlite companion mode: Home Assistant owns the bus connection and
+        # the telegram store — reporting the daemon's (nonexistent) bus
+        # connection as "Disconnected" here was misleading (#184). Report the
+        # live-feed state instead and drop the gateway/security settings that
+        # don't apply.
         import ha_live_bridge
 
         feed = ha_live_bridge.live_feed_status()
@@ -544,8 +554,8 @@ def get_server_config() -> dict:
             },
         }
 
-    return {
-        "mode": "standalone",
+    config = {
+        "mode": "postgres-companion" if STORE_MODE == "postgres-readonly" else "standalone",
         "connection": {
             "type": os.getenv("KNX_CONNECTION_TYPE", "AUTOMATIC"),
             "gateway_ip": os.getenv("KNX_GATEWAY_IP", "AUTO"),
@@ -576,6 +586,16 @@ def get_server_config() -> dict:
             "write_enabled": write_enabled(),
         },
     }
+    if STORE_MODE == "postgres-readonly":
+        # The bus connection above is ours (for writes); the telegram store
+        # itself is a shared, read-only database another process owns and
+        # writes to, fed to the live view via LISTEN/NOTIFY.
+        import pg_listen_bridge
+
+        config["status"]["telegram_store"] = "shared-postgres-readonly"
+        config["status"]["live_source"] = "postgres-listen-notify"
+        config["status"]["live_connected"] = pg_listen_bridge.live_feed_status()["connected"]
+    return config
 
 
 async def knx_startup():
@@ -594,7 +614,17 @@ async def knx_startup():
 
     # Initialize the Telegram Store (including schema creation/renames)
     await store.initialize()
-    store.start()
+    if STORE_MODE == "postgres-readonly":
+        # A plain (unbuffered) read-only PostgresStore has no write-flush loop
+        # to start — the writer (e.g. Home Assistant) owns the schema and all
+        # writes.
+        if await store.needs_migration():
+            logger.warning(
+                "The telegram store schema needs a migration that only its "
+                "owner may run — queries may fail or miss data until then."
+            )
+    else:
+        store.start()
 
     await _load_project_data()
 
@@ -616,4 +646,7 @@ async def knx_shutdown():
     if xknx_instance:
         logger.info("Stopping KNX Daemon...")
         await xknx_instance.stop()
-    await store.stop()
+    if STORE_MODE == "postgres-readonly":
+        await store.close()
+    else:
+        await store.stop()

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,9 +14,10 @@ from fastapi.staticfiles import StaticFiles  # noqa: E402
 
 import cyclic_send  # noqa: E402
 import mcp_server  # noqa: E402
+import pg_listen_bridge  # noqa: E402
 from api import get_backend_version  # noqa: E402
 from api import router as api_router  # noqa: E402
-from database import READ_ONLY, engine  # noqa: E402
+from database import STORE_MODE, engine  # noqa: E402
 from ha_live_bridge import companion_shutdown, companion_startup  # noqa: E402
 from knx_daemon import knx_shutdown, knx_startup  # noqa: E402
 from security import is_safe_path  # noqa: E402
@@ -29,10 +30,16 @@ async def lifespan(app: FastAPI):
     # Startup
     version = get_backend_version()
     logger.info(f"Starting Spectrum KNX Backend (Version: {version})")
-    if READ_ONLY:
-        # Companion mode: no KNX daemon — another process (Home Assistant)
-        # owns the bus connection and writes the store we read.
+    if STORE_MODE == "external-readonly":
+        # Sqlite companion mode: no KNX daemon — another process (Home
+        # Assistant) owns the bus connection and writes the store we read.
         await companion_startup()
+    elif STORE_MODE == "postgres-readonly":
+        # Shared-Postgres companion mode: our own daemon still connects to
+        # the bus (for writes), but never touches the store — the writer
+        # already does. Live updates come from LISTEN/NOTIFY instead.
+        await knx_startup()
+        await pg_listen_bridge.postgres_listen_startup()
     else:
         await knx_startup()
 
@@ -43,8 +50,12 @@ async def lifespan(app: FastAPI):
         yield
 
     # Shutdown
-    if READ_ONLY:
+    if STORE_MODE == "external-readonly":
         await companion_shutdown()
+    elif STORE_MODE == "postgres-readonly":
+        await pg_listen_bridge.postgres_listen_shutdown()
+        await cyclic_send.shutdown()
+        await knx_shutdown()
     else:
         await cyclic_send.shutdown()
         await knx_shutdown()

--- a/backend/pg_listen_bridge.py
+++ b/backend/pg_listen_bridge.py
@@ -1,0 +1,98 @@
+"""Live telegram feed for postgres-readonly mode (STORE_MODE=postgres-readonly).
+
+Home Assistant (or another writer) owns the shared Postgres database; this
+module feeds the live websocket view via the knx_telegram_store library's
+LISTEN/NOTIFY support (store.listen_for_new_telegrams()). Unlike
+external-readonly's ha_live_bridge, our own KNX daemon still runs alongside
+this mode for outbound bus writes (see knx_daemon.py) but never reports
+telegrams to the store or the live feed itself — only this listener does,
+driven directly by the writer's inserts, so the feed always matches what is
+actually persisted. On reconnect the gap is replayed from the store, so a
+brief LISTEN drop does not lose telegrams.
+"""
+
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from knx_telegram_store import TelegramQuery
+
+from database import store
+from ws_manager import manager
+
+logger = logging.getLogger("uvicorn.error")
+
+_task: asyncio.Task | None = None
+_connected: bool = False
+_last_seen: datetime | None = None
+
+
+def live_feed_status() -> dict:
+    """Current live-feed state for the status API."""
+    return {"connected": _connected}
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """The store round-trips naive timestamps as UTC by convention."""
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)
+
+
+async def _replay_gap() -> None:
+    """Broadcast telegrams the writer persisted while the listener was disconnected."""
+    from api import _build_telegram_response
+
+    global _last_seen
+    if _last_seen is None:
+        return
+    try:
+        result = await store.query(TelegramQuery(start_time=_last_seen, order_descending=False, limit=5000))
+        fresh = [t for t in result.telegrams if _as_utc(t.timestamp) > _last_seen]
+        if fresh:
+            _last_seen = _as_utc(fresh[-1].timestamp)
+            for telegram in _build_telegram_response(fresh):
+                await manager.broadcast(telegram)
+    except Exception as err:
+        logger.warning(f"Gap replay from store failed: {err}")
+
+
+async def _listen_loop() -> None:
+    from api import _build_telegram_response
+
+    global _connected, _last_seen
+    backoff = 1.0
+    while True:
+        try:
+            _connected = True
+            backoff = 1.0
+            await _replay_gap()
+            async for telegram in store.listen_for_new_telegrams():
+                _last_seen = _as_utc(telegram.timestamp)
+                await manager.broadcast(_build_telegram_response([telegram])[0])
+        except asyncio.CancelledError:
+            _connected = False
+            raise
+        except Exception as err:
+            _connected = False
+            logger.warning(f"Postgres LISTEN/NOTIFY bridge disconnected: {err} — retrying in {backoff:.0f}s")
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+
+
+async def postgres_listen_startup() -> None:
+    """Start the LISTEN/NOTIFY task feeding the live view."""
+    global _task
+    logger.info("Postgres companion mode: live updates via LISTEN/NOTIFY")
+    _task = asyncio.create_task(_listen_loop())
+
+
+async def postgres_listen_shutdown() -> None:
+    """Stop the LISTEN/NOTIFY task."""
+    global _task, _connected
+    _connected = False
+    if _task is not None:
+        _task.cancel()
+        try:
+            await _task
+        except asyncio.CancelledError:
+            pass
+        _task = None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "asyncpg",
     "fastapi",
     "httpx",
-    "knx-telegram-store>=0.11.2",
+    "knx-telegram-store>=0.12.0",
     "mcp",
     "pydantic",
     "python-dotenv",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,7 @@ h11==0.16.0
 idna==3.18
 ifaddr==0.2.0
 iniconfig==2.3.0
-knx-telegram-store==0.11.2
+knx-telegram-store==0.12.0
 packaging==26.2
 pluggy==1.6.0
 pycparser==3.0

--- a/backend/tests/test_api_knx_control.py
+++ b/backend/tests/test_api_knx_control.py
@@ -26,6 +26,28 @@ def test_send_rejected_when_not_connected():
     assert response.status_code == 409
 
 
+def test_send_allowed_in_postgres_readonly_when_connected():
+    """Bus writes must not be blocked by the telegram store's read-only-ness.
+
+    postgres-readonly keeps a live daemon connection for writes even though
+    READ_ONLY (store) is True in that mode.
+    """
+    import api
+
+    with (
+        patch.object(api, "READ_ONLY", True),
+        patch.object(knx_daemon, "ALLOW_WRITE", True),
+        patch.object(knx_daemon, "is_connected", return_value=True),
+        patch.object(knx_daemon, "send_group_value", new=AsyncMock()) as send,
+    ):
+        response = client.post(
+            "/api/knx/send",
+            json={"address": "1/2/3", "payload": 50, "dpt": "5.001", "response": False},
+        )
+    assert response.status_code == 200
+    send.assert_awaited_once_with("1/2/3", 50, "5.001", False)
+
+
 def test_send_writes_to_bus():
     with (
         patch.object(knx_daemon, "ALLOW_WRITE", True),

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,44 @@
+"""Tests for database.py's STORE_MODE branching.
+
+database.py builds `store`/`engine` at import time from env vars, and other
+modules import those objects by reference (`from database import store`).
+Re-importing it in-process (e.g. via importlib.reload) would leave those
+already-bound references stale and could corrupt state for every other test
+in the suite that touches the shared store/engine. Each case here runs in a
+fresh subprocess instead, so it is fully isolated and never runs a real
+network connection (constructing a store just builds an engine object; it
+does not connect).
+"""
+
+import subprocess
+import sys
+
+
+def _run(store_mode: str, database_url: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", "import database; print(type(database.store).__name__)"],
+        cwd=__file__.rsplit("/tests/", 1)[0],
+        env={"STORE_MODE": store_mode, "DATABASE_URL": database_url, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def test_postgres_readonly_builds_plain_postgres_store():
+    result = _run("postgres-readonly", "postgresql+asyncpg://user:pass@localhost/db")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PostgresStore"
+
+
+def test_postgres_readonly_rejects_sqlite_url():
+    result = _run("postgres-readonly", "sqlite+aiosqlite:///some/path.db")
+    assert result.returncode != 0
+    assert "STORE_MODE=postgres-readonly requires a postgres DATABASE_URL" in result.stderr
+
+
+def test_standalone_postgres_still_builds_buffered_store():
+    """Unaffected by the new mode: standalone + postgres URL keeps writing/buffering."""
+    result = _run("standalone", "postgresql+asyncpg://user:pass@localhost/db")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "BufferedPostgresStore"

--- a/backend/tests/test_knx_daemon.py
+++ b/backend/tests/test_knx_daemon.py
@@ -321,20 +321,19 @@ def test_encode_payload_unknown_dpt_raises():
 
 
 @pytest.mark.parametrize(
-    ("allow_write", "read_only", "connected", "expected"),
+    ("allow_write", "connected", "expected"),
     [
-        (True, False, True, True),
-        (False, False, True, False),
-        (True, True, True, False),
-        (True, False, False, False),
+        (True, True, True),
+        (False, True, False),
+        (True, False, False),
     ],
 )
-def test_write_enabled(allow_write, read_only, connected, expected):
+def test_write_enabled(allow_write, connected, expected):
+    """Independent of the telegram store's read-only-ness (postgres-readonly can write)."""
     import knx_daemon
 
     with (
         patch.object(knx_daemon, "ALLOW_WRITE", allow_write),
-        patch.object(knx_daemon, "READ_ONLY", read_only),
         patch.object(knx_daemon, "is_connected", return_value=connected),
     ):
         assert knx_daemon.write_enabled() is expected
@@ -388,22 +387,23 @@ async def test_send_group_value_without_connection_raises():
 def test_get_server_config_standalone_reports_mode():
     import knx_daemon
 
-    with patch.object(knx_daemon, "READ_ONLY", False):
+    with patch.object(knx_daemon, "STORE_MODE", "standalone"):
         config = knx_daemon.get_server_config()
 
     assert config["mode"] == "standalone"
     assert "gateway_ip" in config["connection"]
     assert "knxkeys_found" in config["files"]
+    assert "telegram_store" not in config["status"]
 
 
 @pytest.mark.parametrize("feed_connected", [True, False])
 def test_get_server_config_companion_reports_live_feed(feed_connected):
-    """Companion mode must not report the daemon's bus connection (#184)."""
+    """Sqlite companion mode must not report the daemon's bus connection (#184)."""
     import ha_live_bridge
     import knx_daemon
 
     with (
-        patch.object(knx_daemon, "READ_ONLY", True),
+        patch.object(knx_daemon, "STORE_MODE", "external-readonly"),
         patch.object(ha_live_bridge, "_active_source", "ha_websocket"),
         patch.object(ha_live_bridge, "_connected", feed_connected),
     ):
@@ -416,3 +416,28 @@ def test_get_server_config_companion_reports_live_feed(feed_connected):
     # No gateway/security noise that doesn't apply in companion mode
     assert config["security"] == {}
     assert "knxkeys_found" not in config["files"]
+
+
+@pytest.mark.parametrize("feed_connected", [True, False])
+def test_get_server_config_postgres_readonly_reports_bus_and_store(feed_connected):
+    """postgres-readonly reports a real bus connection (own daemon) alongside the shared store."""
+    import knx_daemon
+    import pg_listen_bridge
+
+    with (
+        patch.object(knx_daemon, "STORE_MODE", "postgres-readonly"),
+        patch.object(knx_daemon, "is_connected", return_value=True),
+        patch.object(knx_daemon, "write_enabled", return_value=True),
+        patch.object(pg_listen_bridge, "_connected", feed_connected),
+    ):
+        config = knx_daemon.get_server_config()
+
+    assert config["mode"] == "postgres-companion"
+    # Same connection/security shape as standalone — it is our own bus connection.
+    assert "gateway_ip" in config["connection"]
+    assert "knxkeys_found" in config["files"]
+    assert config["status"]["connected"] is True
+    assert config["status"]["write_enabled"] is True
+    assert config["status"]["telegram_store"] == "shared-postgres-readonly"
+    assert config["status"]["live_source"] == "postgres-listen-notify"
+    assert config["status"]["live_connected"] is feed_connected

--- a/backend/tests/test_pg_listen_bridge.py
+++ b/backend/tests/test_pg_listen_bridge.py
@@ -1,0 +1,91 @@
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
+
+import pg_listen_bridge
+from pg_listen_bridge import _as_utc, _replay_gap
+
+
+def _stored(minutes_ago: float, destination: str = "1/1/1") -> StoredTelegram:
+    return StoredTelegram(
+        timestamp=datetime.now(UTC) - timedelta(minutes=minutes_ago),
+        source="1.1.1",
+        destination=destination,
+        telegramtype="GroupValueWrite",
+        direction="Incoming",
+        value=20.0,
+        dpt_main=9,
+    )
+
+
+def test_live_feed_status_reflects_bridge_state():
+    with patch.object(pg_listen_bridge, "_connected", True):
+        assert pg_listen_bridge.live_feed_status() == {"connected": True}
+
+    with patch.object(pg_listen_bridge, "_connected", False):
+        assert pg_listen_bridge.live_feed_status() == {"connected": False}
+
+
+@pytest.mark.asyncio
+async def test_replay_gap_noop_when_never_seen():
+    with patch.object(pg_listen_bridge, "_last_seen", None):
+        # No store.query patch: a call here would raise, proving it's skipped.
+        await _replay_gap()
+
+
+@pytest.mark.asyncio
+@patch("pg_listen_bridge.store.query", new_callable=AsyncMock)
+@patch("pg_listen_bridge.manager.broadcast", new_callable=AsyncMock)
+async def test_replay_gap_broadcasts_fresh_and_advances(mock_broadcast, mock_query):
+    old, new = _stored(10), _stored(1, "2/2/2")
+    mock_query.return_value = TelegramQueryResult(telegrams=[old, new], total_count=2, limit_reached=False)
+    since = datetime.now(UTC) - timedelta(minutes=5)
+
+    pg_listen_bridge._last_seen = since
+    await _replay_gap()
+
+    mock_broadcast.assert_awaited_once()
+    broadcast_arg = mock_broadcast.await_args.args[0]
+    assert broadcast_arg["target_address"] == "2/2/2"
+    assert pg_listen_bridge._last_seen == _as_utc(new.timestamp)
+
+    query = mock_query.call_args[0][0]
+    assert query.start_time == since
+    assert query.order_descending is False
+
+
+@pytest.mark.asyncio
+@patch("pg_listen_bridge.manager.broadcast", new_callable=AsyncMock)
+async def test_listen_loop_broadcasts_notified_telegrams(mock_broadcast):
+    telegram = _stored(0, "3/3/3")
+
+    async def _one_telegram_then_hang():
+        # Mirrors the real generator: never completes on its own, only via
+        # cancellation/exception. A generator that exhausts normally would
+        # make the loop immediately reconnect and re-yield, breaking the
+        # single-broadcast assertion below.
+        yield telegram
+        await asyncio.Event().wait()
+
+    with (
+        patch.object(pg_listen_bridge, "store") as mock_store,
+        patch.object(pg_listen_bridge, "_replay_gap", new=AsyncMock()),
+    ):
+        mock_store.listen_for_new_telegrams = lambda: _one_telegram_then_hang()
+        task = asyncio.create_task(pg_listen_bridge._listen_loop())
+
+        # Give the loop a chance to consume the single-item generator.
+        for _ in range(50):
+            if mock_broadcast.await_count:
+                break
+            await asyncio.sleep(0.02)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    mock_broadcast.assert_awaited_once()
+    assert mock_broadcast.await_args.args[0]["target_address"] == "3/3/3"
+    assert pg_listen_bridge._last_seen == _as_utc(telegram.timestamp)


### PR DESCRIPTION
Closes #400.

## What

A new `STORE_MODE=postgres-readonly`, distinct from `external-readonly` (which stays sqlite-only, unchanged). Reads a PostgreSQL database owned and written by another process (e.g. Home Assistant's KNX integration with `telegram_db_backend: postgres`), while our own KNX daemon still connects to the bus for outbound writes — it never persists telegrams itself in this mode, since the writer already does.

Depends on `knx-telegram-store>=0.12.0` (XKNX/knx-telegram-store#27, released) for `PostgresStore(read_only=True)` and `listen_for_new_telegrams()`.

## Changes

- **`database.py`**: builds a plain (unbuffered) read-only `PostgresStore` for this mode. The raw SQLAlchemy engine also gets `default_transaction_read_only=on` as defense-in-depth beyond the store's own rejection (covers e.g. `/api/statistics`'s direct SQL).
- **`knx_daemon.py`**:
  - `write_enabled()` no longer depends on the store's read-only-ness — bus-write capability and store-write capability are orthogonal now that a mode can have one without the other.
  - `knx_startup()`/`knx_shutdown()` guard `store.start()`/`.stop()` (buffered-store-only methods a plain `PostgresStore` doesn't have).
  - `process_telegram_async` returns immediately in this mode: the daemon stays connected only to enable writes, never records or broadcasts what it observes on the bus itself (that would duplicate/race with the writer's own inserts).
  - `get_server_config()` gets a third branch: same connection/security shape as `standalone` (it's a real bus connection), plus `telegram_store`/`live_source`/`live_connected` status fields.
- **`pg_listen_bridge.py`** (new): drives the live websocket feed from `store.listen_for_new_telegrams()` (Postgres `LISTEN`/`NOTIFY`), with gap replay on reconnect — mirrors `ha_live_bridge.py`'s existing pattern for the sqlite case.
- **`api.py`**: fixed two spots that gated on the store's `READ_ONLY` flag where they should gate on actual bus-write/connection capability — `_require_bus_write()` and the websocket's initial `connection_state` message. Without this fix, this whole mode would have immediately hit a bug where bus writes stay blocked despite the daemon being connected.

## Testing

- Unit tests for the new `write_enabled()`/`get_server_config()` behavior, `database.py`'s mode selection (subprocess-isolated, since it builds `store`/`engine` at import time), and `pg_listen_bridge.py` (gap replay, notify-driven broadcast).
- A regression test proving the `_require_bus_write()` fix: a send succeeds with `READ_ONLY=True` as long as the daemon is actually connected.
- End-to-end, manually: booted the real app in `postgres-readonly` mode against a live Postgres container, confirmed `/api/server/config` reports the new mode, and that a telegram written by a separate process arrived over `/ws/telegrams` via `LISTEN`/`NOTIFY` — not duplicated, not missed.

205 backend tests pass, ruff clean on all touched files.
