### PR TITLE
feat: building structure GA table readability (#306)

### DIFF
--- a/frontend/src/components/BuildingOverlay.tsx
+++ b/frontend/src/components/BuildingOverlay.tsx
@@ -4,9 +4,16 @@ import {
 } from 'lucide-react';
 import { apiUrl } from '../utils/basePath';
 import { useExpanded } from '../utils/buildingExpansion';
+import { GaNameWidthContext } from '../utils/gaNameWidth';
 import { SendToGaPopover } from './SendToGaPopover';
 import { GaValuesTable } from './GaValuesTable';
 import type { Telegram } from '../hooks/useWebSocket';
+
+// GA name column width is clamped to keep a single very long name from blowing
+// up the shared table layout, while still giving short project names their
+// natural width (#306).
+const MIN_GA_NAME_WIDTH_CH = 8;
+const MAX_GA_NAME_WIDTH_CH = 60;
 
 // ── Types (mirror /api/building response) ──────────────────────────────────────
 
@@ -134,6 +141,30 @@ const functionMatches = (func: FunctionNode, q: string): boolean =>
   func.group_addresses.some(g =>
     g.address.toLowerCase().includes(q) || (g.name ?? '').toLowerCase().includes(q)
   );
+
+// Widest GA name across the whole project, so every GaValuesTable instance in
+// the tree (comm objects and functions alike) aligns its DPT/TIME/VALUE
+// columns at the same x position (#306).
+const collectMaxGaNameLength = (data: BuildingData): number => {
+  let maxLen = 0;
+  const consider = (name: string | null | undefined) => {
+    if (name && name.length > maxLen) maxLen = name.length;
+  };
+  const walkKo = (ko: Ko) => ko.group_addresses.forEach(g => consider(g.name));
+  const walkDevice = (d: DeviceNode) => {
+    d.channels.forEach(c => c.kos.forEach(walkKo));
+    d.kos.forEach(walkKo);
+  };
+  const walkFunc = (f: FunctionNode) => f.group_addresses.forEach(g => consider(g.name));
+  const walkSpace = (s: SpaceNode) => {
+    s.spaces.forEach(walkSpace);
+    s.devices.forEach(walkDevice);
+    (s.functions ?? []).forEach(walkFunc);
+  };
+  data.tree.forEach(walkSpace);
+  data.unassigned_devices.forEach(walkDevice);
+  return maxLen;
+};
 
 const spaceMatches = (s: SpaceNode, q: string): boolean =>
   s.name.toLowerCase().includes(q) ||
@@ -664,6 +695,13 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
 
   const isEmpty = data && data.tree.length === 0 && data.unassigned_devices.length === 0;
 
+  const gaNameWidthCh = useMemo(() => {
+    if (!data) return null;
+    const maxLen = collectMaxGaNameLength(data);
+    if (maxLen === 0) return null;
+    return Math.min(Math.max(maxLen, MIN_GA_NAME_WIDTH_CH), MAX_GA_NAME_WIDTH_CH) + 1;
+  }, [data]);
+
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       {/* Header */}
@@ -706,6 +744,7 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
         </div>
       ) : (
         <div style={{ flex: 1, overflowY: 'auto', padding: '0.5rem 0' }}>
+          <GaNameWidthContext.Provider value={gaNameWidthCh}>
           {sortSpaces(data.tree).map((space, i) => (
             <SpaceRow
               key={`${space.name}-${i}`} space={space} path={`${space.type}:${space.name}#${i}`} depth={0} query={query}
@@ -728,6 +767,7 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
               ))}
             </div>
           )}
+          </GaNameWidthContext.Provider>
         </div>
       )}
 

--- a/frontend/src/components/GaValuesTable.test.tsx
+++ b/frontend/src/components/GaValuesTable.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { afterEach, expect, test, vi } from 'vitest';
 import { GaValuesTable, type GaTableEntry } from './GaValuesTable';
+import { GaNameWidthContext } from '../utils/gaNameWidth';
 import type { Telegram } from '../hooks/useWebSocket';
 
 const ENTRIES: GaTableEntry[] = [
@@ -31,7 +32,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test('fetches last values for its addresses and marks never-seen GAs', async () => {
+test('fetches last values for its addresses and leaves never-seen GAs blank', async () => {
   vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
     expect(url).toContain('/api/telegrams/last');
@@ -42,7 +43,11 @@ test('fetches last values for its addresses and marks never-seen GAs', async () 
   render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
 
   await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
-  expect(screen.getByText('never seen')).toBeInTheDocument();
+  const neverSeenRow = screen.getByText('Kitchen Status').closest('tr')!;
+  const cells = within(neverSeenRow).getAllByRole('cell');
+  expect(cells[3]).toHaveTextContent(''); // TIME
+  expect(cells[3]).toHaveAttribute('title', 'Never updated');
+  expect(cells[4]).toHaveTextContent(''); // VALUE
 });
 
 test('updates a value live from the websocket feed and ignores unrelated GAs', async () => {
@@ -54,13 +59,12 @@ test('updates a value live from the websocket feed and ignores unrelated GAs', a
     <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />
   );
   await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
-  expect(screen.getByText('never seen')).toBeInTheDocument();
+  expect(within(screen.getByText('Kitchen Status').closest('tr')!).getAllByRole('cell')[4]).toHaveTextContent('');
 
   rerender(
     <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('1/2/10', 'Off')} onFilterGAs={() => {}} onLastSeen={() => {}} />
   );
   await waitFor(() => expect(screen.getByText('Off')).toBeInTheDocument());
-  expect(screen.queryByText('never seen')).not.toBeInTheDocument();
 
   rerender(
     <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('9/9/9', 'Ignored')} onFilterGAs={() => {}} onLastSeen={() => {}} />
@@ -101,4 +105,37 @@ test('highlights the sending group address', async () => {
   expect(screen.getByLabelText('sending')).toBeInTheDocument();
   const sendingRow = screen.getByTitle('Sending group address');
   expect(within(sendingRow).getByText('1/2/3')).toBeInTheDocument();
+});
+
+test('highlights the hovered row and restores the sending tint on leave', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
+
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+  await waitFor(() => expect(screen.getByText('1/2/3')).toBeInTheDocument());
+
+  const sendingRow = screen.getByTitle('Sending group address');
+  fireEvent.mouseEnter(sendingRow);
+  expect(sendingRow.style.background).toBe('var(--bg-hover)');
+  fireEvent.mouseLeave(sendingRow);
+  expect(sendingRow.style.background).toBe('rgba(99, 102, 241, 0.08)');
+
+  const otherRow = screen.getByText('Kitchen Status').closest('tr')!;
+  fireEvent.mouseEnter(otherRow);
+  expect(otherRow.style.background).toBe('var(--bg-hover)');
+  fireEvent.mouseLeave(otherRow);
+  expect(otherRow.style.background).toBe('transparent');
+});
+
+test('sizes the NAME column from GaNameWidthContext when provided', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
+
+  render(
+    <GaNameWidthContext.Provider value={24}>
+      <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />
+    </GaNameWidthContext.Provider>
+  );
+  await waitFor(() => expect(screen.getByText('Kitchen Light')).toBeInTheDocument());
+
+  const nameCell = screen.getByText('Kitchen Light').closest('td')!;
+  expect(nameCell.style.width).toBe('24ch');
 });

--- a/frontend/src/components/GaValuesTable.tsx
+++ b/frontend/src/components/GaValuesTable.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useContext } from 'react';
 import { format } from 'date-fns';
 import { Filter, Clock, ChevronUp, ChevronDown } from 'lucide-react';
 import { apiUrl } from '../utils/basePath';
+import { GaNameWidthContext } from '../utils/gaNameWidth';
 import { SendToGaPopover } from './SendToGaPopover';
 import type { Telegram } from '../hooks/useWebSocket';
 
 // Sortable table of group addresses with their last seen values (#269).
-// Used by the building view for a KO's linked GAs and a function's GAs.
+// Used by the building view for a KO's linked GAs and a function's GAs (#306).
 
 export interface GaTableEntry {
   address: string;
@@ -97,6 +98,10 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
 }) => {
   const [valuesByGA, setValuesByGA] = useState<Record<string, Telegram>>({});
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null);
+  const nameWidthCh = useContext(GaNameWidthContext);
+  const nameColumnStyle: React.CSSProperties = nameWidthCh
+    ? { width: `${nameWidthCh}ch`, maxWidth: `${nameWidthCh}ch` }
+    : { maxWidth: 300 };
 
   const addresses = useMemo(() => [...new Set(entries.map(e => e.address))], [entries]);
   const addressSet = useMemo(() => new Set(addresses), [addresses]);
@@ -112,7 +117,7 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
       for (const t of (json.telegrams ?? []) as Telegram[]) map[t.target_address] = t;
       setValuesByGA(map);
     } catch {
-      // network errors are non-fatal; the table just shows "never seen"
+      // network errors are non-fatal; the table just shows blank TIME/VALUE cells
     }
   }, [addresses]);
 
@@ -179,6 +184,8 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
                 key={entry.address}
                 style={entry.sending ? { background: 'rgba(99,102,241,0.08)' } : undefined}
                 title={entry.sending ? 'Sending group address' : undefined}
+                onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-hover)')}
+                onMouseLeave={e => (e.currentTarget.style.background = entry.sending ? 'rgba(99,102,241,0.08)' : 'transparent')}
               >
                 <td style={{ ...cellStyle, width: '1%' }}>
                   {/* The sending GA is framed rather than icon-tagged (#295). */}
@@ -199,7 +206,7 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
                     }}
                   >{entry.address}</span>
                 </td>
-                <td style={{ ...cellStyle, maxWidth: 300, color: 'var(--text-dim)' }} title={entry.name || undefined}>
+                <td style={{ ...cellStyle, ...nameColumnStyle, color: 'var(--text-dim)' }} title={entry.name || undefined}>
                   {entry.name || '—'}
                 </td>
                 <td style={{ ...cellStyle, width: '1%', color: 'var(--text-dim)' }} title={dptLabel || undefined}>
@@ -209,15 +216,15 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
                   style={{ ...cellStyle, width: '1%', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}
                   title={t ? `by ${t.source_address}${t.source_name ? ` (${t.source_name})` : ''}` : 'Never updated'}
                 >
-                  {t ? format(new Date(t.timestamp), 'yyyy-MM-dd HH:mm:ss.SS') : '—'}
+                  {t ? format(new Date(t.timestamp), 'yyyy-MM-dd HH:mm:ss.SS') : ''}
                 </td>
                 <td style={{ ...cellStyle, fontWeight: 600, color: t ? 'var(--text-main)' : 'var(--text-dim)' }}>
-                  {t ? (
+                  {t && (
                     <>
                       {t.value_formatted ?? t.value_numeric ?? '—'}
                       {t.unit && <span style={{ fontWeight: 400, color: 'var(--text-dim)' }}> {t.unit}</span>}
                     </>
-                  ) : 'never seen'}
+                  )}
                 </td>
                 <td style={{ ...cellStyle, width: '1%' }}>
                   <span style={{ display: 'inline-flex', alignItems: 'center' }}>

--- a/frontend/src/utils/gaNameWidth.ts
+++ b/frontend/src/utils/gaNameWidth.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+// Every GaValuesTable instance in a building tree shares one NAME column
+// width, computed once from all GA names in the loaded project, so DPT/TIME/
+// VALUE line up at the same x position across every function and comm-object
+// table (#306). Falls back to a fixed max-width outside this context (tests,
+// other callers).
+export const GaNameWidthContext = createContext<number | null>(null);


### PR DESCRIPTION
## Summary
- Add row hover highlighting to the shared `GaValuesTable` (comm-object and function GA tables in Building Structure), matching the existing hover treatment on the surrounding tree rows.
- Compute one project-wide GA name-column width (`GaNameWidthContext`, provided by `BuildingOverlay`) so DPT/TIME/VALUE line up at the same x position across every function and comm-object table in the tree.
- Leave TIME and VALUE cells blank for never-seen GAs instead of showing `—` / "never seen" placeholder text.

`GaValuesTable` already served as the shared GA table for both comm objects (`KoRow`) and functions (`FunctionRow`) since #269 — this issue's design comment proposed extracting a new shared component, but that discovery meant only the three readability fixes above were needed.

Closes #306

## Test plan
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 276/276 passing (updated + added `GaValuesTable` tests for blank never-seen cells, hover, and context-driven column width)
- [x] Verified in a running instance (Vite dev server + Playwright, stubbed `/api/building`/`/api/telegrams/last`): hover highlight, cross-table column alignment (DPT/TIME/VALUE at the same x in both the KO table and the function table below it), and blank never-seen cells all confirmed visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)