### PR TITLE
release: prepare v2.0.0-beta.5 pre-release

### DIFF
--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.0.0-beta.5
+
+### Added
+
+- **Shared PostgreSQL companion mode**: New `STORE_MODE=postgres-readonly` reads a PostgreSQL database owned and written by another process (e.g. Home Assistant's KNX integration), with live updates via PostgreSQL `LISTEN`/`NOTIFY` instead of polling. Unlike the existing sqlite companion mode, the KNX daemon still connects to the bus for outbound writes; it never writes telegrams itself in this mode.
+
+### Changed
+
+- **Performance**: Offloaded blocking file I/O (project/knxkeys uploads) to a thread pool so it no longer stalls the async event loop.
+- **Performance**: `get_statistics` reuses precomputed project name maps instead of rebuilding them on every request.
+
+### Fixed
+
+- **Security**: Restricted CORS to specific configured origins instead of allowing `*` together with credentials.
+
 ## 2.0.0-beta.4
 
 ### Changed

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "2.0.0-beta.4"
+version: "2.0.0-beta.5"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.0.0-beta.5
+
+### Added
+
+- **Shared PostgreSQL companion mode**: New `STORE_MODE=postgres-readonly` reads a PostgreSQL database owned and written by another process (e.g. Home Assistant's KNX integration), with live updates via PostgreSQL `LISTEN`/`NOTIFY` instead of polling. Unlike the existing sqlite companion mode, the KNX daemon still connects to the bus for outbound writes; it never writes telegrams itself in this mode.
+
+### Changed
+
+- **Performance**: Offloaded blocking file I/O (project/knxkeys uploads) to a thread pool so it no longer stalls the async event loop.
+- **Performance**: `get_statistics` reuses precomputed project name maps instead of rebuilding them on every request.
+
+### Fixed
+
+- **Security**: Restricted CORS to specific configured origins instead of allowing `*` together with credentials.
+
 ## 2.0.0-beta.4
 
 ### Changed

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "2.0.0-beta.4"
+version: "2.0.0-beta.5"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
Beta release since v2.0.0-beta.4. Bumps both Home Assistant add-ons to 2.0.0-beta.5 — see the CHANGELOG.md diff for the full list (postgres-readonly companion mode #401, two perf fixes, one CORS security fix).