### PR TITLE
feat: telegram list quick filter v2 with DELTA TIME column (#309)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -585,6 +585,12 @@ function App() {
     setIsFilterOpen(true);
   }, [handleFiltersChange]);
 
+  // Time-Delta-Context window, now edited from the telegram list's DELTA TIME
+  // quick-filter cell rather than the filter pane (#309, #371).
+  const handleDeltaContextChange = useCallback((deltaBeforeMs: number, deltaAfterMs: number) => {
+    handleFiltersChange(prev => ({ ...prev, deltaBeforeMs, deltaAfterMs }));
+  }, [handleFiltersChange]);
+
   const sortedLiveTelegrams = useMemo(
     () => sortTelegrams(liveTelegrams, sortConfig),
     [liveTelegrams, sortConfig]
@@ -1204,6 +1210,7 @@ function App() {
                     onQuickFilterEnabledChange={setQuickFilterEnabled}
                     quickPatterns={quickPatterns}
                     onQuickPatternsChange={setQuickPatterns}
+                    onDeltaContextChange={handleDeltaContextChange}
                     listFollow={listFollow}
                     onListFollowChange={setListFollow}
                     listAnchorKey={listAnchorKey}

--- a/frontend/src/components/FilterPanel.tsx
+++ b/frontend/src/components/FilterPanel.tsx
@@ -597,64 +597,6 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
           </Section>
         )}
 
-        {/* Time-delta context window */}
-        <Section title="Time-Delta Context" defaultOpen={false}>
-          <div style={{ padding: '0.25rem 0' }}>
-            <div style={{ fontSize: '0.7rem', color: 'var(--text-dim)', marginBottom: '0.75rem', lineHeight: 1.5 }}>
-              Include telegrams within a window around any filter-matching telegram,
-              even if they don't match the filter.
-            </div>
-
-            {/* −delta (before) */}
-            <label style={{ display: 'block', fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.3rem' }}>− Before (ms)</label>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.65rem' }}>
-              <Clock size={13} style={{ color: 'var(--text-dim)', flexShrink: 0 }} />
-              <input
-                type="number"
-                min={0}
-                step={10}
-                value={activeFilters.deltaBeforeMs || ''}
-                placeholder="0 = off"
-                onChange={e => update({ deltaBeforeMs: Math.max(0, Number(e.target.value)) })}
-                style={{
-                  flex: 1, background: 'var(--bg-tag)', border: '1px solid var(--border-color)',
-                  borderRadius: '6px', padding: '0.45rem 0.6rem', color: 'var(--text-main)',
-                  fontSize: '0.8125rem', fontFamily: 'inherit', outline: 'none',
-                }}
-              />
-              <span style={{ fontSize: '0.75rem', color: 'var(--text-dim)', flexShrink: 0 }}>ms</span>
-            </div>
-
-            {/* +delta (after) */}
-            <label style={{ display: 'block', fontSize: '0.65rem', color: 'var(--text-dim)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.3rem' }}>+ After (ms)</label>
-            <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-              <Clock size={13} style={{ color: 'var(--text-dim)', flexShrink: 0 }} />
-              <input
-                type="number"
-                min={0}
-                step={10}
-                value={activeFilters.deltaAfterMs || ''}
-                placeholder="0 = off"
-                onChange={e => update({ deltaAfterMs: Math.max(0, Number(e.target.value)) })}
-                style={{
-                  flex: 1, background: 'var(--bg-tag)', border: '1px solid var(--border-color)',
-                  borderRadius: '6px', padding: '0.45rem 0.6rem', color: 'var(--text-main)',
-                  fontSize: '0.8125rem', fontFamily: 'inherit', outline: 'none',
-                }}
-              />
-              <span style={{ fontSize: '0.75rem', color: 'var(--text-dim)', flexShrink: 0 }}>ms</span>
-            </div>
-
-            {(activeFilters.deltaBeforeMs > 0 || activeFilters.deltaAfterMs > 0) && (
-              <div style={{ fontSize: '0.65rem', color: 'var(--accent-primary)', marginTop: '0.5rem' }}>
-                {activeFilters.deltaBeforeMs > 0 && <span>−{activeFilters.deltaBeforeMs}ms </span>}
-                {activeFilters.deltaAfterMs > 0 && <span>+{activeFilters.deltaAfterMs}ms </span>}
-                context active
-              </div>
-            )}
-          </div>
-        </Section>
-
       </div>
       </>)}
     </div>

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -101,6 +101,12 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     setIsFilterOpen(false);
   };
 
+  // Time-Delta-Context window, edited from the telegram list's DELTA TIME
+  // quick-filter cell rather than the filter pane (#309, #371).
+  const handleDeltaContextChange = (deltaBeforeMs: number, deltaAfterMs: number) => {
+    onFiltersChange({ ...activeFilters, deltaBeforeMs, deltaAfterMs });
+  };
+
   const sortedTelegrams = useMemo(
     () => sortTelegrams(telegrams, sortConfig),
     [telegrams, sortConfig]
@@ -321,6 +327,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
               activeFilters={activeFilters}
               onQuickFilter={handleQuickFilter}
               onQuickVisualize={handleQuickVisualize}
+              onDeltaContextChange={handleDeltaContextChange}
             />
           )}
         </div>

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -8,6 +8,8 @@ import { SendToGaPopover } from './SendToGaPopover';
 import { GotoTimeControl } from './GotoTimeControl';
 import { getPref, setPref } from '../utils/prefs';
 import type { SortKey, SortLevel, SortConfig } from '../utils/sortConfig';
+import { makeAddressPatternMatcher } from '../utils/addressPattern';
+import { makeValueMatcher } from '../utils/valuePattern';
 
 export type { SortKey, SortLevel, SortConfig };
 
@@ -24,13 +26,16 @@ interface TelegramTableProps {
   /** Enables the per-row "Send to this GA" quick popover; true only when the bus is writable (#214). */
   canSend?: boolean;
 
-  // Lifted Quick-Filter state (#280, #341)
+  // Lifted Quick-Filter state (#280, #309, #341)
   quickFilterOpen?: boolean;
   onQuickFilterOpenChange?: (open: boolean) => void;
   quickFilterEnabled?: boolean;
   onQuickFilterEnabledChange?: (enabled: boolean) => void;
-  quickPatterns?: Partial<Record<ColId, string>>;
-  onQuickPatternsChange?: (patterns: Partial<Record<ColId, string>>) => void;
+  quickPatterns?: Partial<Record<ColId, QuickCellValue>>;
+  onQuickPatternsChange?: (patterns: Partial<Record<ColId, QuickCellValue>>) => void;
+  /** Edits the Time-Delta-Context window (#309, #371) — moved here from the
+   * filter pane; current values come from `activeFilters.deltaBeforeMs/deltaAfterMs`. */
+  onDeltaContextChange?: (deltaBeforeMs: number, deltaAfterMs: number) => void;
 
   // Lifted Follow / Anchor state (#203, #341)
   listFollow?: boolean;
@@ -51,6 +56,16 @@ interface TelegramTableProps {
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
+
+// A quick-filter cell's two input rows (#309). Most columns use both (address/DPT
+// pattern + name regex on source/target/dpt; from/to on time/value); TYPE only
+// uses `top` (a comma-separated fixed-value list); `delta` isn't matched through
+// this pipeline at all — its two rows edit the Time-Delta-Context window instead.
+interface QuickCellValue {
+  top: string;
+  bottom: string;
+}
+const EMPTY_CELL: QuickCellValue = { top: '', bottom: '' };
 
 interface ColumnDef {
   id: ColId;
@@ -118,23 +133,15 @@ const ROW_ESTIMATE = 85; // matches the virtualizer's estimateSize
 const anchorKey = (t: Telegram) =>
   `${t.timestamp}-${t.source_address}-${t.target_address}-${t.raw_hex ?? ''}`;
 
-// ── Quick filter bar (#271) ──────────────────────────────────────────────────
-
-/** Per-column text the quick filter matches against (addresses and names alike). */
-const quickFilterHaystack = (id: ColId, t: Telegram): string => {
-  switch (id) {
-    case 'time': return format(new Date(t.timestamp), 'yyyy-MM-dd HH:mm:ss.SS');
-    case 'delta': return ''; // derived from visible row order — nothing to filter
-    case 'source': return `${t.source_address} ${t.source_name ?? ''}`;
-    case 'target': return `${t.target_address} ${t.target_name ?? ''}`;
-    case 'type': return `${t.simplified_type || t.telegram_type} ${t.direction ?? ''}`;
-    case 'dpt': return `${t.dpt_name ?? ''} ${t.dpt_main != null ? dptKey(t.dpt_main, t.dpt_sub) : ''}`;
-    case 'value': return `${t.value_formatted ?? t.value_numeric ?? ''} ${t.unit ?? ''} ${t.raw_hex ?? ''}`;
-  }
-};
+// ── Quick filter bar (#271, #309) ────────────────────────────────────────────
+// Two rows per applicable column: a top pattern row (address/DPT-key patterns
+// with wildcards and ranges, or a from/range bound) and a bottom text row
+// (regex/literal, or a to/range bound). TYPE only uses the top row (a
+// comma-separated fixed-value list); DELTA doesn't participate here at all —
+// it edits the Time-Delta-Context window instead (#371).
 
 /** Case-insensitive regex matcher; an invalid pattern degrades to a literal substring match. */
-const makeQuickMatcher = (pattern: string): ((s: string) => boolean) => {
+const makeTextMatcher = (pattern: string): ((s: string) => boolean) => {
   try {
     const re = new RegExp(pattern, 'i');
     return s => re.test(s);
@@ -144,9 +151,79 @@ const makeQuickMatcher = (pattern: string): ((s: string) => boolean) => {
   }
 };
 
+/** Builds one combined predicate from all active quick-filter cells, so
+ * patterns are compiled once per change rather than per telegram. */
+const compileQuickFilters = (patterns: Partial<Record<ColId, QuickCellValue>>): ((t: Telegram) => boolean) => {
+  const checks: ((t: Telegram) => boolean)[] = [];
+
+  const time = patterns.time;
+  if (time?.top || time?.bottom) {
+    const from = time.top ? new Date(time.top).getTime() : null;
+    const to = time.bottom ? new Date(time.bottom).getTime() : null;
+    checks.push(t => {
+      const ts = new Date(t.timestamp).getTime();
+      if (from != null && !Number.isNaN(from) && ts < from) return false;
+      if (to != null && !Number.isNaN(to) && ts > to) return false;
+      return true;
+    });
+  }
+
+  const source = patterns.source;
+  if (source?.top) {
+    const m = makeAddressPatternMatcher(source.top);
+    checks.push(t => m(t.source_address));
+  }
+  if (source?.bottom) {
+    const m = makeTextMatcher(source.bottom);
+    checks.push(t => m(t.source_name ?? ''));
+  }
+
+  const target = patterns.target;
+  if (target?.top) {
+    const m = makeAddressPatternMatcher(target.top);
+    checks.push(t => m(t.target_address));
+  }
+  if (target?.bottom) {
+    const m = makeTextMatcher(target.bottom);
+    checks.push(t => m(t.target_name ?? ''));
+  }
+
+  const type = patterns.type;
+  if (type?.top) {
+    const values = type.top.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+    if (values.length > 0) {
+      checks.push(t => {
+        const typeVal = (t.simplified_type || t.telegram_type || '').toLowerCase();
+        const dirVal = (t.direction ?? '').toLowerCase();
+        return values.some(v => v === typeVal || v === dirVal);
+      });
+    }
+  }
+
+  const dpt = patterns.dpt;
+  if (dpt?.top) {
+    const m = makeAddressPatternMatcher(dpt.top);
+    checks.push(t => t.dpt_main != null && m(dptKey(t.dpt_main, t.dpt_sub)));
+  }
+  if (dpt?.bottom) {
+    const m = makeTextMatcher(dpt.bottom);
+    checks.push(t => m(t.dpt_name ?? ''));
+  }
+
+  const value = patterns.value;
+  if (value?.top || value?.bottom) {
+    const m = makeValueMatcher(value.top ?? '', value.bottom ?? '');
+    checks.push(m);
+  }
+
+  if (checks.length === 0) return () => true;
+  return t => checks.every(check => check(t));
+};
+
 export const TelegramTable: React.FC<TelegramTableProps> = ({
   telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend,
   quickFilterOpen, onQuickFilterOpenChange, quickFilterEnabled, onQuickFilterEnabledChange, quickPatterns, onQuickPatternsChange,
+  onDeltaContextChange,
   listFollow, onListFollowChange, listAnchorKey, onListAnchorKeyChange,
   markedKeys, onMarkedKeysChange, lastMarkedKey, onLastMarkedKeyChange,
   infoBarOpen, onInfoBarOpenChange,
@@ -211,7 +288,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   // in the bar switches it without losing the patterns.
   const [internalQuickOpen, setInternalQuickOpen] = useState(false);
   const [internalQuickEnabled, setInternalQuickEnabled] = useState(false);
-  const [internalQuickPatterns, setInternalQuickPatterns] = useState<Partial<Record<ColId, string>>>({});
+  const [internalQuickPatterns, setInternalQuickPatterns] = useState<Partial<Record<ColId, QuickCellValue>>>({});
 
   const quickOpen = quickFilterOpen ?? internalQuickOpen;
   const setQuickOpen = useCallback((val: boolean | ((prev: boolean) => boolean)) => {
@@ -228,11 +305,16 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   }, [quickEnabled, onQuickFilterEnabledChange]);
 
   const currentPatterns = quickPatterns ?? internalQuickPatterns;
-  const setQuickPatterns = useCallback((val: Partial<Record<ColId, string>> | ((prev: Partial<Record<ColId, string>>) => Partial<Record<ColId, string>>)) => {
+  const setQuickPatterns = useCallback((val: Partial<Record<ColId, QuickCellValue>> | ((prev: Partial<Record<ColId, QuickCellValue>>) => Partial<Record<ColId, QuickCellValue>>)) => {
     const next = typeof val === 'function' ? val(currentPatterns) : val;
     setInternalQuickPatterns(next);
     onQuickPatternsChange?.(next);
   }, [currentPatterns, onQuickPatternsChange]);
+
+  /** Updates one row (top/bottom) of a quick-filter cell, preserving the other row. */
+  const setQuickCell = useCallback((id: ColId, row: 'top' | 'bottom', text: string) => {
+    setQuickPatterns(prev => ({ ...prev, [id]: { ...(prev[id] ?? EMPTY_CELL), [row]: text } }));
+  }, [setQuickPatterns]);
 
   const toggleQuickOpen = () => {
     const nextOpen = !quickOpen;
@@ -277,11 +359,8 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
 
   const quickFiltered = useMemo(() => {
     if (!quickOpen || !quickEnabled) return telegrams;
-    const matchers = Object.entries(currentPatterns)
-      .filter(([, p]) => p && p.trim() !== '')
-      .map(([id, p]) => [id, makeQuickMatcher(p!.trim())] as const);
-    if (matchers.length === 0) return telegrams;
-    return telegrams.filter(t => matchers.every(([id, m]) => m(quickFilterHaystack(id as ColId, t))));
+    const matches = compileQuickFilters(currentPatterns);
+    return telegrams.filter(matches);
   }, [telegrams, quickOpen, quickEnabled, currentPatterns]);
 
   // Time deltas between consecutive rows, by visual (sorted) order — always
@@ -1062,7 +1141,9 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
         ))}
       </div>
 
-      {/* Quick filter bar (#271) — one regex/literal input per visible column */}
+      {/* Quick filter bar (#271, #309) — two rows per column: a pattern/from row
+          and a text/to row, except TYPE (one row) and DELTA (Time-Delta-Context
+          before/after, #371) which don't go through the pattern pipeline. */}
       {quickOpen && (
         <div
           style={{
@@ -1076,26 +1157,104 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
           }}
         >
           {visibleCols.map(c => (
-            <div key={c.id} style={{ padding: '0.35rem 0.5rem', display: 'flex', alignItems: 'center', gap: '0.35rem', minWidth: 0 }}>
+            <div key={c.id} style={{ padding: '0.35rem 0.5rem', display: 'flex', alignItems: 'flex-start', gap: '0.35rem', minWidth: 0 }}>
               {c.id === 'time' && (
                 <button
                   className={`quick-filter-bar-toggle ${quickEnabled ? 'open' : ''}`}
                   onClick={() => setQuickEnabled(e => !e)}
                   title={quickEnabled ? 'Disable quick filter (keeps patterns)' : 'Enable quick filter'}
+                  style={{ marginTop: '0.2rem' }}
                 >
                   <Filter size={12} />
                 </button>
               )}
-              {c.id !== 'delta' && (
-                <input
-                  className="quick-filter-bar-input"
-                  type="text"
-                  value={currentPatterns[c.id] ?? ''}
-                  placeholder="regex…"
-                  aria-label={`Quick filter ${c.label}`}
-                  onChange={e => setQuickPatterns(prev => ({ ...prev, [c.id]: e.target.value }))}
-                />
-              )}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', minWidth: 0, flex: 1 }}>
+                {c.id === 'delta' ? (
+                  <>
+                    <input
+                      className="quick-filter-bar-input"
+                      type="number" min={0} step={10}
+                      value={activeFilters.deltaBeforeMs || ''}
+                      placeholder="before ms"
+                      aria-label="Time-Delta-Context before (ms)"
+                      onChange={e => onDeltaContextChange?.(Math.max(0, Number(e.target.value) || 0), activeFilters.deltaAfterMs)}
+                    />
+                    <input
+                      className="quick-filter-bar-input"
+                      type="number" min={0} step={10}
+                      value={activeFilters.deltaAfterMs || ''}
+                      placeholder="after ms"
+                      aria-label="Time-Delta-Context after (ms)"
+                      onChange={e => onDeltaContextChange?.(activeFilters.deltaBeforeMs, Math.max(0, Number(e.target.value) || 0))}
+                    />
+                  </>
+                ) : c.id === 'type' ? (
+                  <input
+                    className="quick-filter-bar-input"
+                    type="text"
+                    value={currentPatterns.type?.top ?? ''}
+                    placeholder="WRITE, RESPONSE, Incoming…"
+                    aria-label="Quick filter TYPE"
+                    onChange={e => setQuickCell('type', 'top', e.target.value)}
+                  />
+                ) : c.id === 'time' ? (
+                  <>
+                    <input
+                      className="quick-filter-bar-input"
+                      type="datetime-local" step="1"
+                      value={currentPatterns.time?.top ?? ''}
+                      aria-label="Quick filter TIME from"
+                      onChange={e => setQuickCell('time', 'top', e.target.value)}
+                    />
+                    <input
+                      className="quick-filter-bar-input"
+                      type="datetime-local" step="1"
+                      value={currentPatterns.time?.bottom ?? ''}
+                      aria-label="Quick filter TIME to"
+                      onChange={e => setQuickCell('time', 'bottom', e.target.value)}
+                    />
+                  </>
+                ) : c.id === 'value' ? (
+                  <>
+                    <input
+                      className="quick-filter-bar-input"
+                      type="text"
+                      value={currentPatterns.value?.top ?? ''}
+                      placeholder="from / 0x.. / 0b.. / &quot;regex&quot;"
+                      aria-label="Quick filter VALUE from"
+                      onChange={e => setQuickCell('value', 'top', e.target.value)}
+                    />
+                    <input
+                      className="quick-filter-bar-input"
+                      type="text"
+                      value={currentPatterns.value?.bottom ?? ''}
+                      placeholder="to / pattern…"
+                      aria-label="Quick filter VALUE to"
+                      onChange={e => setQuickCell('value', 'bottom', e.target.value)}
+                    />
+                  </>
+                ) : (
+                  // source / target / dpt: top = address/DPT-key pattern, bottom = name/description regex
+                  <>
+                    <input
+                      className="quick-filter-bar-input"
+                      type="text"
+                      value={currentPatterns[c.id]?.top ?? ''}
+                      placeholder={c.id === 'dpt' ? '1.008-1.011, 16.*' : c.id === 'source' ? '*.1.*, 1.2.12-1.2.91' : '1/5/*, 3/1/1-3/1/127'}
+                      aria-label={`Quick filter ${c.label} pattern`}
+                      onChange={e => setQuickCell(c.id, 'top', e.target.value)}
+                    />
+                    <input
+                      className="quick-filter-bar-input"
+                      type="text"
+                      value={currentPatterns[c.id]?.bottom ?? ''}
+                      placeholder={c.id === 'dpt' ? 'description regex…' : 'name regex…'}
+                      aria-label={`Quick filter ${c.label} name`}
+                      onChange={e => setQuickCell(c.id, 'bottom', e.target.value)}
+                    />
+                  </>
+                )}
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/components/TelegramTableQuickFilter.test.tsx
+++ b/frontend/src/components/TelegramTableQuickFilter.test.tsx
@@ -1,9 +1,16 @@
 import { render, fireEvent, screen } from '@testing-library/react';
 import { expect, test, vi, beforeAll } from 'vitest';
+import { format } from 'date-fns';
 import { TelegramTable, type SortConfig } from './TelegramTable';
 import { makeTelegram } from '../test/telegramFactory';
 import type { Telegram } from '../hooks/useWebSocket';
 import { DEFAULT_FILTERS } from '../types/filters';
+
+// The <input type="datetime-local"> quick-filter rows are interpreted as
+// local time (matching the datetime-local semantics used elsewhere in the
+// app, e.g. GotoTimeControl) — derive the input value from a telegram's own
+// UTC timestamp so the test doesn't depend on the runner's timezone.
+const localInputValue = (isoUtc: string) => format(new Date(isoUtc), "yyyy-MM-dd'T'HH:mm:ss");
 
 // jsdom has no layout: give the virtualizer a viewport so it renders rows.
 beforeAll(() => {
@@ -54,45 +61,58 @@ const renderTable = () =>
 
 const rowCount = (container: HTMLElement) => container.querySelectorAll('.log-row').length;
 
-test('expanding the quick filter bar and typing filters the rows (#271)', () => {
+test('expanding the quick filter bar and typing in the name row filters the rows (#271, #309)', () => {
   const { container } = renderTable();
   expect(rowCount(container)).toBe(3);
-  expect(screen.queryByLabelText('Quick filter TARGET')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Quick filter TARGET name')).not.toBeInTheDocument();
 
   fireEvent.click(screen.getByTitle('Show quick filter bar'));
-  const input = screen.getByLabelText('Quick filter TARGET');
+  const nameInput = screen.getByLabelText('Quick filter TARGET name');
 
-  fireEvent.change(input, { target: { value: 'küche' } });
+  fireEvent.change(nameInput, { target: { value: 'küche' } });
   expect(rowCount(container)).toBe(1);
 
-  // Regex alternation across address and name.
-  fireEvent.change(input, { target: { value: '1/2/(3|4)' } });
+  // Regex alternation on the name row.
+  fireEvent.change(nameInput, { target: { value: 'Küche|Flur' } });
   expect(rowCount(container)).toBe(2);
 });
 
-test('an invalid regex falls back to a literal substring match', () => {
+test('the address pattern row (#309) matches by wildcard, independent of the name row', () => {
   const { container } = renderTable();
   fireEvent.click(screen.getByTitle('Show quick filter bar'));
 
+  fireEvent.change(screen.getByLabelText('Quick filter TARGET pattern'), { target: { value: '1/2/*' } });
+  expect(rowCount(container)).toBe(2);
+
+  fireEvent.change(screen.getByLabelText('Quick filter TARGET pattern'), { target: { value: '2/0/0-2/0/9' } });
+  expect(rowCount(container)).toBe(1);
+});
+
+test('an invalid regex in the name row falls back to a literal substring match', () => {
+  const { container } = renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  const nameInput = screen.getByLabelText('Quick filter TARGET name');
+
   // "(" alone is an invalid regex — must not crash, matches nothing literally…
-  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: '(' } });
+  fireEvent.change(nameInput, { target: { value: '(' } });
   expect(rowCount(container)).toBe(0);
 
   // …and a literal fragment of a name still matches.
-  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: 'jalousie' } });
+  fireEvent.change(nameInput, { target: { value: 'jalousie' } });
   expect(rowCount(container)).toBe(1);
 });
 
 test('the toggle disables filtering without losing patterns; collapsing restores all rows', () => {
   const { container } = renderTable();
   fireEvent.click(screen.getByTitle('Show quick filter bar'));
-  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: 'küche' } });
+  const nameInput = screen.getByLabelText('Quick filter TARGET name');
+  fireEvent.change(nameInput, { target: { value: 'küche' } });
   expect(rowCount(container)).toBe(1);
 
   // Disable via the bar's toggle — patterns stay, rows come back.
   fireEvent.click(screen.getByTitle('Disable quick filter (keeps patterns)'));
   expect(rowCount(container)).toBe(3);
-  expect(screen.getByLabelText('Quick filter TARGET')).toHaveValue('küche');
+  expect(screen.getByLabelText('Quick filter TARGET name')).toHaveValue('küche');
 
   // Re-enable — filtering resumes with the kept pattern.
   fireEvent.click(screen.getByTitle('Enable quick filter'));
@@ -100,14 +120,46 @@ test('the toggle disables filtering without losing patterns; collapsing restores
 
   // Collapse — bar gone, all rows visible again.
   fireEvent.click(screen.getByTitle('Hide quick filter bar'));
-  expect(screen.queryByLabelText('Quick filter TARGET')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Quick filter TARGET name')).not.toBeInTheDocument();
   expect(rowCount(container)).toBe(3);
 });
 
 test('filters combine across columns (AND)', () => {
   const { container } = renderTable();
   fireEvent.click(screen.getByTitle('Show quick filter bar'));
-  fireEvent.change(screen.getByLabelText('Quick filter TARGET'), { target: { value: 'licht' } });
-  fireEvent.change(screen.getByLabelText('Quick filter VALUE'), { target: { value: '0x02' } });
+  fireEvent.change(screen.getByLabelText('Quick filter TARGET name'), { target: { value: 'licht' } });
+  fireEvent.change(screen.getByLabelText('Quick filter VALUE from'), { target: { value: '0x02' } });
+  expect(rowCount(container)).toBe(1);
+});
+
+test('the TYPE row matches a comma-separated list against type or direction', () => {
+  const telegrams: Telegram[] = [
+    makeTelegram({ simplified_type: 'Write', direction: 'Incoming' }),
+    makeTelegram({ simplified_type: 'Read', direction: 'Incoming' }),
+    makeTelegram({ simplified_type: 'Response', direction: 'Outgoing' }),
+  ];
+  const { container } = render(
+    <TelegramTable
+      telegrams={telegrams}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  fireEvent.change(screen.getByLabelText('Quick filter TYPE'), { target: { value: 'Write, Outgoing' } });
+  expect(rowCount(container)).toBe(2); // the Write/Incoming row and the Response/Outgoing row
+});
+
+test('the TIME row restricts to a from/to range', () => {
+  const { container } = renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  const boundary = localInputValue('2024-01-01T10:00:02.000Z'); // the middle telegram's own timestamp
+  fireEvent.change(screen.getByLabelText('Quick filter TIME from'), { target: { value: boundary } });
+  expect(rowCount(container)).toBe(2);
+  fireEvent.change(screen.getByLabelText('Quick filter TIME to'), { target: { value: boundary } });
   expect(rowCount(container)).toBe(1);
 });

--- a/frontend/src/components/qolStatePersistence.test.tsx
+++ b/frontend/src/components/qolStatePersistence.test.tsx
@@ -106,16 +106,16 @@ test('TelegramTable quick-filter and follow/anchor survive unmount/remount', () 
 
   // Open filter bar and type
   fireEvent.click(screen.getByTitle('Show quick filter bar'));
-  const input = screen.getByLabelText('Quick filter TARGET');
+  const input = screen.getByLabelText('Quick filter TARGET pattern');
   fireEvent.change(input, { target: { value: '1/1/1' } });
 
   // Unmount
   fireEvent.click(screen.getByText('Toggle Table'));
-  expect(screen.queryByLabelText('Quick filter TARGET')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Quick filter TARGET pattern')).not.toBeInTheDocument();
 
   // Remount
   fireEvent.click(screen.getByText('Toggle Table'));
-  expect(screen.getByLabelText('Quick filter TARGET')).toHaveValue('1/1/1');
+  expect(screen.getByLabelText('Quick filter TARGET pattern')).toHaveValue('1/1/1');
 });
 
 // ── 2. Visualizer Zoom Persistence Test (Task 3.2) ──

--- a/frontend/src/utils/addressPattern.test.ts
+++ b/frontend/src/utils/addressPattern.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { makeAddressPatternMatcher } from './addressPattern';
+
+describe('makeAddressPatternMatcher', () => {
+  it('matches an exact address', () => {
+    const m = makeAddressPatternMatcher('1/2/3');
+    expect(m('1/2/3')).toBe(true);
+    expect(m('1/2/4')).toBe(false);
+  });
+
+  it('matches a wildcard segment (group address)', () => {
+    const m = makeAddressPatternMatcher('1/5/*');
+    expect(m('1/5/0')).toBe(true);
+    expect(m('1/5/255')).toBe(true);
+    expect(m('1/6/0')).toBe(false);
+  });
+
+  it('matches wildcards in multiple segments', () => {
+    const m = makeAddressPatternMatcher('*/*/255');
+    expect(m('1/5/255')).toBe(true);
+    expect(m('9/0/255')).toBe(true);
+    expect(m('9/0/254')).toBe(false);
+  });
+
+  it('matches a physical-address wildcard', () => {
+    const m = makeAddressPatternMatcher('*.1.*');
+    expect(m('1.1.5')).toBe(true);
+    expect(m('9.1.200')).toBe(true);
+    expect(m('1.2.5')).toBe(false);
+  });
+
+  it('rejects a value with the wrong segment count', () => {
+    const m = makeAddressPatternMatcher('1/5/*');
+    expect(m('1.5.3')).toBe(false); // different delimiter entirely
+  });
+
+  it('matches a range between two full physical addresses', () => {
+    const m = makeAddressPatternMatcher('1.2.12-1.2.91');
+    expect(m('1.2.12')).toBe(true);
+    expect(m('1.2.50')).toBe(true);
+    expect(m('1.2.91')).toBe(true);
+    expect(m('1.2.11')).toBe(false);
+    expect(m('1.2.92')).toBe(false);
+    expect(m('1.3.1')).toBe(false);
+  });
+
+  it('matches a group-address range', () => {
+    const m = makeAddressPatternMatcher('3/1/1-3/1/127');
+    expect(m('3/1/1')).toBe(true);
+    expect(m('3/1/127')).toBe(true);
+    expect(m('3/1/128')).toBe(false);
+  });
+
+  it('handles a reversed range (hi given before lo)', () => {
+    const m = makeAddressPatternMatcher('3/1/127-3/1/1');
+    expect(m('3/1/50')).toBe(true);
+  });
+
+  it('matches a DPT-key range and a DPT-key wildcard', () => {
+    const m = makeAddressPatternMatcher('1.008-1.011, 16.*');
+    expect(m('1.008')).toBe(true);
+    expect(m('1.010')).toBe(true);
+    expect(m('1.012')).toBe(false);
+    expect(m('16.000')).toBe(true);
+    expect(m('16.001')).toBe(true);
+    expect(m('9.001')).toBe(false);
+  });
+
+  it('ORs multiple comma-separated tokens', () => {
+    const m = makeAddressPatternMatcher('1/1/1, 1/2/*, 2/0/0-2/0/9');
+    expect(m('1/1/1')).toBe(true);
+    expect(m('1/2/99')).toBe(true);
+    expect(m('2/0/5')).toBe(true);
+    expect(m('3/0/0')).toBe(false);
+  });
+
+  it('an empty pattern matches everything', () => {
+    const m = makeAddressPatternMatcher('   ');
+    expect(m('anything')).toBe(true);
+  });
+
+  it('ignores whitespace around tokens', () => {
+    const m = makeAddressPatternMatcher(' 1/1/1 , 1/2/3 ');
+    expect(m('1/1/1')).toBe(true);
+    expect(m('1/2/3')).toBe(true);
+  });
+});

--- a/frontend/src/utils/addressPattern.ts
+++ b/frontend/src/utils/addressPattern.ts
@@ -1,0 +1,65 @@
+// Comma-ORed address/DPT-key pattern matching for the telegram list's quick
+// filter (#309): wildcards (`*` = any whole segment) and ranges (`A-B`) on
+// dot- or slash-delimited addresses, e.g. "*.1.*, 1.2.12-1.2.91" (physical),
+// "1/5/*, */*/255, 3/1/1-3/1/127" (group), "1.008-1.011, 16.*" (DPT key).
+
+type Matcher = (value: string) => boolean;
+
+const delimiterOf = (s: string): '/' | '.' => (s.includes('/') ? '/' : '.');
+
+/** Converts a dotted/slashed address into one comparable integer, treating
+ * each segment as a base-65536 digit (comfortably covers KNX's 16-bit
+ * address fields). Returns null for non-numeric segments (e.g. wildcards). */
+const toComparable = (addr: string, delim: string): number | null => {
+  const parts = addr.split(delim).map(Number);
+  if (parts.length === 0 || parts.some(Number.isNaN)) return null;
+  return parts.reduce((acc, p) => acc * 65536 + p, 0);
+};
+
+const rangeMatcher = (loStr: string, hiStr: string): Matcher | null => {
+  const delim = delimiterOf(loStr);
+  if (delimiterOf(hiStr) !== delim) return null;
+  const lo = toComparable(loStr, delim);
+  const hi = toComparable(hiStr, delim);
+  if (lo == null || hi == null) return null;
+  const [min, max] = lo <= hi ? [lo, hi] : [hi, lo];
+  return value => {
+    const v = toComparable(value, delim);
+    return v != null && v >= min && v <= max;
+  };
+};
+
+const wildcardMatcher = (pattern: string): Matcher => {
+  const delim = delimiterOf(pattern);
+  const patSegs = pattern.split(delim);
+  return value => {
+    const valSegs = value.split(delim);
+    if (valSegs.length !== patSegs.length) return false;
+    return patSegs.every((p, i) => p === '*' || p === valSegs[i]);
+  };
+};
+
+const tokenToMatcher = (token: string): Matcher => {
+  if (token.includes('-') && !token.includes('*')) {
+    const [loStr, hiStr] = token.split('-').map(s => s.trim());
+    if (loStr && hiStr) {
+      const range = rangeMatcher(loStr, hiStr);
+      if (range) return range;
+    }
+  }
+  if (token.includes('*')) return wildcardMatcher(token);
+  return value => value === token;
+};
+
+/**
+ * Builds a matcher for a comma-separated field of address/DPT-key patterns
+ * and ranges, ORed together. An empty/whitespace-only pattern imposes no
+ * restriction (matches everything) — check `isBlank` before applying it if
+ * "no restriction" should instead mean "field inactive".
+ */
+export function makeAddressPatternMatcher(input: string): Matcher {
+  const tokens = input.split(',').map(t => t.trim()).filter(Boolean);
+  if (tokens.length === 0) return () => true;
+  const matchers = tokens.map(tokenToMatcher);
+  return value => matchers.some(m => m(value));
+}

--- a/frontend/src/utils/uiState.test.ts
+++ b/frontend/src/utils/uiState.test.ts
@@ -17,7 +17,7 @@ test('round-trip save/load works correctly', () => {
     quickFilter: {
       open: true,
       enabled: true,
-      patterns: { source_address: '1.1.1' },
+      patterns: { source: { top: '1.1.1', bottom: '' } },
     },
     listFollow: false,
     listAnchorKey: 'some-key',
@@ -83,4 +83,21 @@ test('sanitize drops invalid fields and fills defaults', () => {
     listFollow: true,
     zoomRange: null,
   });
+});
+
+test('drops pre-#309 single-string pattern cells instead of guessing top/bottom', () => {
+  localStorage.setItem(
+    UI_STORAGE_KEY,
+    JSON.stringify({
+      v: 1,
+      quickFilter: {
+        open: true,
+        enabled: true,
+        patterns: { source: '1.1.1', target: { top: '1/2/3', bottom: 'kitchen' } },
+      },
+    })
+  );
+
+  const loaded = loadUiState();
+  expect(loaded?.quickFilter.patterns).toEqual({ target: { top: '1/2/3', bottom: 'kitchen' } });
 });

--- a/frontend/src/utils/uiState.ts
+++ b/frontend/src/utils/uiState.ts
@@ -2,7 +2,9 @@ export interface UiSessionState {
   quickFilter: {
     open: boolean;
     enabled: boolean;
-    patterns: Record<string, string>;
+    /** Each column's two quick-filter rows (#309) — e.g. an address pattern
+     * and a name regex, or a from/to range. */
+    patterns: Record<string, { top: string; bottom: string }>;
   };
   listFollow: boolean;
   listAnchorKey: string | null;
@@ -65,13 +67,16 @@ export function loadUiState(): UiSessionState | null {
 
 function sanitize(p: Partial<StoredUiState>): UiSessionState {
   const q = (p.quickFilter ?? {}) as Partial<UiSessionState['quickFilter']>;
-  const patterns = q.patterns && typeof q.patterns === 'object' && !Array.isArray(q.patterns)
-    ? Object.fromEntries(
-        Object.entries(q.patterns).filter(
-          (entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string'
-        )
-      )
-    : {};
+  const isCell = (v: unknown): v is { top: string; bottom: string } =>
+    !!v && typeof v === 'object' && typeof (v as { top?: unknown }).top === 'string' && typeof (v as { bottom?: unknown }).bottom === 'string';
+  const patterns: Record<string, { top: string; bottom: string }> = {};
+  if (q.patterns && typeof q.patterns === 'object' && !Array.isArray(q.patterns)) {
+    // Cells from the pre-#309 single-string shape are dropped (low-stakes UI
+    // preference) rather than guessed into top/bottom.
+    for (const [key, val] of Object.entries(q.patterns)) {
+      if (isCell(val)) patterns[key] = val;
+    }
+  }
 
   const zoom = Array.isArray(p.zoomRange) && p.zoomRange.length === 2 && typeof p.zoomRange[0] === 'number' && typeof p.zoomRange[1] === 'number'
     ? (p.zoomRange as [number, number])

--- a/frontend/src/utils/valuePattern.test.ts
+++ b/frontend/src/utils/valuePattern.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { makeValueMatcher, type ValueMatchable } from './valuePattern';
+
+function v(overrides: Partial<ValueMatchable>): ValueMatchable {
+  return { value_numeric: null, raw_hex: null, value_formatted: null, unit: null, ...overrides };
+}
+
+describe('makeValueMatcher', () => {
+  it('treats two plain numbers as an inclusive numeric range', () => {
+    const m = makeValueMatcher('100', '200');
+    expect(m(v({ value_numeric: 100 }))).toBe(true);
+    expect(m(v({ value_numeric: 150 }))).toBe(true);
+    expect(m(v({ value_numeric: 200 }))).toBe(true);
+    expect(m(v({ value_numeric: 99 }))).toBe(false);
+    expect(m(v({ value_numeric: 201 }))).toBe(false);
+  });
+
+  it('handles a reversed numeric range', () => {
+    const m = makeValueMatcher('200', '100');
+    expect(m(v({ value_numeric: 150 }))).toBe(true);
+  });
+
+  it('matches a single decimal value with no second row', () => {
+    const m = makeValueMatcher('42', '');
+    expect(m(v({ value_numeric: 42 }))).toBe(true);
+    expect(m(v({ value_numeric: 43 }))).toBe(false);
+  });
+
+  it('matches decimal wildcards: + for one digit, * for any run', () => {
+    const m = makeValueMatcher('1+3', '');
+    expect(m(v({ value_numeric: 123 }))).toBe(true);
+    expect(m(v({ value_numeric: 143 }))).toBe(true);
+    expect(m(v({ value_numeric: 1243 }))).toBe(false);
+
+    const star = makeValueMatcher('*000', '');
+    expect(star(v({ value_numeric: 5000 }))).toBe(true);
+    expect(star(v({ value_numeric: 5001 }))).toBe(false);
+  });
+
+  it('matches an exact hex pattern against raw_hex', () => {
+    const m = makeValueMatcher('0x07', '');
+    expect(m(v({ raw_hex: '07' }))).toBe(true);
+    expect(m(v({ raw_hex: '08' }))).toBe(false);
+  });
+
+  it('matches hex wildcards', () => {
+    const m = makeValueMatcher('0x0+', '');
+    expect(m(v({ raw_hex: '01' }))).toBe(true);
+    expect(m(v({ raw_hex: '0f' }))).toBe(true);
+    expect(m(v({ raw_hex: '10' }))).toBe(false);
+  });
+
+  it('matches an exact binary pattern against the decoded bits', () => {
+    const m = makeValueMatcher('0b1', '');
+    expect(m(v({ raw_hex: '01' }))).toBe(true); // 00000001, strips to "1"
+    expect(m(v({ raw_hex: '00' }))).toBe(false);
+  });
+
+  it('matches binary wildcards against the full decoded byte', () => {
+    const m = makeValueMatcher('0b0000000+', '');
+    expect(m(v({ raw_hex: '01' }))).toBe(true); // 00000001
+    expect(m(v({ raw_hex: '02' }))).toBe(false); // 00000010
+  });
+
+  it('matches a quoted pattern as regex against the formatted value', () => {
+    const m = makeValueMatcher('"\\d+ lx"', '');
+    expect(m(v({ value_formatted: '120 lx' }))).toBe(true);
+    expect(m(v({ value_formatted: 'On' }))).toBe(false);
+  });
+
+  it('degrades an invalid quoted regex to a literal wildcard pattern', () => {
+    const m = makeValueMatcher('"*000"', '');
+    expect(m(v({ value_formatted: '5000' }))).toBe(true);
+  });
+
+  it('an empty cell matches everything', () => {
+    const m = makeValueMatcher('', '');
+    expect(m(v({ value_numeric: 1 }))).toBe(true);
+  });
+
+  it('ORs the two rows when they are not both plain numbers', () => {
+    const m = makeValueMatcher('On', 'Off');
+    expect(m(v({ value_formatted: 'On' }))).toBe(true);
+    expect(m(v({ value_formatted: 'Off' }))).toBe(true);
+    expect(m(v({ value_formatted: 'Toggle' }))).toBe(false);
+  });
+});

--- a/frontend/src/utils/valuePattern.ts
+++ b/frontend/src/utils/valuePattern.ts
@@ -1,0 +1,90 @@
+// VALUE column quick-filter matching for the telegram list (#309): binary
+// (`0b…`), hex (`0x…`) and decimal digit patterns with `+` (any single digit)
+// and `*` (any run of digits) wildcards, plus quoted-regex/literal text —
+// matched against a telegram's raw hex, decimal value, or formatted text.
+
+export interface ValueMatchable {
+  value_numeric: number | null;
+  raw_hex?: string | null;
+  value_formatted?: string | null;
+  unit?: string | null;
+}
+
+type Matcher = (t: ValueMatchable) => boolean;
+
+/** `+` -> exactly one digit of `digitClass`, `*` -> any run of that digit class. */
+const wildcardToRegex = (pattern: string, digitClass: string): RegExp => {
+  const body = pattern
+    .split('')
+    .map(ch => (ch === '+' ? `[${digitClass}]` : ch === '*' ? `[${digitClass}]*` : ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+    .join('');
+  return new RegExp(`^${body}$`, 'i');
+};
+
+const hexMatcher = (pattern: string): Matcher => {
+  const re = wildcardToRegex(pattern.slice(2), '0-9a-fA-F');
+  return t => !!t.raw_hex && re.test(t.raw_hex.replace(/^0x/i, ''));
+};
+
+const binaryMatcher = (pattern: string): Matcher => {
+  const re = wildcardToRegex(pattern.slice(2), '01');
+  return t => {
+    if (!t.raw_hex) return false;
+    const bits = t.raw_hex
+      .replace(/^0x/i, '')
+      .split('')
+      .map(c => parseInt(c, 16).toString(2).padStart(4, '0'))
+      .join('');
+    return re.test(bits) || re.test(bits.replace(/^0+(?=.)/, ''));
+  };
+};
+
+const decimalWildcardMatcher = (pattern: string): Matcher => {
+  const re = wildcardToRegex(pattern, '0-9');
+  return t => t.value_numeric != null && re.test(String(t.value_numeric));
+};
+
+const isPlainNumber = (s: string): boolean => /^-?\d+(\.\d+)?$/.test(s);
+
+const regexOrLiteralMatcher = (pattern: string): Matcher => {
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern, 'i');
+  } catch {
+    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, ch => (ch === '*' ? '.*' : ch === '+' ? '.' : `\\${ch}`));
+    re = new RegExp(`^${escaped}$`, 'i');
+  }
+  return t => {
+    const haystack = [t.value_formatted ?? t.value_numeric ?? '', t.unit, t.raw_hex].filter(Boolean).join(' ');
+    return re.test(haystack);
+  };
+};
+
+/** Parses one VALUE cell entry (a single row's text) into a matcher. */
+function parseValueToken(token: string): Matcher {
+  if (token.startsWith('"') && token.endsWith('"') && token.length >= 2) {
+    return regexOrLiteralMatcher(token.slice(1, -1));
+  }
+  if (/^0x/i.test(token)) return hexMatcher(token);
+  if (/^0b/i.test(token)) return binaryMatcher(token);
+  if (/^[\d+*]+$/.test(token) && /\d/.test(token)) return decimalWildcardMatcher(token);
+  return regexOrLiteralMatcher(token);
+}
+
+/**
+ * Builds a matcher from the VALUE cell's two rows. When both rows are plain
+ * numbers (no wildcards), they form a numeric range against `value_numeric`;
+ * otherwise each non-empty row is parsed as its own pattern and ORed.
+ */
+export function makeValueMatcher(top: string, bottom: string): Matcher {
+  const from = top.trim();
+  const to = bottom.trim();
+  if (from && to && isPlainNumber(from) && isPlainNumber(to)) {
+    const lo = Math.min(Number(from), Number(to));
+    const hi = Math.max(Number(from), Number(to));
+    return t => t.value_numeric != null && t.value_numeric >= lo && t.value_numeric <= hi;
+  }
+  const matchers = [from, to].filter(Boolean).map(parseValueToken);
+  if (matchers.length === 0) return () => true;
+  return t => matchers.some(m => m(t));
+}


### PR DESCRIPTION
## Summary
- **Two-row quick-filter cells** (#309): SOURCE/TARGET/DPT get a top *pattern* row (comma-ORed wildcards and ranges over addresses/DPT keys — e.g. `*.1.*, 1.2.12-1.2.91` for a PA, `1/5/*, 3/1/1-3/1/127` for a GA, `1.008-1.011, 16.*` for a DPT key) and a bottom *name/description* regex row (the pre-existing regex-with-literal-fallback behavior). TIME and VALUE get from/to rows. TYPE keeps a single row — a comma-separated fixed-value list matched against either the telegram's type or its direction.
- **New parser utilities**, each standalone and unit tested:
  - `utils/addressPattern.ts` — wildcard segments (`*`) and ranges (`A-B`) over dot/slash-delimited addresses and DPT keys.
  - `utils/valuePattern.ts` — binary (`0b…`) and hex (`0x…`) digit wildcards, decimal digit wildcards, numeric from/to ranges, and quoted-regex-with-literal-fallback text matching.
- **Time-Delta-Context moves into the DELTA TIME column** (#371's decision B): the Δt cell's two quick-filter rows are now the before/after-ms inputs, replacing the filter pane's "Time-Delta Context" section. The underlying data (`ActiveFilters.deltaBeforeMs/deltaAfterMs`) and its consumers (history-load params, live-view context expansion) are unchanged — only the editing UI moved, via a new `onDeltaContextChange` callback wired in both the Group Monitor and History Search views.
- The persisted quick-filter shape upgrades from one string per column to `{top, bottom}`; pre-#309 single-string cells are dropped on load (a low-stakes UI preference) rather than guessed into a row.

Closes #309

## Test plan
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 330/330 passing: new `addressPattern.test.ts` (12 cases) and `valuePattern.test.ts` (12 cases); rewrote `TelegramTableQuickFilter.test.tsx` for the two-row model plus new TYPE/TIME-range/address-pattern coverage; updated `uiState.test.ts` for the `{top,bottom}` persisted shape and the pre-#309 migration
- [x] Verified in a running instance (Vite dev server + Playwright, telegrams injected over a stubbed WebSocket): the two-row bar renders correctly for every column including the DELTA TIME before/after inputs, an address-pattern filter (`1/1/1, 1/1/9`) correctly narrows the list, and the filter pane's old Time-Delta Context section is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
