### PR TITLE
feat: building structure readability and functionality (#307)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -521,9 +521,27 @@ async def get_project():
 
 def _build_ko(co: dict, gas: dict) -> dict:
     """Serialize a communication object (KO) with its connected group addresses."""
-    group_addresses = [
-        {"address": ga, "name": gas.get(ga, {}).get("name", "")} for ga in co.get("group_address_links") or []
-    ]
+    group_addresses = []
+    for ga_addr in co.get("group_address_links") or []:
+        ga_master = gas.get(ga_addr) or {}
+        # Each GA's own DPT, resolved from the project — may differ from the KO's
+        # own DPT declaration even within the same main category (#307).
+        ga_dpt = ga_master.get("dpt")
+        group_addresses.append(
+            {
+                "address": ga_addr,
+                "name": ga_master.get("name", ""),
+                "dpt": (
+                    {
+                        "main": ga_dpt.get("main"),
+                        "sub": ga_dpt.get("sub"),
+                        "name": format_dpt_name(ga_dpt.get("main"), ga_dpt.get("sub"))[0],
+                    }
+                    if ga_dpt
+                    else None
+                ),
+            }
+        )
     # Resolve each DPT's descriptive name (e.g. "5.001 - Percent") so the building
     # view can show it like the group monitor does, not just the raw numbers.
     dpts = [
@@ -630,6 +648,9 @@ def _build_space(space: dict, devices: dict, cos: dict, gas: dict, functions_dic
                     "id": func_id,
                     "name": func.get("name", ""),
                     "type": func.get("function_type", ""),
+                    # ETS function-type name (e.g. FT-1 -> "Licht schalten"), resolved by
+                    # xknxproject from ETS master data (#307).
+                    "type_name": func.get("usage_text", ""),
                     "group_addresses": group_addresses,
                 }
             )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -107,6 +107,7 @@ def test_get_building_with_project():
             "Func-1": {
                 "name": "Dimming Light",
                 "function_type": "Dimming",
+                "usage_text": "Licht dimmen",
                 "group_addresses": {
                     # As in real projects: the function ref carries no name and an
                     # opaque UUID role — the real name/DPT come from the project (#295).
@@ -167,6 +168,7 @@ def test_get_building_with_project():
     assert func["id"] == "Func-1"
     assert func["name"] == "Dimming Light"
     assert func["type"] == "Dimming"
+    assert func["type_name"] == "Licht dimmen"  # resolved by xknxproject from ETS master data (#307)
     ga = func["group_addresses"][0]
     assert ga["address"] == "1/2/3"
     assert ga["name"] == "Light On/Off"  # resolved from the project, not the empty ref (#295)
@@ -182,7 +184,13 @@ def test_get_building_with_project():
     assert len(device["channels"]) == 1
     assert device["channels"][0]["name"] == "Channel A"
     assert device["channels"][0]["kos"][0]["number"] == 1
-    assert device["channels"][0]["kos"][0]["group_addresses"][0] == {"address": "1/2/3", "name": "Light On/Off"}
+    assert device["channels"][0]["kos"][0]["group_addresses"][0] == {
+        "address": "1/2/3",
+        "name": "Light On/Off",
+        # Each GA's own DPT, resolved from the project (#307) — may differ from
+        # the KO's own declared DPT even within the same main category.
+        "dpt": {"main": 1, "sub": 1, "name": "1.001 - Switch"},
+    }
     # DPTs carry a resolved descriptive name for the building view (#160).
     assert device["channels"][0]["kos"][0]["dpts"] == [{"main": 1, "sub": 1, "name": "1.001 - Switch"}]
     assert len(device["kos"]) == 1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -561,6 +561,14 @@ function App() {
     setIsDatabaseOpen(false);
   };
 
+  // Add a function's/device's/comm-object's group addresses to the visualization
+  // selection (union, like handleFilterGAs) and open the visualizer (#307).
+  const handleVisualizeGAs = useCallback((addresses: string[]) => {
+    setSelectedVisualizationTargets(prev => [...new Set([...prev, ...addresses])]);
+    setActivePanel('visualizer');
+    setIsDatabaseOpen(false);
+  }, []);
+
   const handleQuickLastSeen = useCallback((address: string | string[], mode: 'ga' | 'pa') => {
     setLastSeenAddresses(Array.isArray(address) ? address : [address]);
     setLastSeenMode(mode);
@@ -1148,6 +1156,7 @@ function App() {
                     onFilterDevice={(pa) => handleQuickFilter('sources', pa)}
                     onFilterGAs={handleFilterGAs}
                     onLastSeen={handleQuickLastSeen}
+                    onVisualizeGAs={handleVisualizeGAs}
                     onDeviceStatus={setStatusDevice}
                     writeEnabled={serverConfig?.status?.write_enabled}
                     latestTelegram={latestTelegram}

--- a/frontend/src/components/BuildingOverlay.test.tsx
+++ b/frontend/src/components/BuildingOverlay.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import type { BuildingOverlay as BuildingOverlayType } from './BuildingOverlay';
+
+// The tree's expand/collapse state is deliberately persisted at module scope
+// (mirrored to sessionStorage) so it survives the overlay unmounting — see
+// utils/buildingExpansion.ts. That means it also persists across tests in this
+// file unless reset: clear storage and re-import the module fresh each time.
+let BuildingOverlay: typeof BuildingOverlayType;
+
+beforeEach(async () => {
+  sessionStorage.clear();
+  vi.resetModules();
+  ({ BuildingOverlay } = await import('./BuildingOverlay'));
+});
+
+const BUILDING_DATA = {
+  status: 'ok',
+  unassigned_devices: [],
+  tree: [
+    {
+      kind: 'space',
+      type: 'Building',
+      name: 'Main House',
+      spaces: [],
+      devices: [
+        {
+          address: '1.1.1',
+          name: 'Push Button',
+          manufacturer: 'MDT',
+          hardware: 'BE-GTM1TS.01',
+          channels: [],
+          kos: [
+            {
+              number: 1,
+              name: 'Switch',
+              text: 'Switching',
+              function_text: '',
+              dpts: [{ main: 1, sub: 1, name: '1.001 - Switch' }],
+              flags: { transmit: true },
+              group_addresses: [
+                // Sending GA (listed first per ETS convention) shares the KO's own DPT.
+                { address: '1/1/1', name: 'Switch GA', dpt: { main: 1, sub: 1, name: '1.001 - Switch' } },
+                // Different DPT main category than the KO's own declared DPT (#307 mismatch).
+                { address: '1/1/2', name: 'Status GA', dpt: { main: 5, sub: 1, name: '5.001 - Percent' } },
+              ],
+            },
+          ],
+        },
+      ],
+      functions: [
+        {
+          id: 'func1',
+          name: 'Kitchen Light',
+          type: 'FT-1',
+          type_name: 'Licht schalten',
+          group_addresses: [
+            { address: '1/1/1', name: 'Switch GA', dpts: [{ main: 1, sub: 1, name: '1.001 - Switch' }] },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function mockFetch(routes: Record<string, unknown>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    for (const [path, body] of Object.entries(routes)) {
+      if (url.includes(path)) return { ok: true, json: async () => body } as Response;
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+const noop = () => {};
+
+test('resolves and shows the ETS function-type name next to the function (#307)', async () => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/building': BUILDING_DATA, '/api/telegrams/last': { telegrams: [] } }));
+
+  render(
+    <BuildingOverlay
+      onClose={noop} onFilterDevice={noop} onFilterGAs={noop} onLastSeen={noop}
+      onVisualizeGAs={noop} onDeviceStatus={noop}
+    />
+  );
+
+  await waitFor(() => expect(screen.getByText('Kitchen Light')).toBeInTheDocument());
+  expect(screen.getByText('Licht schalten')).toBeInTheDocument();
+});
+
+test('visualizing a function adds all its group addresses and opens the visualizer (#307)', async () => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/building': BUILDING_DATA, '/api/telegrams/last': { telegrams: [] } }));
+  const onVisualizeGAs = vi.fn();
+
+  render(
+    <BuildingOverlay
+      onClose={noop} onFilterDevice={noop} onFilterGAs={noop} onLastSeen={noop}
+      onVisualizeGAs={onVisualizeGAs} onDeviceStatus={noop}
+    />
+  );
+
+  await waitFor(() => expect(screen.getByText('Kitchen Light')).toBeInTheDocument());
+  fireEvent.click(screen.getByTitle('Visualize all 1 group address of this function'));
+  expect(onVisualizeGAs).toHaveBeenCalledWith(['1/1/1']);
+});
+
+test('visualizing a device adds all its group addresses (#307)', async () => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/building': BUILDING_DATA, '/api/telegrams/last': { telegrams: [] } }));
+  const onVisualizeGAs = vi.fn();
+
+  render(
+    <BuildingOverlay
+      onClose={noop} onFilterDevice={noop} onFilterGAs={noop} onLastSeen={noop}
+      onVisualizeGAs={onVisualizeGAs} onDeviceStatus={noop}
+    />
+  );
+
+  await waitFor(() => expect(screen.getByText('Push Button')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('Push Button')); // expand the device
+  fireEvent.click(screen.getByTitle('Visualize all 2 group addresses of this device'));
+  expect(onVisualizeGAs).toHaveBeenCalledWith(['1/1/1', '1/1/2']);
+});
+
+test('comm object filter action uses the multi-GA icon, not the single-GA one (#307)', async () => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/building': BUILDING_DATA, '/api/telegrams/last': { telegrams: [] } }));
+
+  render(
+    <BuildingOverlay
+      onClose={noop} onFilterDevice={noop} onFilterGAs={noop} onLastSeen={noop}
+      onVisualizeGAs={noop} onDeviceStatus={noop}
+    />
+  );
+
+  await waitFor(() => expect(screen.getByText('Push Button')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('Push Button'));
+  expect(screen.getByTitle('Filter by connected group addresses')).toBeInTheDocument();
+});
+
+test('comm object header shows the DPT-family mismatch and the newest value, framed when sent from the sending GA (#307)', async () => {
+  vi.stubGlobal('fetch', mockFetch({
+    '/api/building': BUILDING_DATA,
+    '/api/telegrams/last': {
+      telegrams: [
+        {
+          timestamp: new Date().toISOString(),
+          source_address: '1.1.9', source_name: 'Push Button',
+          target_address: '1/1/1', target_name: 'Switch GA',
+          telegram_type: 'GroupValueWrite', dpt: '1.001', dpt_main: 1, dpt_sub: 1, dpt_name: '1.001 - Switch',
+          value_numeric: 1, value_json: null, value_formatted: 'On', raw_data: '01',
+        },
+      ],
+    },
+  }));
+
+  render(
+    <BuildingOverlay
+      onClose={noop} onFilterDevice={noop} onFilterGAs={noop} onLastSeen={noop}
+      onVisualizeGAs={noop} onDeviceStatus={noop}
+    />
+  );
+
+  await waitFor(() => expect(screen.getByText('Push Button')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('Push Button'));
+
+  // The KO's own DPT is main category 1; one connected GA (1/1/2) is main category 5.
+  await waitFor(() => expect(screen.getByText('5.*')).toBeInTheDocument());
+
+  const valueEl = await screen.findByText('On');
+  expect(valueEl.style.border).toContain('var(--accent-primary)'); // framed: newest telegram targets the sending GA
+});
+
+test('visualizing a single GA row inside the expanded comm-object table propagates through (#307)', async () => {
+  vi.stubGlobal('fetch', mockFetch({ '/api/building': BUILDING_DATA, '/api/telegrams/last': { telegrams: [] } }));
+  const onVisualizeGAs = vi.fn();
+
+  render(
+    <BuildingOverlay
+      onClose={noop} onFilterDevice={noop} onFilterGAs={noop} onLastSeen={noop}
+      onVisualizeGAs={onVisualizeGAs} onDeviceStatus={noop}
+    />
+  );
+
+  await waitFor(() => expect(screen.getByText('Push Button')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('Push Button')); // expand device
+  fireEvent.click(screen.getByText('Switching')); // expand the KO's GA table
+
+  const row = (await screen.findByText('Status GA')).closest('tr')!;
+  fireEvent.click(within(row).getByTitle('Visualize this group address'));
+  expect(onVisualizeGAs).toHaveBeenCalledWith(['1/1/2']);
+});

--- a/frontend/src/components/BuildingOverlay.tsx
+++ b/frontend/src/components/BuildingOverlay.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { format } from 'date-fns';
 import {
   X, RefreshCw, Building2, ChevronDown, ChevronRight, Cpu, Layers, Filter, ListFilter, Clock, Activity, Sparkles,
+  LineChart,
 } from 'lucide-react';
 import { apiUrl } from '../utils/basePath';
 import { useExpanded } from '../utils/buildingExpansion';
 import { GaNameWidthContext } from '../utils/gaNameWidth';
+import { useLastSeenValues } from '../hooks/useLastSeenValues';
 import { SendToGaPopover } from './SendToGaPopover';
 import { GaValuesTable } from './GaValuesTable';
 import type { Telegram } from '../hooks/useWebSocket';
@@ -20,6 +23,9 @@ const MAX_GA_NAME_WIDTH_CH = 60;
 export interface GaRef {
   address: string;
   name: string;
+  /** This GA's own DPT, resolved from the project — may differ from the KO's
+   * declared DPT even within the same main category (#307). */
+  dpt?: { main: number; sub: number | null; name?: string | null } | null;
 }
 
 export interface Ko {
@@ -57,6 +63,9 @@ export interface FunctionNode {
   id: string;
   name: string;
   type: string;
+  /** ETS function-type name (e.g. FT-1 -> "Licht schalten"), resolved by
+   * xknxproject from ETS master data (#307). */
+  type_name?: string;
   group_addresses: FunctionGA[];
 }
 
@@ -83,6 +92,8 @@ interface BuildingOverlayProps {
   onFilterGAs: (addresses: string[]) => void;
   /** Open the last-seen overlay for one or more addresses. */
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  /** Open the visualization panel plotting one or more group addresses (#307). */
+  onVisualizeGAs: (addresses: string[]) => void;
   /** Open the live KO status view for a device (#153). */
   onDeviceStatus: (device: DeviceNode) => void;
   writeEnabled?: boolean;
@@ -217,12 +228,13 @@ const KoRow: React.FC<{
   depth: number;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  onVisualizeGAs: (addresses: string[]) => void;
   writeEnabled?: boolean;
   latestTelegram?: Telegram | null;
-}> = ({ ko, koKey, depth, onFilterGAs, onLastSeen, writeEnabled, latestTelegram }) => {
+}> = ({ ko, koKey, depth, onFilterGAs, onLastSeen, onVisualizeGAs, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`ko:${koKey}`, false);
   const dpt = formatDpt(ko.dpts);
-  const gaAddresses = ko.group_addresses.map(g => g.address);
+  const gaAddresses = useMemo(() => ko.group_addresses.map(g => g.address), [ko.group_addresses]);
   const hasGAs = gaAddresses.length > 0;
   // ETS lists the sending GA first among a transmitting object's links.
   const sendingGA = ko.flags?.transmit && hasGAs ? ko.group_addresses[0].address : null;
@@ -230,6 +242,27 @@ const KoRow: React.FC<{
   const label = (nameText && ko.function_text && nameText !== ko.function_text)
     ? `${nameText} (${ko.function_text})`
     : (nameText || ko.function_text || `Object ${ko.number ?? ''}`);
+
+  // Newest telegram across the KO's linked GAs, and whether any linked GA's own
+  // DPT main category differs from the KO's own declared DPT — both shown in the
+  // header, aligned with the GA table's TIME/VALUE/DPT columns beneath it (#307).
+  const valuesByGA = useLastSeenValues(gaAddresses, latestTelegram);
+  const newest = useMemo(() => {
+    let latest: Telegram | null = null;
+    for (const addr of gaAddresses) {
+      const t = valuesByGA[addr];
+      if (t && (!latest || new Date(t.timestamp) > new Date(latest.timestamp))) latest = t;
+    }
+    return latest;
+  }, [gaAddresses, valuesByGA]);
+  const mismatchMain = useMemo(() => {
+    const ownMain = ko.dpts[0]?.main;
+    if (ownMain == null) return null;
+    const other = ko.group_addresses.find(ga => ga.dpt?.main != null && ga.dpt.main !== ownMain);
+    return other?.dpt?.main ?? null;
+  }, [ko.dpts, ko.group_addresses]);
+  const framed = !!newest && newest.target_address === sendingGA;
+
   return (
     <div>
     <div
@@ -277,7 +310,7 @@ const KoRow: React.FC<{
           title={dpt.name ? `${dpt.label} – ${dpt.name}` : dpt.label}
           style={{
             display: 'flex', flexDirection: 'column', alignItems: 'flex-end',
-            flexShrink: 0, minWidth: 0, maxWidth: '45%',
+            flexShrink: 0, minWidth: 0, maxWidth: '35%',
           }}
         >
           <span style={{ fontSize: '0.65rem', color: 'var(--text-dim)', whiteSpace: 'nowrap' }}>
@@ -291,6 +324,38 @@ const KoRow: React.FC<{
               {dpt.name}
             </span>
           )}
+          {mismatchMain != null && (
+            <span
+              title={`A connected group address has a different DPT main category (${mismatchMain}.*) than this communication object's own DPT`}
+              style={{ fontSize: '0.65rem', color: 'var(--warning, #f59e0b)', whiteSpace: 'nowrap' }}
+            >
+              {mismatchMain}.*
+            </span>
+          )}
+        </div>
+      )}
+      {newest && (
+        <div style={{
+          display: 'flex', flexDirection: 'column', alignItems: 'flex-end',
+          flexShrink: 0, minWidth: 0, maxWidth: '25%',
+        }}>
+          <span
+            style={{ fontSize: '0.65rem', color: 'var(--text-dim)', whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' }}
+            title={`by ${newest.source_address}${newest.source_name ? ` (${newest.source_name})` : ''}`}
+          >
+            {format(new Date(newest.timestamp), 'yyyy-MM-dd HH:mm:ss.SS')}
+          </span>
+          <span
+            style={{
+              fontSize: '0.65rem', fontWeight: 600, color: 'var(--text-main)', whiteSpace: 'nowrap',
+              ...(framed
+                ? { border: '1px solid var(--accent-primary)', borderRadius: '4px', padding: '0.02rem 0.3rem' }
+                : {}),
+            }}
+          >
+            {newest.value_formatted ?? newest.value_numeric ?? '—'}
+            {newest.unit && <span style={{ fontWeight: 400, color: 'var(--text-dim)' }}> {newest.unit}</span>}
+          </span>
         </div>
       )}
       {gaAddresses.length > 0 && (
@@ -308,12 +373,21 @@ const KoRow: React.FC<{
           )}
           <button
             style={iconBtnStyle}
+            title={`Visualize connected group address${gaAddresses.length > 1 ? 'es' : ''}`}
+            onClick={e => { e.stopPropagation(); onVisualizeGAs(gaAddresses); }}
+            onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+            onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+          >
+            <LineChart size={12} />
+          </button>
+          <button
+            style={iconBtnStyle}
             title={`Filter by connected group address${gaAddresses.length > 1 ? 'es' : ''}`}
             onClick={e => { e.stopPropagation(); onFilterGAs(gaAddresses); }}
             onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
             onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
           >
-            <Filter size={12} />
+            <ListFilter size={12} />
           </button>
           <button
             style={iconBtnStyle}
@@ -332,7 +406,7 @@ const KoRow: React.FC<{
           entries={ko.group_addresses.map(ga => ({
             address: ga.address,
             name: ga.name || '',
-            dpt: ko.dpts?.[0],
+            dpt: ga.dpt ?? ko.dpts?.[0],
             sending: ga.address === sendingGA,
           }))}
           depth={depth + 1}
@@ -340,6 +414,7 @@ const KoRow: React.FC<{
           writeEnabled={writeEnabled}
           onFilterGAs={onFilterGAs}
           onLastSeen={onLastSeen}
+          onVisualizeGAs={onVisualizeGAs}
         />
       )}
     </div>
@@ -355,10 +430,11 @@ const DeviceRow: React.FC<{
   onFilterDevice: (pa: string) => void;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  onVisualizeGAs: (addresses: string[]) => void;
   onDeviceStatus: (device: DeviceNode) => void;
   writeEnabled?: boolean;
   latestTelegram?: Telegram | null;
-}> = ({ device, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled, latestTelegram }) => {
+}> = ({ device, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onVisualizeGAs, onDeviceStatus, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`dev:${device.address}`, false);
   const koCount = device.channels.reduce((s, c) => s + c.kos.length, 0) + device.kos.length;
   const hasChildren = koCount > 0;
@@ -408,6 +484,17 @@ const DeviceRow: React.FC<{
             <ListFilter size={12} />
           </button>
         )}
+        {allGAs.length > 0 && (
+          <button
+            style={iconBtnStyle}
+            title={`Visualize all ${allGAs.length} group address${allGAs.length > 1 ? 'es' : ''} of this device`}
+            onClick={e => { e.stopPropagation(); onVisualizeGAs(allGAs); }}
+            onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+            onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+          >
+            <LineChart size={12} />
+          </button>
+        )}
         <button
           style={iconBtnStyle}
           title="Show last seen values"
@@ -437,15 +524,15 @@ const DeviceRow: React.FC<{
             return (
               <ChannelRow
                 key={ch.id} channel={ch} deviceAddress={device.address} visibleKos={visibleKos} depth={depth + 1}
-                query={query} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} writeEnabled={writeEnabled}
-                latestTelegram={latestTelegram}
+                query={query} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
+                writeEnabled={writeEnabled} latestTelegram={latestTelegram}
               />
             );
           })}
           {sortKos(query ? device.kos.filter(k => koMatches(k, query)) : device.kos).map((ko, i) => (
             <KoRow
               key={`${ko.number}-${i}`} ko={ko} koKey={`${device.address}:${ko.number}-${i}`}
-              depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+              depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
               writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
@@ -463,9 +550,10 @@ const ChannelRow: React.FC<{
   query: string;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  onVisualizeGAs: (addresses: string[]) => void;
   writeEnabled?: boolean;
   latestTelegram?: Telegram | null;
-}> = ({ channel, deviceAddress, visibleKos, depth, query, onFilterGAs, onLastSeen, writeEnabled, latestTelegram }) => {
+}> = ({ channel, deviceAddress, visibleKos, depth, query, onFilterGAs, onLastSeen, onVisualizeGAs, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`ch:${deviceAddress}:${channel.id}`, false);
   const effectiveOpen = open || !!query;
   const allGAs = useMemo(() => channelGAs(channel), [channel]);
@@ -500,7 +588,7 @@ const ChannelRow: React.FC<{
       {effectiveOpen && visibleKos.map((ko, i) => (
         <KoRow
           key={`${ko.number}-${i}`} ko={ko} koKey={`${deviceAddress}:${channel.id}:${ko.number}-${i}`}
-          depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen}
+          depth={depth + 1} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
           writeEnabled={writeEnabled} latestTelegram={latestTelegram}
         />
       ))}
@@ -516,9 +604,10 @@ const FunctionRow: React.FC<{
   query: string;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  onVisualizeGAs: (addresses: string[]) => void;
   writeEnabled?: boolean;
   latestTelegram?: Telegram | null;
-}> = ({ func, depth, query, onFilterGAs, onLastSeen, writeEnabled, latestTelegram }) => {
+}> = ({ func, depth, query, onFilterGAs, onLastSeen, onVisualizeGAs, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`func:${func.id}`, false);
   const effectiveOpen = open || !!query;
   const allGAs = useMemo(() => func.group_addresses.map(g => g.address), [func]);
@@ -536,11 +625,23 @@ const FunctionRow: React.FC<{
         <span style={{ flex: 1, minWidth: 0, fontSize: '0.78rem', fontWeight: 600, color: 'var(--text-main)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
           {func.name || 'Function'}
         </span>
-        {func.type && (
+        {func.type_name && (
+          // ETS function-type name resolved from project master data (e.g. FT-1 -> "Licht schalten") (#307).
           <span style={{
-            fontSize: '0.65rem', color: 'var(--text-dim)', flexShrink: 0,
-            background: 'var(--bg-tag)', padding: '0.1rem 0.3rem', borderRadius: 4, marginRight: '0.3rem'
+            fontSize: '0.72rem', color: 'var(--text-dim)', flexShrink: 0, maxWidth: '30%',
+            overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginRight: '0.4rem',
           }}>
+            {func.type_name}
+          </span>
+        )}
+        {func.type && (
+          <span
+            title={func.type_name || undefined}
+            style={{
+              fontSize: '0.65rem', color: 'var(--text-dim)', flexShrink: 0,
+              background: 'var(--bg-tag)', padding: '0.1rem 0.3rem', borderRadius: 4, marginRight: '0.3rem'
+            }}
+          >
             {func.type}
           </span>
         )}
@@ -549,6 +650,15 @@ const FunctionRow: React.FC<{
         </span>
         {allGAs.length > 0 && (
           <>
+            <button
+              style={iconBtnStyle}
+              title={`Visualize all ${allGAs.length} group address${allGAs.length > 1 ? 'es' : ''} of this function`}
+              onClick={e => { e.stopPropagation(); onVisualizeGAs(allGAs); }}
+              onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+              onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+            >
+              <LineChart size={12} />
+            </button>
             <button
               style={iconBtnStyle}
               title={`Filter all ${allGAs.length} group address${allGAs.length > 1 ? 'es' : ''} of this function`}
@@ -582,6 +692,7 @@ const FunctionRow: React.FC<{
           writeEnabled={writeEnabled}
           onFilterGAs={onFilterGAs}
           onLastSeen={onLastSeen}
+          onVisualizeGAs={onVisualizeGAs}
         />
       )}
     </div>
@@ -598,10 +709,11 @@ const SpaceRow: React.FC<{
   onFilterDevice: (pa: string) => void;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  onVisualizeGAs: (addresses: string[]) => void;
   onDeviceStatus: (device: DeviceNode) => void;
   writeEnabled?: boolean;
   latestTelegram?: Telegram | null;
-}> = ({ space, path, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled, latestTelegram }) => {
+}> = ({ space, path, depth, query, onFilterDevice, onFilterGAs, onLastSeen, onVisualizeGAs, onDeviceStatus, writeEnabled, latestTelegram }) => {
   const [open, toggle] = useExpanded(`space:${path}`, depth < 2);
   if (query && !spaceMatches(space, query)) return null;
   const effectiveOpen = open || !!query;
@@ -633,21 +745,22 @@ const SpaceRow: React.FC<{
           {sortSpaces(space.spaces).map((sub, i) => (
             <SpaceRow
               key={`${sub.name}-${i}`} space={sub} path={`${path}/${sub.type}:${sub.name}#${i}`} depth={depth + 1} query={query}
-              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
+              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
+              onDeviceStatus={onDeviceStatus} writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
           {visibleFunctions.map((func, i) => (
             <FunctionRow
               key={`${func.id}-${i}`} func={func} depth={depth + 1} query={query}
-              onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} writeEnabled={writeEnabled} latestTelegram={latestTelegram}
+              onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
+              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
           {visibleDevices.map(device => (
             <DeviceRow
               key={device.address} device={device} depth={depth + 1} query={query}
-              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
+              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
+              onDeviceStatus={onDeviceStatus} writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
         </div>
@@ -659,7 +772,7 @@ const SpaceRow: React.FC<{
 // ── Main overlay ────────────────────────────────────────────────────────────────
 
 export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
-  onClose, onFilterDevice, onFilterGAs, onLastSeen, onDeviceStatus, writeEnabled, latestTelegram,
+  onClose, onFilterDevice, onFilterGAs, onLastSeen, onVisualizeGAs, onDeviceStatus, writeEnabled, latestTelegram,
   searchQuery: searchQueryProp, onSearchQueryChange,
 }) => {
   const [data, setData] = useState<BuildingData | null>(null);
@@ -748,8 +861,8 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
           {sortSpaces(data.tree).map((space, i) => (
             <SpaceRow
               key={`${space.name}-${i}`} space={space} path={`${space.type}:${space.name}#${i}`} depth={0} query={query}
-              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-              writeEnabled={writeEnabled} latestTelegram={latestTelegram}
+              onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
+              onDeviceStatus={onDeviceStatus} writeEnabled={writeEnabled} latestTelegram={latestTelegram}
             />
           ))}
 
@@ -761,8 +874,8 @@ export const BuildingOverlay: React.FC<BuildingOverlayProps> = ({
               {visibleUnassigned.map(device => (
                 <DeviceRow
                   key={device.address} device={device} depth={1} query={query}
-                  onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onDeviceStatus={onDeviceStatus}
-                  writeEnabled={writeEnabled} latestTelegram={latestTelegram}
+                  onFilterDevice={onFilterDevice} onFilterGAs={onFilterGAs} onLastSeen={onLastSeen} onVisualizeGAs={onVisualizeGAs}
+                  onDeviceStatus={onDeviceStatus} writeEnabled={writeEnabled} latestTelegram={latestTelegram}
                 />
               ))}
             </div>

--- a/frontend/src/components/GaValuesTable.test.tsx
+++ b/frontend/src/components/GaValuesTable.test.tsx
@@ -40,7 +40,7 @@ test('fetches last values for its addresses and leaves never-seen GAs blank', as
     return { ok: true, json: async () => ({ telegrams: [telegram('1/2/3', 'On')] }) } as Response;
   }));
 
-  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />);
 
   await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
   const neverSeenRow = screen.getByText('Kitchen Status').closest('tr')!;
@@ -56,18 +56,18 @@ test('updates a value live from the websocket feed and ignores unrelated GAs', a
   )));
 
   const { rerender } = render(
-    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />
+    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />
   );
   await waitFor(() => expect(screen.getByText('On')).toBeInTheDocument());
   expect(within(screen.getByText('Kitchen Status').closest('tr')!).getAllByRole('cell')[4]).toHaveTextContent('');
 
   rerender(
-    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('1/2/10', 'Off')} onFilterGAs={() => {}} onLastSeen={() => {}} />
+    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('1/2/10', 'Off')} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />
   );
   await waitFor(() => expect(screen.getByText('Off')).toBeInTheDocument());
 
   rerender(
-    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('9/9/9', 'Ignored')} onFilterGAs={() => {}} onLastSeen={() => {}} />
+    <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={telegram('9/9/9', 'Ignored')} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />
   );
   expect(screen.queryByText('Ignored')).not.toBeInTheDocument();
 });
@@ -75,7 +75,7 @@ test('updates a value live from the websocket feed and ignores unrelated GAs', a
 test('sorts by group address ascending, descending, then back to ETS order', async () => {
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
 
-  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />);
   await waitFor(() => expect(screen.getByText('1/2/3')).toBeInTheDocument());
 
   const gaCell = (row: HTMLElement) => within(row).getAllByRole('cell')[0].textContent;
@@ -99,7 +99,7 @@ test('sorts by group address ascending, descending, then back to ETS order', asy
 test('highlights the sending group address', async () => {
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
 
-  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />);
   await waitFor(() => expect(screen.getByText('1/2/3')).toBeInTheDocument());
 
   expect(screen.getByLabelText('sending')).toBeInTheDocument();
@@ -110,7 +110,7 @@ test('highlights the sending group address', async () => {
 test('highlights the hovered row and restores the sending tint on leave', async () => {
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
 
-  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />);
+  render(<GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />);
   await waitFor(() => expect(screen.getByText('1/2/3')).toBeInTheDocument());
 
   const sendingRow = screen.getByTitle('Sending group address');
@@ -126,12 +126,29 @@ test('highlights the hovered row and restores the sending tint on leave', async 
   expect(otherRow.style.background).toBe('transparent');
 });
 
+test('visualizes a single GA row (#307)', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
+  const onVisualizeGAs = vi.fn();
+
+  render(
+    <GaValuesTable
+      entries={ENTRIES} depth={0} latestTelegram={null}
+      onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={onVisualizeGAs}
+    />
+  );
+  await waitFor(() => expect(screen.getByText('1/2/3')).toBeInTheDocument());
+
+  const row = screen.getByText('Kitchen Status').closest('tr')!;
+  fireEvent.click(within(row).getByTitle('Visualize this group address'));
+  expect(onVisualizeGAs).toHaveBeenCalledWith(['1/2/10']);
+});
+
 test('sizes the NAME column from GaNameWidthContext when provided', async () => {
   vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ telegrams: [] }) } as Response)));
 
   render(
     <GaNameWidthContext.Provider value={24}>
-      <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} />
+      <GaValuesTable entries={ENTRIES} depth={0} latestTelegram={null} onFilterGAs={() => {}} onLastSeen={() => {}} onVisualizeGAs={() => {}} />
     </GaNameWidthContext.Provider>
   );
   await waitFor(() => expect(screen.getByText('Kitchen Light')).toBeInTheDocument());

--- a/frontend/src/components/GaValuesTable.tsx
+++ b/frontend/src/components/GaValuesTable.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useMemo, useCallback, useContext } from 'react';
+import React, { useState, useMemo, useContext } from 'react';
 import { format } from 'date-fns';
-import { Filter, Clock, ChevronUp, ChevronDown } from 'lucide-react';
-import { apiUrl } from '../utils/basePath';
+import { Filter, Clock, LineChart, ChevronUp, ChevronDown } from 'lucide-react';
 import { GaNameWidthContext } from '../utils/gaNameWidth';
+import { useLastSeenValues } from '../hooks/useLastSeenValues';
 import { SendToGaPopover } from './SendToGaPopover';
 import type { Telegram } from '../hooks/useWebSocket';
 
@@ -30,6 +30,8 @@ interface GaValuesTableProps {
   writeEnabled?: boolean;
   onFilterGAs: (addresses: string[]) => void;
   onLastSeen: (address: string | string[], mode: 'ga' | 'pa') => void;
+  /** Open the visualization panel plotting this GA (#307). */
+  onVisualizeGAs: (addresses: string[]) => void;
 }
 
 const gaSortValue = (address: string): number => {
@@ -94,44 +96,16 @@ const HeaderCell: React.FC<{
 };
 
 export const GaValuesTable: React.FC<GaValuesTableProps> = ({
-  entries, depth, latestTelegram, writeEnabled, onFilterGAs, onLastSeen,
+  entries, depth, latestTelegram, writeEnabled, onFilterGAs, onLastSeen, onVisualizeGAs,
 }) => {
-  const [valuesByGA, setValuesByGA] = useState<Record<string, Telegram>>({});
   const [sort, setSort] = useState<{ key: SortKey; dir: 'asc' | 'desc' } | null>(null);
   const nameWidthCh = useContext(GaNameWidthContext);
   const nameColumnStyle: React.CSSProperties = nameWidthCh
     ? { width: `${nameWidthCh}ch`, maxWidth: `${nameWidthCh}ch` }
     : { maxWidth: 300 };
 
-  const addresses = useMemo(() => [...new Set(entries.map(e => e.address))], [entries]);
-  const addressSet = useMemo(() => new Set(addresses), [addresses]);
-
-  const fetchValues = useCallback(async () => {
-    if (addresses.length === 0) return;
-    try {
-      const res = await fetch(
-        apiUrl(`/api/telegrams/last?target_address=${encodeURIComponent(addresses.join(','))}`)
-      );
-      const json = await res.json();
-      const map: Record<string, Telegram> = {};
-      for (const t of (json.telegrams ?? []) as Telegram[]) map[t.target_address] = t;
-      setValuesByGA(map);
-    } catch {
-      // network errors are non-fatal; the table just shows blank TIME/VALUE cells
-    }
-  }, [addresses]);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void fetchValues();
-  }, [fetchValues]);
-
-  // Keep values current from the live feed without re-fetching.
-  useEffect(() => {
-    if (!latestTelegram || !addressSet.has(latestTelegram.target_address)) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setValuesByGA(prev => ({ ...prev, [latestTelegram.target_address]: latestTelegram }));
-  }, [latestTelegram, addressSet]);
+  const addresses = useMemo(() => entries.map(e => e.address), [entries]);
+  const valuesByGA = useLastSeenValues(addresses, latestTelegram);
 
   const handleSort = (key: SortKey) =>
     setSort(prev => {
@@ -237,6 +211,15 @@ export const GaValuesTable: React.FC<GaValuesTableProps> = ({
                         buttonStyle={iconBtnStyle}
                       />
                     )}
+                    <button
+                      style={iconBtnStyle}
+                      title="Visualize this group address"
+                      onClick={e => { e.stopPropagation(); onVisualizeGAs([entry.address]); }}
+                      onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                      onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                    >
+                      <LineChart size={11} />
+                    </button>
                     <button
                       style={iconBtnStyle}
                       title="Filter by this group address"

--- a/frontend/src/hooks/useLastSeenValues.ts
+++ b/frontend/src/hooks/useLastSeenValues.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { apiUrl } from '../utils/basePath';
+import type { Telegram } from './useWebSocket';
+
+// Fetches the last-seen telegram for a set of group addresses and keeps it
+// current from the live feed. Shared by GaValuesTable (#269) and the building
+// view's comm-object summary row (#307).
+export const useLastSeenValues = (
+  addresses: string[],
+  latestTelegram?: Telegram | null
+): Record<string, Telegram> => {
+  const [valuesByGA, setValuesByGA] = useState<Record<string, Telegram>>({});
+  // Dedupe while preserving caller order, so the request URL (and thus the fetch
+  // mock/network-log assertions) stays stable across renders with the same set.
+  const addressKey = [...new Set(addresses)].join(',');
+  const uniqueAddresses = useMemo(() => (addressKey ? addressKey.split(',') : []), [addressKey]);
+  const addressSet = useMemo(() => new Set(uniqueAddresses), [uniqueAddresses]);
+
+  const fetchValues = useCallback(async () => {
+    if (uniqueAddresses.length === 0) return;
+    try {
+      const res = await fetch(
+        apiUrl(`/api/telegrams/last?target_address=${encodeURIComponent(uniqueAddresses.join(','))}`)
+      );
+      const json = await res.json();
+      const map: Record<string, Telegram> = {};
+      for (const t of (json.telegrams ?? []) as Telegram[]) map[t.target_address] = t;
+      setValuesByGA(map);
+    } catch {
+      // network errors are non-fatal; callers just see no last-seen values
+    }
+  }, [uniqueAddresses]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchValues();
+  }, [fetchValues]);
+
+  // Keep values current from the live feed without re-fetching.
+  useEffect(() => {
+    if (!latestTelegram || !addressSet.has(latestTelegram.target_address)) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setValuesByGA(prev => ({ ...prev, [latestTelegram.target_address]: latestTelegram }));
+  }, [latestTelegram, addressSet]);
+
+  return valuesByGA;
+};


### PR DESCRIPTION
## Summary
- **FT type name resolution**: `xknxproject` already resolves the ETS function-type name from master data as `Function.usage_text` (since 3.3.0; backend pins 3.10.0) — the backend now passes it through as `type_name` and the frontend renders it next to the function name. No hardcoded FT-N lookup table needed.
- **Visualize action**: added to functions, devices, and individual GA rows in the shared `GaValuesTable` — adds the relevant group address(es) to the visualization selection (union, matching `handleFilterGAs`'s existing merge semantics) and opens the Visualization panel.
- **Per-GA DPT + mismatch detection**: the backend now resolves each comm-object-linked GA's *own* DPT (previously only the comm object's declared DPT was available), and the comm-object header shows a mismatch indicator (`<main>.*`) when a linked GA's DPT main category differs from the comm object's own.
- **Comm-object summary row**: shows the newest telegram (time + value) across a comm object's linked GAs in its header, framed when that telegram was sent on the comm object's own sending GA — extracted the last-seen fetch/live-update logic (previously inline in `GaValuesTable`) into a shared `useLastSeenValues` hook so the header can use it too without duplicating fetches.
- **Icon fix**: the comm object's "filter by connected GAs" action now uses the `ListFilter` icon, matching every other multi-GA filter action in the tree (it previously used the single-target `Filter` icon).
- The GA-table column layout/hover/alignment items from the issue were already covered by #306 (merged), since `GaValuesTable` turned out to already be the shared component.

Closes #307

## Test plan
- [x] `ruff check` — clean (no new issues; pre-existing `tests/test_api.py` I001 unrelated)
- [x] Backend: `pytest` — 205/205 passing (updated + added assertions for per-GA DPT and `type_name`)
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 283/283 passing (new `BuildingOverlay.test.tsx` covering FT name, visualize actions, DPT mismatch, and framing; extended `GaValuesTable.test.tsx`)
- [x] Verified in a running instance (Vite dev server + Playwright, stubbed `/api/building`/`/api/telegrams/last`): FT type name renders, visualize icons work on function/device/GA rows, the DPT-mismatch label and framed newest-value summary render correctly on the comm-object row, and the filter icon uses the multi-GA glyph

🤖 Generated with [Claude Code](https://claude.com/claude-code)
