### PR TITLE
feat: telegram list multi-level sort, always-on delta column, quick info bar (#311)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,7 @@ import {
 } from './utils/uiState';
 import { DeviceStatusOverlay } from './components/DeviceStatusOverlay';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
-import { readSortConfigPref, writeSortConfigPref } from './utils/sortConfig';
+import { readSortConfigPref, writeSortConfigPref, toggleSortLevel, sortTelegrams } from './utils/sortConfig';
 import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor, FolderInput, Send, Sparkles, Clock, List } from 'lucide-react';
 import { getPref, setPref } from './utils/prefs';
 import { getLabel, getFileName } from './utils/labels';
@@ -211,6 +211,7 @@ function App() {
   const [quickPatterns, setQuickPatterns] = useState(initialUiState.quickFilter.patterns);
   const [listFollow, setListFollow] = useState(initialUiState.listFollow);
   const [listAnchorKey, setListAnchorKey] = useState<string | null>(initialUiState.listAnchorKey);
+  const [infoBarOpen, setInfoBarOpen] = useState(initialUiState.infoBarOpen);
   const [zoomRange, setZoomRange] = useState<[number, number] | null>(initialUiState.zoomRange);
   const [statsSearch, setStatsSearch] = useState(initialUiState.statsSearch);
   const [buildingSearch, setBuildingSearch] = useState(initialUiState.buildingSearch);
@@ -472,6 +473,7 @@ function App() {
         },
         listFollow,
         listAnchorKey,
+        infoBarOpen,
         zoomRange,
         statsSearch,
         buildingSearch,
@@ -488,6 +490,7 @@ function App() {
     quickPatterns,
     listFollow,
     listAnchorKey,
+    infoBarOpen,
     zoomRange,
     statsSearch,
     buildingSearch,
@@ -528,14 +531,11 @@ function App() {
   const [markedTelegramKeys, setMarkedTelegramKeys] = useState<string[]>([]);
   const [lastMarkedTelegramKey, setLastMarkedTelegramKey] = useState<string | null>(null);
 
-  // ── Sorting ─────────────────────────────────────────────────────────────────
+  // ── Sorting (#311: multi-level, ctrl/cmd-click adds a level) ─────────────────
   const [sortConfig, setSortConfig] = useState<SortConfig>(readSortConfigPref);
-  const handleSort = (key: SortKey) => {
+  const handleSort = (key: SortKey, opts?: { additive?: boolean }) => {
     setSortConfig(prev => {
-      const next: SortConfig = {
-        key,
-        direction: prev.key === key && prev.direction === 'desc' ? 'asc' : 'desc',
-      };
+      const next = toggleSortLevel(prev, key, !!opts?.additive);
       writeSortConfigPref(next);
       return next;
     });
@@ -585,25 +585,10 @@ function App() {
     setIsFilterOpen(true);
   }, [handleFiltersChange]);
 
-  const sortedLiveTelegrams = useMemo(() => {
-    const items = [...liveTelegrams];
-    items.sort((a, b) => {
-      const aVal = a[sortConfig.key];
-      const bVal = b[sortConfig.key];
-      if (aVal === bVal) return 0;
-      if (aVal == null) return 1;
-      if (bVal == null) return -1;
-      if (sortConfig.key === 'timestamp') {
-        return sortConfig.direction === 'asc'
-          ? new Date(aVal as string).getTime() - new Date(bVal as string).getTime()
-          : new Date(bVal as string).getTime() - new Date(aVal as string).getTime();
-      }
-      return sortConfig.direction === 'asc'
-        ? aVal < bVal ? -1 : 1
-        : aVal < bVal ? 1 : -1;
-    });
-    return items;
-  }, [liveTelegrams, sortConfig]);
+  const sortedLiveTelegrams = useMemo(
+    () => sortTelegrams(liveTelegrams, sortConfig),
+    [liveTelegrams, sortConfig]
+  );
 
   // ── In-memory filtering (live view) ────────────────────────────────────────
   const filteredLiveTelegrams = useMemo(() => {
@@ -1227,6 +1212,8 @@ function App() {
                     onMarkedKeysChange={setMarkedTelegramKeys}
                     lastMarkedKey={lastMarkedTelegramKey}
                     onLastMarkedKeyChange={setLastMarkedTelegramKey}
+                    infoBarOpen={infoBarOpen}
+                    onInfoBarOpenChange={setInfoBarOpen}
                   />
                   </>
                 )}

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { TelegramTable, type SortConfig, type SortKey } from './TelegramTable';
-import { readSortConfigPref, writeSortConfigPref } from '../utils/sortConfig';
+import { readSortConfigPref, writeSortConfigPref, toggleSortLevel, sortTelegrams } from '../utils/sortConfig';
 import type { Telegram } from '../hooks/useWebSocket';
 import { History, Download, AlertTriangle, Trash2, SlidersHorizontal, LineChart, RefreshCw } from 'lucide-react';
 import { HistoryLoader } from './HistoryLoader';
@@ -75,12 +75,9 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
       .catch(err => console.error('Failed to load shared view:', err));
   }, [initialView, loadLimit]);
 
-  const handleSort = (key: SortKey) => {
+  const handleSort = (key: SortKey, opts?: { additive?: boolean }) => {
     setSortConfig(prev => {
-      const next: SortConfig = {
-        key,
-        direction: prev.key === key && prev.direction === 'desc' ? 'asc' : 'desc',
-      };
+      const next = toggleSortLevel(prev, key, !!opts?.additive);
       writeSortConfigPref(next);
       return next;
     });
@@ -104,31 +101,10 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     setIsFilterOpen(false);
   };
 
-  const sortedTelegrams = useMemo(() => {
-    const items = [...telegrams];
-    items.sort((a, b) => {
-      const aVal = a[sortConfig.key];
-      const bVal = b[sortConfig.key];
-      if (aVal === bVal) return 0;
-      if (aVal == null) return 1;
-      if (bVal == null) return -1;
-      if (sortConfig.key === 'timestamp') {
-        const timeA = new Date(aVal as string).getTime();
-        const timeB = new Date(bVal as string).getTime();
-        return sortConfig.direction === 'asc'
-          ? timeA - timeB
-          : timeB - timeA;
-      }
-
-      const valA = (aVal as string | number);
-      const valB = (bVal as string | number);
-
-      return sortConfig.direction === 'asc'
-        ? valA < valB ? -1 : 1
-        : valA < valB ? 1 : -1;
-    });
-    return items;
-  }, [telegrams, sortConfig]);
+  const sortedTelegrams = useMemo(
+    () => sortTelegrams(telegrams, sortConfig),
+    [telegrams, sortConfig]
+  );
 
   const handleLoad = (loaded: Telegram[], meta?: { total_count: number; limit_reached: boolean }, range?: LoadedRange) => {
     setTelegrams(prev => {

--- a/frontend/src/components/TelegramTable.test.tsx
+++ b/frontend/src/components/TelegramTable.test.tsx
@@ -32,7 +32,7 @@ const visibleColumns = {
   target: true, targetName: true, type: true, dpt: true, data: true, value: true,
 };
 
-const sortConfig: SortConfig = { key: 'timestamp', direction: 'desc' };
+const sortConfig: SortConfig = [{ key: 'timestamp', direction: 'desc' }];
 
 /** `count` telegrams sorted newest-first, 1 s apart, ending at `newestOffsetS`. */
 const makeList = (count: number, newestOffsetS: number): Telegram[] => {
@@ -115,7 +115,7 @@ test('clicking a row pauses live-following (#266)', () => {
 });
 
 test('newest-on-bottom: clicking a row stays anchored while the full buffer evicts (#297)', () => {
-  const asc: SortConfig = { key: 'timestamp', direction: 'asc' };
+  const asc: SortConfig = [{ key: 'timestamp', direction: 'asc' }];
   // In asc view the parent hands rows oldest-first, newest at the bottom edge.
   const oldestFirst = (count: number, newestOffsetS: number) => makeList(count, newestOffsetS).slice().reverse();
   const renderAsc = (telegrams: Telegram[]) =>
@@ -166,4 +166,126 @@ test('without a click the table keeps following the live edge', () => {
     />,
   );
   expect(screen.queryByText(/new telegram/)).not.toBeInTheDocument();
+});
+
+test('multi-level sort (#311): plain click replaces, ctrl-click adds a level', () => {
+  const onSort = vi.fn();
+  render(
+    <TelegramTable
+      telegrams={makeList(3, 2)}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={onSort}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+  const sourceHeader = screen.getByText('SOURCE').closest('button')!;
+  fireEvent.click(sourceHeader);
+  expect(onSort).toHaveBeenLastCalledWith('source_address', { additive: false });
+
+  fireEvent.click(sourceHeader, { ctrlKey: true });
+  expect(onSort).toHaveBeenLastCalledWith('source_address', { additive: true });
+
+  fireEvent.click(sourceHeader, { metaKey: true });
+  expect(onSort).toHaveBeenLastCalledWith('source_address', { additive: true });
+});
+
+test('multi-level sort (#311): a numbered badge marks each explicit level beyond the first', () => {
+  const multiSort: SortConfig = [{ key: 'source_address', direction: 'asc' }, { key: 'target_address', direction: 'desc' }];
+  render(
+    <TelegramTable
+      telegrams={makeList(3, 2)}
+      visibleColumns={visibleColumns}
+      sortConfig={multiSort}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+  const sourceHeader = screen.getByText('SOURCE').closest('button')!;
+  const targetHeader = screen.getByText('TARGET').closest('button')!;
+  expect(sourceHeader).toHaveTextContent('1');
+  expect(targetHeader).toHaveTextContent('2');
+});
+
+test('delta column (#311): stays visible when sorted by a non-time column', () => {
+  const bySource: SortConfig = [{ key: 'source_address', direction: 'asc' }];
+  render(
+    <TelegramTable
+      telegrams={makeList(3, 2)}
+      visibleColumns={visibleColumns}
+      sortConfig={bySource}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+  expect(screen.getByText('Δt')).toBeInTheDocument();
+});
+
+test('delta-sort exclusive mode (#311): activates on click, pauses live-follow, and exits on another header click', () => {
+  const onListFollowChange = vi.fn();
+  const { rerender } = render(
+    <TelegramTable
+      telegrams={makeList(6, 5)}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+      listFollow={true}
+      onListFollowChange={onListFollowChange}
+    />,
+  );
+
+  fireEvent.click(screen.getByText('Δt').closest('button')!);
+  expect(onListFollowChange).toHaveBeenCalledWith(false);
+
+  // New telegrams while delta-sort is active don't reach the frozen view.
+  onListFollowChange.mockClear();
+  rerender(
+    <TelegramTable
+      telegrams={makeList(7, 6)}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+      listFollow={false}
+      onListFollowChange={onListFollowChange}
+    />,
+  );
+  expect(screen.queryByText(/new telegram/)).not.toBeInTheDocument();
+
+  // Clicking a real column header exits delta-sort and restores live-follow.
+  fireEvent.click(screen.getByText('SOURCE').closest('button')!);
+  expect(onListFollowChange).toHaveBeenLastCalledWith(true);
+});
+
+test('quick info bar (#311): toggled via the header button and summarizes the visible rows', () => {
+  render(
+    <TelegramTable
+      telegrams={makeList(4, 3)}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+
+  expect(screen.queryByText(/4 telegrams/)).not.toBeInTheDocument();
+  fireEvent.click(screen.getByTitle('Show info bar'));
+  expect(screen.getByText(/4 telegrams/)).toBeInTheDocument();
+  expect(screen.getByText(/Oldest:/)).toBeInTheDocument();
+  expect(screen.getByText(/Newest:/)).toBeInTheDocument();
 });

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -2,24 +2,21 @@ import React, { useMemo, useRef, useEffect, useLayoutEffect, useState, useCallba
 import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
-import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock } from 'lucide-react';
+import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock, Info } from 'lucide-react';
 import { dptKey, type ActiveFilters } from '../types/filters';
 import { SendToGaPopover } from './SendToGaPopover';
 import { GotoTimeControl } from './GotoTimeControl';
 import { getPref, setPref } from '../utils/prefs';
+import type { SortKey, SortLevel, SortConfig } from '../utils/sortConfig';
 
-export type SortKey = 'timestamp' | 'source_address' | 'target_address' | 'simplified_type' | 'dpt_name' | 'value_numeric';
-
-export interface SortConfig {
-  key: SortKey;
-  direction: 'asc' | 'desc';
-}
+export type { SortKey, SortLevel, SortConfig };
 
 interface TelegramTableProps {
   telegrams: Telegram[];
   visibleColumns: { [key: string]: boolean };
   sortConfig: SortConfig;
-  onSort: (key: SortKey) => void;
+  /** `additive` (ctrl/cmd-click) adds/toggles a sort level instead of replacing the whole config (#311). */
+  onSort: (key: SortKey, opts?: { additive?: boolean }) => void;
   activeFilters: ActiveFilters;
   onQuickFilter: (key: 'sources' | 'targets' | 'types' | 'dpts', value: string | number) => void;
   onQuickVisualize: (targetAddress: string) => void;
@@ -47,6 +44,10 @@ interface TelegramTableProps {
   onMarkedKeysChange?: (keys: string[]) => void;
   lastMarkedKey?: string | null;
   onLastMarkedKeyChange?: (key: string | null) => void;
+
+  // Lifted Quick Info Bar open state (#311, #341)
+  infoBarOpen?: boolean;
+  onInfoBarOpenChange?: (open: boolean) => void;
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
@@ -98,7 +99,14 @@ const getDPTLabel = (dpt_main: number | null) => {
   return 'Unknown DPT';
 };
 
-type TelegramRow = Telegram & { deltaStr: string | null };
+type TelegramRow = Telegram & { deltaStr: string | null; deltaMs: number | null };
+
+const formatDeltaMs = (diffMs: number): string => {
+  const mm = String(Math.floor(diffMs / 60000)).padStart(2, '0');
+  const ss = String(Math.floor((diffMs % 60000) / 1000)).padStart(2, '0');
+  const ms = String(diffMs % 1000).padStart(3, '0');
+  return `+ ${mm}:${ss}.${ms}`;
+};
 
 const cellPadding = '0.75rem 1rem'; // Unified padding for all cells
 
@@ -140,7 +148,8 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend,
   quickFilterOpen, onQuickFilterOpenChange, quickFilterEnabled, onQuickFilterEnabledChange, quickPatterns, onQuickPatternsChange,
   listFollow, onListFollowChange, listAnchorKey, onListAnchorKeyChange,
-  markedKeys, onMarkedKeysChange, lastMarkedKey, onLastMarkedKeyChange
+  markedKeys, onMarkedKeysChange, lastMarkedKey, onLastMarkedKeyChange,
+  infoBarOpen, onInfoBarOpenChange,
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -231,6 +240,15 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     setQuickEnabled(nextOpen);
   };
 
+  // ── Quick info bar (#311): collapsible summary row above the header. ──────
+  const [internalInfoBarOpen, setInternalInfoBarOpen] = useState(false);
+  const infoOpen = infoBarOpen ?? internalInfoBarOpen;
+  const toggleInfoOpen = useCallback(() => {
+    const next = !infoOpen;
+    setInternalInfoBarOpen(next);
+    onInfoBarOpenChange?.(next);
+  }, [infoOpen, onInfoBarOpenChange]);
+
   // ── Row marks (#310) ─────────────────────────────────────────────────────
   // Controlled when App lifts them (so marks survive navigation), otherwise a
   // local fallback. `lastMarkedKey` may legitimately be null, so distinguish
@@ -266,22 +284,110 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     return telegrams.filter(t => matchers.every(([id, m]) => m(quickFilterHaystack(id as ColId, t))));
   }, [telegrams, quickOpen, quickEnabled, currentPatterns]);
 
-  // Compute time deltas between consecutive rows (by visual order)
-  const telegramRows = useMemo<TelegramRow[]>(() => {
+  // Time deltas between consecutive rows, by visual (sorted) order — always
+  // computed regardless of sort column, respecting whatever hierarchy is
+  // active (#311).
+  const naturalTelegramRows = useMemo<TelegramRow[]>(() => {
     return quickFiltered.map((t, idx) => {
       let deltaStr: string | null = null;
+      let deltaMs: number | null = null;
       if (idx > 0) {
         const curr = new Date(t.timestamp).getTime();
         const prev = new Date(quickFiltered[idx - 1].timestamp).getTime();
-        const diffMs = Math.abs(curr - prev);
-        const mm = String(Math.floor(diffMs / 60000)).padStart(2, '0');
-        const ss = String(Math.floor((diffMs % 60000) / 1000)).padStart(2, '0');
-        const ms = String(diffMs % 1000).padStart(3, '0');
-        deltaStr = `+ ${mm}:${ss}.${ms}`;
+        deltaMs = Math.abs(curr - prev);
+        deltaStr = formatDeltaMs(deltaMs);
       }
-      return { ...t, deltaStr };
+      return { ...t, deltaStr, deltaMs };
     });
   }, [quickFiltered]);
+
+  // ── Delta-sort exclusive mode (#311) ────────────────────────────────────────
+  // Sorting by the Δt column is a self-referential operation (deltas are
+  // derived from row order), so it freezes a snapshot instead of participating
+  // in the normal sortConfig: buffer/live-follow pause, deltas stop
+  // recalculating, and only the frozen set's order changes on repeat clicks.
+  // Any other column header exits the mode and restores the prior live state.
+  const [deltaSortActive, setDeltaSortActive] = useState(false);
+  const [deltaSortDirection, setDeltaSortDirection] = useState<'asc' | 'desc'>('desc');
+  const [deltaFrozenRows, setDeltaFrozenRows] = useState<TelegramRow[] | null>(null);
+  const preDeltaSortFollowRef = useRef<boolean | null>(null);
+
+  const sortByDelta = useCallback((rows: TelegramRow[], direction: 'asc' | 'desc') =>
+    [...rows].sort((a, b) => {
+      if (a.deltaMs == null && b.deltaMs == null) return 0;
+      if (a.deltaMs == null) return 1;
+      if (b.deltaMs == null) return -1;
+      return direction === 'desc' ? b.deltaMs - a.deltaMs : a.deltaMs - b.deltaMs;
+    }), []);
+
+  const handleDeltaHeaderClick = useCallback(() => {
+    if (!deltaSortActive) {
+      setDeltaFrozenRows(sortByDelta(naturalTelegramRows, 'desc'));
+      setDeltaSortDirection('desc');
+      setDeltaSortActive(true);
+      if (onListFollowChange) {
+        preDeltaSortFollowRef.current = listFollow ?? true;
+        onListFollowChange(false);
+      }
+    } else {
+      const nextDir = deltaSortDirection === 'desc' ? 'asc' : 'desc';
+      setDeltaSortDirection(nextDir);
+      setDeltaFrozenRows(prev => (prev ? sortByDelta(prev, nextDir) : prev));
+    }
+  }, [deltaSortActive, deltaSortDirection, naturalTelegramRows, sortByDelta, listFollow, onListFollowChange]);
+
+  const exitDeltaSort = useCallback(() => {
+    if (!deltaSortActive) return;
+    setDeltaSortActive(false);
+    setDeltaFrozenRows(null);
+    if (onListFollowChange && preDeltaSortFollowRef.current !== null) {
+      onListFollowChange(preDeltaSortFollowRef.current);
+    }
+    preDeltaSortFollowRef.current = null;
+  }, [deltaSortActive, onListFollowChange]);
+
+  // A real column header click always exits delta-sort before applying its own sort.
+  const handleColumnSort = useCallback((key: SortKey, opts?: { additive?: boolean }) => {
+    exitDeltaSort();
+    onSort(key, opts);
+  }, [exitDeltaSort, onSort]);
+
+  const telegramRows = deltaSortActive && deltaFrozenRows ? deltaFrozenRows : naturalTelegramRows;
+
+  // ── Quick info bar metrics (#311) ───────────────────────────────────────────
+  // Summarizes the currently visible (sorted + filtered) rows; oldest/newest
+  // and min/max Δt jump to their row via gotoIndex regardless of sort order.
+  const infoMetrics = useMemo(() => {
+    if (telegramRows.length === 0) return null;
+    let oldestIdx = 0, newestIdx = 0;
+    let minDeltaIdx = -1, maxDeltaIdx = -1;
+    const sources = new Set<string>();
+    const targets = new Set<string>();
+    const dpts = new Set<string>();
+    const typeCounts = new Map<string, number>();
+    telegramRows.forEach((t, i) => {
+      if (new Date(t.timestamp) < new Date(telegramRows[oldestIdx].timestamp)) oldestIdx = i;
+      if (new Date(t.timestamp) > new Date(telegramRows[newestIdx].timestamp)) newestIdx = i;
+      if (t.deltaMs != null) {
+        if (minDeltaIdx === -1 || t.deltaMs < telegramRows[minDeltaIdx].deltaMs!) minDeltaIdx = i;
+        if (maxDeltaIdx === -1 || t.deltaMs > telegramRows[maxDeltaIdx].deltaMs!) maxDeltaIdx = i;
+      }
+      sources.add(t.source_address);
+      targets.add(t.target_address);
+      dpts.add(t.dpt_name ?? (t.dpt_main != null ? `DPT ${t.dpt_main}` : 'unknown'));
+      const type = t.simplified_type || t.telegram_type;
+      typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1);
+    });
+    return {
+      count: telegramRows.length,
+      oldestIdx, newestIdx,
+      minDeltaIdx, maxDeltaIdx,
+      sourceCount: sources.size,
+      targetCount: targets.size,
+      dptCount: dpts.size,
+      typeCounts: [...typeCounts.entries()].sort((a, b) => b[1] - a[1]),
+    };
+  }, [telegramRows]);
 
   const virtualizer = useVirtualizer({
     count: telegramRows.length,
@@ -306,8 +412,11 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   // concrete anchor row by key and, after each update, correct scrollTop by the
   // real pixel delta of that row's position — re-run on the next frame so the
   // async re-measure of prepended rows is absorbed too.
-  const isTimeSort = sortConfig.key === 'timestamp';
-  const liveEdge = sortConfig.direction === 'desc' ? 'top' : 'bottom';
+  // Only the *primary* level's key matters for the live edge — a secondary
+  // TIME tiebreaker doesn't make the list time-ordered top-to-bottom (#311).
+  const primarySort = sortConfig[0];
+  const isTimeSort = primarySort?.key === 'timestamp' && !deltaSortActive;
+  const liveEdge = primarySort?.direction === 'asc' ? 'bottom' : 'top';
   const atEdgeRef = useRef(listFollow ?? true);
   const [newSinceAnchor, setNewSinceAnchor] = useState(0);
   // The row pinned to the top of the viewport while anchored, and its offset
@@ -454,10 +563,28 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     scrollToEdge();
   };
 
-  // "Quick goto time" (#282): scroll to the telegram nearest a given time and
-  // stop live-following, so the viewed rows stay put while new ones accumulate.
-  // The jump-to-live pill is the way back. Only meaningful for the timestamp
-  // sort, where rows are ordered by time.
+  // Scrolls to a specific row by index and stops live-following, so the
+  // viewed rows stay put while new ones accumulate. Used by "quick goto time"
+  // and the quick info bar's click-to-jump metrics (#282, #311).
+  const gotoIndex = (idx: number) => {
+    if (idx < 0 || idx >= telegramRows.length) return;
+    atEdgeRef.current = false;
+    onListFollowChange?.(false);
+    setNewSinceAnchor(0);
+    markProgrammatic();
+    virtualizer.scrollToIndex(idx, { align: 'center' });
+    // Pin the row we land on once the virtualizer has settled the scroll (rows
+    // are dynamically measured, so give it two frames before capturing).
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      captureAnchor();
+      atEdgeRef.current = false;
+      onListFollowChange?.(false);
+    }));
+  };
+
+  // "Quick goto time" (#282): jump to the telegram nearest a given time. Only
+  // meaningful for the timestamp sort, where rows are ordered by time — the
+  // info bar's jumps use gotoIndex directly since they already know the index.
   const gotoTime = (targetMs: number) => {
     const rows = telegramRows;
     if (!isTimeSort || rows.length === 0) return;
@@ -467,18 +594,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
       const diff = Math.abs(new Date(rows[i].timestamp).getTime() - targetMs);
       if (diff < bestDiff) { bestDiff = diff; bestIdx = i; }
     }
-    atEdgeRef.current = false;
-    onListFollowChange?.(false);
-    setNewSinceAnchor(0);
-    markProgrammatic();
-    virtualizer.scrollToIndex(bestIdx, { align: 'center' });
-    // Pin the row we land on once the virtualizer has settled the scroll (rows
-    // are dynamically measured, so give it two frames before capturing).
-    requestAnimationFrame(() => requestAnimationFrame(() => {
-      captureAnchor();
-      atEdgeRef.current = false;
-      onListFollowChange?.(false);
-    }));
+    gotoIndex(bestIdx);
   };
 
   // Newest telegram time, used to seed the goto-time input.
@@ -601,13 +717,11 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   }, [totalSize]);
 
   // Visible columns in order, and the matching CSS grid template.
-  // The delta column is only meaningful when sorting by time, so hide it otherwise.
+  // The delta column is always shown when enabled, regardless of sort (#311) —
+  // it's computed from the visible row order under any sort hierarchy.
   const visibleCols = useMemo(
-    () => COLUMNS.filter(c => {
-      if (c.id === 'delta') return visibleColumns.delta && sortConfig.key === 'timestamp';
-      return !c.visibleKey || visibleColumns[c.visibleKey];
-    }),
-    [visibleColumns, sortConfig.key],
+    () => COLUMNS.filter(c => !c.visibleKey || visibleColumns[c.visibleKey]),
+    [visibleColumns],
   );
 
   const gridTemplate = useMemo(
@@ -621,8 +735,29 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     [visibleCols, widthFor],
   );
 
-  const renderSortArrow = (key: SortKey) =>
-    sortConfig.key === key && (sortConfig.direction === 'asc' ? <ChevronUp size={14} /> : <ChevronDown size={14} />);
+  // Multi-level sort indicator (#311): the chevron shows this column's own
+  // direction; a small numbered badge additionally marks its position in the
+  // hierarchy once more than one level is active (ctrl/cmd-click adds levels).
+  const renderSortArrow = (key: SortKey) => {
+    const idx = sortConfig.findIndex(l => l.key === key);
+    if (idx === -1) return null;
+    const icon = sortConfig[idx].direction === 'asc' ? <ChevronUp size={14} /> : <ChevronDown size={14} />;
+    if (sortConfig.length <= 1) return icon;
+    return (
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.15rem' }}>
+        {icon}
+        <span
+          title={`Sort level ${idx + 1} of ${sortConfig.length}`}
+          style={{
+            fontSize: '0.6rem', fontWeight: 700, minWidth: '1rem', textAlign: 'center',
+            padding: '0 0.2rem', borderRadius: '3px', background: 'var(--bg-tag)', color: 'var(--text-dim)',
+          }}
+        >
+          {idx + 1}
+        </span>
+      </span>
+    );
+  };
 
   // ── Per-cell body content (keyed switch keeps body aligned with header order) ──
   const renderCell = (id: ColId, t: TelegramRow): React.ReactNode => {
@@ -792,8 +927,66 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     }
   };
 
+  const infoChipStyle: React.CSSProperties = {
+    display: 'inline-flex', alignItems: 'center', gap: '0.3rem',
+    background: 'var(--bg-tag)', border: '1px solid var(--border-subtle)', borderRadius: '4px',
+    padding: '0.15rem 0.45rem', fontSize: '0.68rem', color: 'var(--text-dim)',
+  };
+  const infoChipBtnStyle: React.CSSProperties = {
+    ...infoChipStyle, cursor: 'pointer', background: 'transparent',
+  };
+
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      {/* Quick info bar (#311): collapsible summary directly above the header. */}
+      {infoOpen && infoMetrics && (
+        <div style={{
+          display: 'flex', flexDirection: 'column', gap: '0.3rem',
+          padding: '0.4rem 0.75rem', borderBottom: '1px solid var(--border-color)',
+          background: 'var(--bg-subtle)', flexShrink: 0,
+        }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', alignItems: 'center' }}>
+            <button
+              style={infoChipBtnStyle} title="Jump to the oldest telegram in the current view"
+              onClick={() => gotoIndex(infoMetrics.oldestIdx)}
+            >
+              Oldest: {format(new Date(telegramRows[infoMetrics.oldestIdx].timestamp), 'yyyy-MM-dd HH:mm:ss.SS')}
+            </button>
+            <button
+              style={infoChipBtnStyle} title="Jump to the newest telegram in the current view"
+              onClick={() => gotoIndex(infoMetrics.newestIdx)}
+            >
+              Newest: {format(new Date(telegramRows[infoMetrics.newestIdx].timestamp), 'yyyy-MM-dd HH:mm:ss.SS')}
+            </button>
+            {infoMetrics.minDeltaIdx !== -1 && (
+              <button
+                style={infoChipBtnStyle} title="Jump to the smallest time gap in the current view"
+                onClick={() => gotoIndex(infoMetrics.minDeltaIdx)}
+              >
+                Min Δt: {telegramRows[infoMetrics.minDeltaIdx].deltaStr}
+              </button>
+            )}
+            {infoMetrics.maxDeltaIdx !== -1 && (
+              <button
+                style={infoChipBtnStyle} title="Jump to the largest time gap in the current view"
+                onClick={() => gotoIndex(infoMetrics.maxDeltaIdx)}
+              >
+                Max Δt: {telegramRows[infoMetrics.maxDeltaIdx].deltaStr}
+              </button>
+            )}
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', alignItems: 'center' }}>
+            <span style={infoChipStyle}>{infoMetrics.count} telegram{infoMetrics.count !== 1 ? 's' : ''}</span>
+            <span style={infoChipStyle}>{infoMetrics.sourceCount} source{infoMetrics.sourceCount !== 1 ? 's' : ''}</span>
+            <span style={infoChipStyle}>{infoMetrics.targetCount} target{infoMetrics.targetCount !== 1 ? 's' : ''}</span>
+            <span style={infoChipStyle}>{infoMetrics.dptCount} DPT{infoMetrics.dptCount !== 1 ? 's' : ''}</span>
+            {infoMetrics.typeCounts.map(([type, n]) => (
+              <span key={type} style={infoChipStyle}>{type}: {n}</span>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div
         style={{
@@ -824,11 +1017,34 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                 <ListFilter size={13} />
               </button>
             )}
+            {c.id === 'time' && (
+              <button
+                className={`quick-filter-bar-toggle ${infoOpen ? 'open' : ''}`}
+                onClick={toggleInfoOpen}
+                title={infoOpen ? 'Hide info bar' : 'Show info bar'}
+              >
+                <Info size={13} />
+              </button>
+            )}
             {c.id === 'time' && isTimeSort && (
               <GotoTimeControl seedMs={newestMs} onGoto={gotoTime} />
             )}
-            {c.sortKey ? (
-              <button className="sort-header" onClick={() => onSort(c.sortKey!)}>
+            {c.id === 'delta' ? (
+              <button
+                className="sort-header"
+                onClick={handleDeltaHeaderClick}
+                title={deltaSortActive
+                  ? 'Sorted by time delta — click to flip direction; click any other column to return to live order'
+                  : 'Sort by time delta (exclusive — pauses live scrolling and freezes the current order)'}
+              >
+                {c.label} {deltaSortActive && (deltaSortDirection === 'asc' ? <ChevronUp size={14} /> : <ChevronDown size={14} />)}
+              </button>
+            ) : c.sortKey ? (
+              <button
+                className="sort-header"
+                onClick={(e) => handleColumnSort(c.sortKey!, { additive: e.ctrlKey || e.metaKey })}
+                title="Click to sort · ctrl/cmd-click to add as a further sort level (TIME is always the deepest tiebreaker)"
+              >
                 {c.label} {renderSortArrow(c.sortKey)}
               </button>
             ) : (

--- a/frontend/src/components/TelegramTableMarks.test.tsx
+++ b/frontend/src/components/TelegramTableMarks.test.tsx
@@ -31,7 +31,7 @@ const visibleColumns = {
   target: true, targetName: true, type: true, dpt: true, data: true, value: true,
 };
 
-const sortConfig: SortConfig = { key: 'timestamp', direction: 'desc' };
+const sortConfig: SortConfig = [{ key: 'timestamp', direction: 'desc' }];
 
 // Five rows so range + additive semantics are unambiguous. Desc timestamp → the
 // DOM row order matches this array order (newest first).

--- a/frontend/src/components/TelegramTableQuickFilter.test.tsx
+++ b/frontend/src/components/TelegramTableQuickFilter.test.tsx
@@ -31,7 +31,7 @@ const visibleColumns = {
   target: true, targetName: true, type: true, dpt: true, data: true, value: true,
 };
 
-const sortConfig: SortConfig = { key: 'timestamp', direction: 'desc' };
+const sortConfig: SortConfig = [{ key: 'timestamp', direction: 'desc' }];
 
 const TELEGRAMS: Telegram[] = [
   makeTelegram({ timestamp: '2024-01-01T10:00:03.000Z', target_address: '1/2/3', target_name: 'Licht Küche', raw_hex: '0x03' }),

--- a/frontend/src/components/qolStatePersistence.test.tsx
+++ b/frontend/src/components/qolStatePersistence.test.tsx
@@ -81,7 +81,7 @@ test('TelegramTable quick-filter and follow/anchor survive unmount/remount', () 
           <TelegramTable
             telegrams={telegrams}
             visibleColumns={visibleColumns}
-            sortConfig={{ key: 'timestamp', direction: 'desc' }}
+            sortConfig={[{ key: 'timestamp', direction: 'desc' }]}
             onSort={vi.fn()}
             activeFilters={DEFAULT_FILTERS}
             onQuickFilter={vi.fn()}

--- a/frontend/src/utils/sortConfig.test.ts
+++ b/frontend/src/utils/sortConfig.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  readSortConfigPref, writeSortConfigPref, toggleSortLevel, sortTelegrams, effectiveSortLevels,
+  type SortConfig,
+} from './sortConfig';
+import type { Telegram } from '../hooks/useWebSocket';
+
+function telegram(overrides: Partial<Telegram>): Telegram {
+  return {
+    timestamp: '2026-01-01T00:00:00.000Z',
+    source_address: '1.1.1',
+    source_name: null,
+    target_address: '1/1/1',
+    target_name: null,
+    telegram_type: 'GroupValueWrite',
+    simplified_type: 'Write',
+    direction: 'Incoming',
+    dpt: '1.001',
+    dpt_main: 1,
+    dpt_sub: 1,
+    dpt_name: '1.001 - Switch',
+    value_numeric: 1,
+    value_json: null,
+    value_formatted: 'On',
+    unit: null,
+    raw_data: '01',
+    raw_hex: '01',
+    ...overrides,
+  } as Telegram;
+}
+
+describe('toggleSortLevel', () => {
+  it('plain click replaces the whole config with a single desc level', () => {
+    const config: SortConfig = [{ key: 'source_address', direction: 'asc' }];
+    expect(toggleSortLevel(config, 'target_address', false)).toEqual([{ key: 'target_address', direction: 'desc' }]);
+  });
+
+  it('plain click on the sole existing level toggles its direction', () => {
+    const config: SortConfig = [{ key: 'timestamp', direction: 'desc' }];
+    expect(toggleSortLevel(config, 'timestamp', false)).toEqual([{ key: 'timestamp', direction: 'asc' }]);
+  });
+
+  it('plain click when multiple levels are active collapses to a single new level', () => {
+    const config: SortConfig = [{ key: 'source_address', direction: 'asc' }, { key: 'target_address', direction: 'desc' }];
+    expect(toggleSortLevel(config, 'target_address', false)).toEqual([{ key: 'target_address', direction: 'desc' }]);
+  });
+
+  it('additive click appends a new deepest level', () => {
+    const config: SortConfig = [{ key: 'source_address', direction: 'asc' }];
+    expect(toggleSortLevel(config, 'target_address', true)).toEqual([
+      { key: 'source_address', direction: 'asc' },
+      { key: 'target_address', direction: 'desc' },
+    ]);
+  });
+
+  it('additive click on an already-explicit level toggles its direction in place', () => {
+    const config: SortConfig = [
+      { key: 'source_address', direction: 'asc' },
+      { key: 'target_address', direction: 'desc' },
+    ];
+    expect(toggleSortLevel(config, 'target_address', true)).toEqual([
+      { key: 'source_address', direction: 'asc' },
+      { key: 'target_address', direction: 'asc' },
+    ]);
+  });
+});
+
+describe('effectiveSortLevels', () => {
+  it('appends an implicit trailing TIME tiebreaker when TIME is not explicit', () => {
+    const config: SortConfig = [{ key: 'source_address', direction: 'asc' }];
+    expect(effectiveSortLevels(config)).toEqual([
+      { key: 'source_address', direction: 'asc' },
+      { key: 'timestamp', direction: 'desc' },
+    ]);
+  });
+
+  it('does not duplicate TIME when already explicit', () => {
+    const config: SortConfig = [{ key: 'source_address', direction: 'asc' }, { key: 'timestamp', direction: 'asc' }];
+    expect(effectiveSortLevels(config)).toEqual(config);
+  });
+});
+
+describe('sortTelegrams', () => {
+  it('sorts by a single level (timestamp desc, the default)', () => {
+    const items = [
+      telegram({ timestamp: '2026-01-01T00:00:01.000Z', target_address: '1/1/1' }),
+      telegram({ timestamp: '2026-01-01T00:00:03.000Z', target_address: '1/1/2' }),
+      telegram({ timestamp: '2026-01-01T00:00:02.000Z', target_address: '1/1/3' }),
+    ];
+    const sorted = sortTelegrams(items, [{ key: 'timestamp', direction: 'desc' }]);
+    expect(sorted.map(t => t.target_address)).toEqual(['1/1/2', '1/1/3', '1/1/1']);
+  });
+
+  it('applies multiple levels in order, with TIME as the implicit deepest tiebreaker', () => {
+    const items = [
+      telegram({ source_address: '1.1.2', timestamp: '2026-01-01T00:00:02.000Z' }),
+      telegram({ source_address: '1.1.1', timestamp: '2026-01-01T00:00:03.000Z' }),
+      telegram({ source_address: '1.1.1', timestamp: '2026-01-01T00:00:01.000Z' }),
+    ];
+    // Primary: source ascending. Secondary (implicit): time descending (default).
+    const sorted = sortTelegrams(items, [{ key: 'source_address', direction: 'asc' }]);
+    expect(sorted.map(t => `${t.source_address}@${t.timestamp}`)).toEqual([
+      '1.1.1@2026-01-01T00:00:03.000Z',
+      '1.1.1@2026-01-01T00:00:01.000Z',
+      '1.1.2@2026-01-01T00:00:02.000Z',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const items = [telegram({ target_address: '1/1/2' }), telegram({ target_address: '1/1/1' })];
+    const original = [...items];
+    sortTelegrams(items, [{ key: 'target_address', direction: 'asc' }]);
+    expect(items).toEqual(original);
+  });
+});
+
+describe('readSortConfigPref / writeSortConfigPref', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('defaults to a single timestamp-desc level when nothing is stored', () => {
+    expect(readSortConfigPref()).toEqual([{ key: 'timestamp', direction: 'desc' }]);
+  });
+
+  it('round-trips a multi-level config', () => {
+    const config: SortConfig = [{ key: 'source_address', direction: 'asc' }, { key: 'timestamp', direction: 'desc' }];
+    writeSortConfigPref(config);
+    expect(readSortConfigPref()).toEqual(config);
+  });
+
+  it('transparently upgrades the pre-#311 single-level object shape', () => {
+    localStorage.setItem('spectrum-knx.sortConfig', JSON.stringify({ key: 'target_address', direction: 'asc' }));
+    expect(readSortConfigPref()).toEqual([{ key: 'target_address', direction: 'asc' }]);
+  });
+
+  it('falls back to the default on malformed stored data', () => {
+    localStorage.setItem('spectrum-knx.sortConfig', 'not json');
+    expect(readSortConfigPref()).toEqual([{ key: 'timestamp', direction: 'desc' }]);
+  });
+});

--- a/frontend/src/utils/sortConfig.ts
+++ b/frontend/src/utils/sortConfig.ts
@@ -1,27 +1,112 @@
 import { getPref, setPref } from './prefs';
-import type { SortConfig, SortKey } from '../components/TelegramTable';
+import type { Telegram } from '../hooks/useWebSocket';
+
+export type SortKey = 'timestamp' | 'source_address' | 'target_address' | 'simplified_type' | 'dpt_name' | 'value_numeric';
+
+export interface SortLevel {
+  key: SortKey;
+  direction: 'asc' | 'desc';
+}
+
+/**
+ * Ordered, explicit sort levels (primary first). TIME is always the implicit
+ * deepest tiebreaker even when not listed here explicitly (#311) — see
+ * `sortTelegrams`.
+ */
+export type SortConfig = SortLevel[];
 
 const SORT_PREF = 'sortConfig';
 const SORT_KEYS: SortKey[] = ['timestamp', 'source_address', 'target_address', 'simplified_type', 'dpt_name', 'value_numeric'];
-const DEFAULT_SORT: SortConfig = { key: 'timestamp', direction: 'desc' };
+const DEFAULT_SORT: SortConfig = [{ key: 'timestamp', direction: 'desc' }];
 
-/** Reads the persisted sort config (key + direction), falling back to the default. */
+const isValidLevel = (l: unknown): l is SortLevel =>
+  !!l && typeof l === 'object' &&
+  SORT_KEYS.includes((l as SortLevel).key) &&
+  ((l as SortLevel).direction === 'asc' || (l as SortLevel).direction === 'desc');
+
+/**
+ * Reads the persisted sort config, falling back to the default. Transparently
+ * upgrades the pre-#311 single-level object shape (`{key, direction}`) to the
+ * one-element array shape.
+ */
 export function readSortConfigPref(): SortConfig {
   try {
     const raw = getPref(SORT_PREF);
     if (raw) {
-      const p = JSON.parse(raw) as Partial<SortConfig>;
-      if (p.key && SORT_KEYS.includes(p.key) && (p.direction === 'asc' || p.direction === 'desc')) {
-        return { key: p.key, direction: p.direction };
+      const parsed: unknown = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        const levels = parsed.filter(isValidLevel);
+        if (levels.length > 0) return levels;
+      } else if (isValidLevel(parsed)) {
+        return [parsed];
       }
     }
   } catch {
     // Ignore malformed stored value
   }
-  return { ...DEFAULT_SORT };
+  return [...DEFAULT_SORT];
 }
 
 /** Persists the sort config so it survives reloads and is shared across views. */
 export function writeSortConfigPref(config: SortConfig): void {
   setPref(SORT_PREF, JSON.stringify(config));
+}
+
+/**
+ * Applies a column-header click to the sort config (#311).
+ * - Plain click: replace with a single-level sort by `key`, toggling
+ *   direction if it was already the sole level (existing single-sort UX).
+ * - Ctrl/Cmd-click (`additive`): TIME is always the implicit deepest level
+ *   (see `sortTelegrams`), so a plain additive click just builds up further
+ *   explicit levels. Toggles `key`'s direction in place if it's already an
+ *   explicit level, otherwise appends it as a new deepest level.
+ */
+export function toggleSortLevel(config: SortConfig, key: SortKey, additive: boolean): SortConfig {
+  const idx = config.findIndex(l => l.key === key);
+  if (!additive) {
+    if (config.length === 1 && config[0].key === key) {
+      return [{ key, direction: config[0].direction === 'desc' ? 'asc' : 'desc' }];
+    }
+    return [{ key, direction: 'desc' }];
+  }
+  if (idx >= 0) {
+    const next = [...config];
+    next[idx] = { key, direction: next[idx].direction === 'desc' ? 'asc' : 'desc' };
+    return next;
+  }
+  return [...config, { key, direction: 'desc' }];
+}
+
+/**
+ * Effective comparator levels: the explicit config plus an implicit trailing
+ * TIME tiebreaker, unless TIME is already one of the explicit levels (#311).
+ */
+export const effectiveSortLevels = (config: SortConfig): SortLevel[] =>
+  config.some(l => l.key === 'timestamp') ? config : [...config, { key: 'timestamp', direction: 'desc' }];
+
+const compareValues = (key: SortKey, a: Telegram, b: Telegram): number => {
+  const aVal = a[key];
+  const bVal = b[key];
+  if (aVal === bVal) return 0;
+  if (aVal == null) return 1;
+  if (bVal == null) return -1;
+  if (key === 'timestamp') return new Date(aVal as string).getTime() - new Date(bVal as string).getTime();
+  return aVal < bVal ? -1 : 1;
+};
+
+/**
+ * Sorts telegrams by a (possibly multi-level) config. Shared by the live
+ * Group Monitor and History Search views so their comparators can't drift.
+ */
+export function sortTelegrams(items: Telegram[], config: SortConfig): Telegram[] {
+  const levels = effectiveSortLevels(config);
+  const copy = [...items];
+  copy.sort((a, b) => {
+    for (const { key, direction } of levels) {
+      const cmp = compareValues(key, a, b);
+      if (cmp !== 0) return direction === 'asc' ? cmp : -cmp;
+    }
+    return 0;
+  });
+  return copy;
 }

--- a/frontend/src/utils/uiState.test.ts
+++ b/frontend/src/utils/uiState.test.ts
@@ -21,6 +21,7 @@ test('round-trip save/load works correctly', () => {
     },
     listFollow: false,
     listAnchorKey: 'some-key',
+    infoBarOpen: true,
     zoomRange: [1000, 2000],
     statsSearch: 'stats',
     buildingSearch: 'building',

--- a/frontend/src/utils/uiState.ts
+++ b/frontend/src/utils/uiState.ts
@@ -6,6 +6,8 @@ export interface UiSessionState {
   };
   listFollow: boolean;
   listAnchorKey: string | null;
+  /** Quick info bar open/closed state above the telegram list header (#311). */
+  infoBarOpen: boolean;
   zoomRange: [number, number] | null;
   statsSearch: string;
   buildingSearch: string;
@@ -24,6 +26,7 @@ export const DEFAULT_UI_STATE: UiSessionState = {
   },
   listFollow: true,
   listAnchorKey: null,
+  infoBarOpen: false,
   zoomRange: null,
   statsSearch: '',
   buildingSearch: '',
@@ -82,6 +85,7 @@ function sanitize(p: Partial<StoredUiState>): UiSessionState {
     },
     listFollow: typeof p.listFollow === 'boolean' ? p.listFollow : true,
     listAnchorKey: typeof p.listAnchorKey === 'string' ? p.listAnchorKey : null,
+    infoBarOpen: typeof p.infoBarOpen === 'boolean' ? p.infoBarOpen : false,
     zoomRange: zoom,
     statsSearch: typeof p.statsSearch === 'string' ? p.statsSearch : '',
     buildingSearch: typeof p.buildingSearch === 'string' ? p.buildingSearch : '',


### PR DESCRIPTION
## Summary
- **Multi-level sort**: ctrl/cmd-click a column header adds it as a further sort level instead of replacing the sort; a small numbered badge marks each level once more than one is active. TIME is always the implicit deepest tiebreaker (even when not an explicit level), so ordering stays deterministic and the delta column stays meaningful under any hierarchy.
- **Always-on delta column**: the Δt column no longer disappears when sorting by a non-time column — it's computed from whichever row order is currently active, respecting the full sort hierarchy.
- **Delta-sort (exclusive mode)**: clicking the Δt header freezes the current view (deltas stop recalculating, live-follow pauses) and sorts the frozen set by delta; clicking it again flips direction. Clicking any *other* column header exits the mode and restores the live-follow state from before entering it.
- **Quick info bar**: a collapsible strip above the header (toggle next to the quick-filter one) summarizing the currently visible rows — oldest/newest telegram and min/max Δt (each click-to-jump via the existing scroll/anchor machinery), plus telegram/source/target/DPT counts and a per-type breakdown.
- Extracted the Group Monitor's and History Search's duplicated sort comparators into a shared `utils/sortConfig.ts` (`sortTelegrams`, `toggleSortLevel`), and `gotoTime`'s scroll/anchor logic into a reusable `gotoIndex` shared with the info bar's jump actions.
- `readSortConfigPref` transparently upgrades the pre-#311 single-level persisted shape, so existing installs keep their sort preference.

Closes #311

## Test plan
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 302/302 passing (new `sortConfig.test.ts`; extended `TelegramTable.test.tsx` for multi-sort clicks/badges, always-on delta column, delta-sort mode, and the info bar; updated the array-shaped `SortConfig` across existing tests)
- [x] Verified in a running instance (Vite dev server + Playwright, telegrams injected over a stubbed WebSocket): the info bar renders and its counts are correct, ctrl-click builds a two-level SOURCE→TARGET sort with numbered badges and the row order matches, and clicking Δt freezes the view sorted by descending time gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
