### PR TITLE
feat: toggle Time-Delta-Context without losing the entered values (#318)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,6 +42,7 @@ import { useUpdateCheck } from './hooks/useUpdateCheck';
 import {
   DEFAULT_FILTERS,
   dptKey,
+  effectiveDeltaContext,
   hasActiveFilters,
   matchesTelegram,
   type ActiveFilters,
@@ -591,6 +592,11 @@ function App() {
     handleFiltersChange(prev => ({ ...prev, deltaBeforeMs, deltaAfterMs }));
   }, [handleFiltersChange]);
 
+  // Toggles the window on/off without losing the entered values (#318).
+  const handleDeltaContextEnabledChange = useCallback((deltaContextEnabled: boolean) => {
+    handleFiltersChange(prev => ({ ...prev, deltaContextEnabled }));
+  }, [handleFiltersChange]);
+
   const sortedLiveTelegrams = useMemo(
     () => sortTelegrams(liveTelegrams, sortConfig),
     [liveTelegrams, sortConfig]
@@ -613,7 +619,8 @@ function App() {
       noFilter ? true : matchesTelegram(t, f)
     );
 
-    const hasDelta = f.deltaBeforeMs > 0 || f.deltaAfterMs > 0;
+    const { before: deltaBeforeMs, after: deltaAfterMs } = effectiveDeltaContext(f);
+    const hasDelta = deltaBeforeMs > 0 || deltaAfterMs > 0;
 
     if (!hasDelta) {
       return sortedLiveTelegrams.filter((_, idx) => matches[idx]);
@@ -630,7 +637,7 @@ function App() {
       if (matches[idx]) return true;
       const ts = new Date(t.timestamp).getTime();
       return matchingTimestamps.some(mts =>
-        (ts >= mts - f.deltaBeforeMs) && (ts <= mts + f.deltaAfterMs)
+        (ts >= mts - deltaBeforeMs) && (ts <= mts + deltaAfterMs)
       );
     });
   }, [sortedLiveTelegrams, activeFilters, filtersEnabled]);
@@ -1211,6 +1218,7 @@ function App() {
                     quickPatterns={quickPatterns}
                     onQuickPatternsChange={setQuickPatterns}
                     onDeltaContextChange={handleDeltaContextChange}
+                    onDeltaContextEnabledChange={handleDeltaContextEnabledChange}
                     listFollow={listFollow}
                     onListFollowChange={setListFollow}
                     listAnchorKey={listAnchorKey}

--- a/frontend/src/components/HistoryLoader.tsx
+++ b/frontend/src/components/HistoryLoader.tsx
@@ -149,10 +149,10 @@ export const HistoryLoader: React.FC<HistoryLoaderProps> = ({ onClose, onLoad, o
             {filters.dpts.map(d => (
               <span key={d} style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'var(--bg-tag)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>DPT {d}</span>
             ))}
-            {filters.deltaBeforeMs > 0 && (
+            {filters.deltaContextEnabled && filters.deltaBeforeMs > 0 && (
               <span style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'var(--bg-tag)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>−{filters.deltaBeforeMs}ms before</span>
             )}
-            {filters.deltaAfterMs > 0 && (
+            {filters.deltaContextEnabled && filters.deltaAfterMs > 0 && (
               <span style={{ fontSize: '0.7rem', padding: '0.2rem 0.55rem', borderRadius: '999px', background: 'var(--bg-tag)', color: 'var(--text-dim)', border: '1px solid var(--border-color)' }}>+{filters.deltaAfterMs}ms after</span>
             )}
           </div>

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -107,6 +107,11 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
     onFiltersChange({ ...activeFilters, deltaBeforeMs, deltaAfterMs });
   };
 
+  // Toggles the window on/off without losing the entered values (#318).
+  const handleDeltaContextEnabledChange = (deltaContextEnabled: boolean) => {
+    onFiltersChange({ ...activeFilters, deltaContextEnabled });
+  };
+
   const sortedTelegrams = useMemo(
     () => sortTelegrams(telegrams, sortConfig),
     [telegrams, sortConfig]
@@ -328,6 +333,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
               onQuickFilter={handleQuickFilter}
               onQuickVisualize={handleQuickVisualize}
               onDeltaContextChange={handleDeltaContextChange}
+              onDeltaContextEnabledChange={handleDeltaContextEnabledChange}
             />
           )}
         </div>

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useEffect, useLayoutEffect, useState, useCallba
 import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
-import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock, Info } from 'lucide-react';
+import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock, Info, Power } from 'lucide-react';
 import { dptKey, type ActiveFilters } from '../types/filters';
 import { SendToGaPopover } from './SendToGaPopover';
 import { GotoTimeControl } from './GotoTimeControl';
@@ -36,6 +36,8 @@ interface TelegramTableProps {
   /** Edits the Time-Delta-Context window (#309, #371) — moved here from the
    * filter pane; current values come from `activeFilters.deltaBeforeMs/deltaAfterMs`. */
   onDeltaContextChange?: (deltaBeforeMs: number, deltaAfterMs: number) => void;
+  /** Toggles the window on/off without losing the entered values (#318). */
+  onDeltaContextEnabledChange?: (enabled: boolean) => void;
 
   // Lifted Follow / Anchor state (#203, #341)
   listFollow?: boolean;
@@ -223,7 +225,7 @@ const compileQuickFilters = (patterns: Partial<Record<ColId, QuickCellValue>>): 
 export const TelegramTable: React.FC<TelegramTableProps> = ({
   telegrams, visibleColumns, sortConfig, onSort, activeFilters, onQuickFilter, onQuickVisualize, onQuickLastSeen, canSend,
   quickFilterOpen, onQuickFilterOpenChange, quickFilterEnabled, onQuickFilterEnabledChange, quickPatterns, onQuickPatternsChange,
-  onDeltaContextChange,
+  onDeltaContextChange, onDeltaContextEnabledChange,
   listFollow, onListFollowChange, listAnchorKey, onListAnchorKeyChange,
   markedKeys, onMarkedKeysChange, lastMarkedKey, onLastMarkedKeyChange,
   infoBarOpen, onInfoBarOpenChange,
@@ -1168,6 +1170,18 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                   <Filter size={12} />
                 </button>
               )}
+              {c.id === 'delta' && (
+                <button
+                  className={`quick-filter-bar-toggle ${activeFilters.deltaContextEnabled ? 'open' : ''}`}
+                  onClick={() => onDeltaContextEnabledChange?.(!activeFilters.deltaContextEnabled)}
+                  title={activeFilters.deltaContextEnabled
+                    ? 'Disable Time-Delta-Context (keeps the entered before/after values)'
+                    : 'Enable Time-Delta-Context with the previously entered values'}
+                  style={{ marginTop: '0.2rem' }}
+                >
+                  <Power size={12} />
+                </button>
+              )}
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', minWidth: 0, flex: 1 }}>
                 {c.id === 'delta' ? (
                   <>
@@ -1177,6 +1191,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                       value={activeFilters.deltaBeforeMs || ''}
                       placeholder="before ms"
                       aria-label="Time-Delta-Context before (ms)"
+                      style={{ opacity: activeFilters.deltaContextEnabled ? 1 : 0.5 }}
                       onChange={e => onDeltaContextChange?.(Math.max(0, Number(e.target.value) || 0), activeFilters.deltaAfterMs)}
                     />
                     <input
@@ -1185,6 +1200,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                       value={activeFilters.deltaAfterMs || ''}
                       placeholder="after ms"
                       aria-label="Time-Delta-Context after (ms)"
+                      style={{ opacity: activeFilters.deltaContextEnabled ? 1 : 0.5 }}
                       onChange={e => onDeltaContextChange?.(activeFilters.deltaBeforeMs, Math.max(0, Number(e.target.value) || 0))}
                     />
                   </>

--- a/frontend/src/components/TelegramTableQuickFilter.test.tsx
+++ b/frontend/src/components/TelegramTableQuickFilter.test.tsx
@@ -163,3 +163,33 @@ test('the TIME row restricts to a from/to range', () => {
   fireEvent.change(screen.getByLabelText('Quick filter TIME to'), { target: { value: boundary } });
   expect(rowCount(container)).toBe(1);
 });
+
+test('the DELTA TIME toggle disables/enables the context window without losing the entered values (#318)', () => {
+  const onDeltaContextChange = vi.fn();
+  const onDeltaContextEnabledChange = vi.fn();
+  render(
+    <TelegramTable
+      telegrams={TELEGRAMS}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={{ ...DEFAULT_FILTERS, deltaBeforeMs: 500, deltaAfterMs: 250, deltaContextEnabled: true }}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+      onDeltaContextChange={onDeltaContextChange}
+      onDeltaContextEnabledChange={onDeltaContextEnabledChange}
+    />,
+  );
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+
+  // Values are shown regardless of enabled state.
+  expect(screen.getByLabelText('Time-Delta-Context before (ms)')).toHaveValue(500);
+  expect(screen.getByLabelText('Time-Delta-Context after (ms)')).toHaveValue(250);
+
+  fireEvent.click(screen.getByTitle('Disable Time-Delta-Context (keeps the entered before/after values)'));
+  expect(onDeltaContextEnabledChange).toHaveBeenCalledWith(false);
+
+  // Editing a value while enabled still goes through onDeltaContextChange, preserving the other field.
+  fireEvent.change(screen.getByLabelText('Time-Delta-Context before (ms)'), { target: { value: '750' } });
+  expect(onDeltaContextChange).toHaveBeenCalledWith(750, 250);
+});

--- a/frontend/src/types/filters.test.ts
+++ b/frontend/src/types/filters.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, test } from 'vitest';
-import { DEFAULT_FILTERS, dptKey, matchesDpt, matchesTelegram } from './filters';
+import { DEFAULT_FILTERS, dptKey, effectiveDeltaContext, matchesDpt, matchesTelegram } from './filters';
+
+describe('effectiveDeltaContext', () => {
+  test('returns the stored before/after values when enabled', () => {
+    const f = { ...DEFAULT_FILTERS, deltaBeforeMs: 500, deltaAfterMs: 250, deltaContextEnabled: true };
+    expect(effectiveDeltaContext(f)).toEqual({ before: 500, after: 250 });
+  });
+
+  test('zeroes the effective window when disabled, without touching the stored values (#318)', () => {
+    const f = { ...DEFAULT_FILTERS, deltaBeforeMs: 500, deltaAfterMs: 250, deltaContextEnabled: false };
+    expect(effectiveDeltaContext(f)).toEqual({ before: 0, after: 0 });
+    expect(f.deltaBeforeMs).toBe(500); // re-enabling would restore these, not lose them
+    expect(f.deltaAfterMs).toBe(250);
+  });
+});
 
 describe('dptKey', () => {
   test('pads the sub to three digits', () => {

--- a/frontend/src/types/filters.ts
+++ b/frontend/src/types/filters.ts
@@ -32,6 +32,13 @@ export interface ActiveFilters {
   /** ms after a matching telegram to also include (0 = disabled) */
   deltaAfterMs: number;
   /**
+   * Toggles the Time-Delta-Context window on/off without losing the entered
+   * before/after values, so re-enabling doesn't require retyping them (#318).
+   * Defaults to true: existing links/workspaces with a non-zero before/after
+   * and no stored flag keep behaving as "on", matching pre-#318 behavior.
+   */
+  deltaContextEnabled: boolean;
+  /**
    * @deprecated All active filters combine with AND (#275); this no longer affects
    * matching. Retained only so old shared links / workspaces carrying `rel_st=OR`
    * still parse without error — they load and apply as AND. Cross-category OR returns
@@ -51,8 +58,16 @@ export const DEFAULT_FILTERS: ActiveFilters = {
   dpts: [],
   deltaBeforeMs: 0,
   deltaAfterMs: 0,
+  deltaContextEnabled: true,
   sourceTargetRelation: 'AND',
 };
+
+/** The before/after window actually in effect — zeroed while the toggle is off,
+ * even though the stored values are kept so re-enabling restores them (#318). */
+export function effectiveDeltaContext(f: ActiveFilters): { before: number; after: number } {
+  if (!f.deltaContextEnabled) return { before: 0, after: 0 };
+  return { before: f.deltaBeforeMs, after: f.deltaAfterMs };
+}
 
 /** Minimal telegram shape needed for in-memory filtering. */
 export interface FilterableTelegram {

--- a/frontend/src/utils/historyLoad.test.ts
+++ b/frontend/src/utils/historyLoad.test.ts
@@ -1,5 +1,20 @@
 import { expect, test } from 'vitest';
-import { buildHistoryUrl, rangeToMs } from './historyLoad';
+import { applyFilterParams, buildHistoryUrl, rangeToMs } from './historyLoad';
+import { DEFAULT_FILTERS } from '../types/filters';
+
+test('applyFilterParams sends the Time-Delta-Context window when enabled', () => {
+  const url = applyFilterParams('/api/telegrams', { ...DEFAULT_FILTERS, deltaBeforeMs: 500, deltaAfterMs: 250 });
+  expect(url).toContain('delta_before_ms=500');
+  expect(url).toContain('delta_after_ms=250');
+});
+
+test('applyFilterParams omits the window while disabled, even with stored values (#318)', () => {
+  const url = applyFilterParams('/api/telegrams', {
+    ...DEFAULT_FILTERS, deltaBeforeMs: 500, deltaAfterMs: 250, deltaContextEnabled: false,
+  });
+  expect(url).not.toContain('delta_before_ms');
+  expect(url).not.toContain('delta_after_ms');
+});
 
 test('buildHistoryUrl handles relative ranges correctly', () => {
   const url = buildHistoryUrl({ kind: 'relative', seconds: 3600 }, 100);

--- a/frontend/src/utils/historyLoad.ts
+++ b/frontend/src/utils/historyLoad.ts
@@ -1,5 +1,5 @@
 import type { Telegram } from '../hooks/useWebSocket';
-import type { ActiveFilters } from '../types/filters';
+import { effectiveDeltaContext, type ActiveFilters } from '../types/filters';
 import { apiUrl } from './basePath';
 
 export interface HistoryMetadata {
@@ -20,8 +20,9 @@ export function applyFilterParams(url: string, filters?: ActiveFilters): string 
   if (filters.targets.length > 0) params.push(`target_address=${encodeURIComponent(filters.targets.join(','))}`);
   if (filters.types.length > 0) params.push(`telegram_type=${encodeURIComponent(filters.types.join(','))}`);
   if (filters.dpts.length > 0) params.push(`dpt_main=${encodeURIComponent(filters.dpts.join(','))}`);
-  if (filters.deltaBeforeMs > 0) params.push(`delta_before_ms=${filters.deltaBeforeMs}`);
-  if (filters.deltaAfterMs > 0) params.push(`delta_after_ms=${filters.deltaAfterMs}`);
+  const { before, after } = effectiveDeltaContext(filters);
+  if (before > 0) params.push(`delta_before_ms=${before}`);
+  if (after > 0) params.push(`delta_after_ms=${after}`);
   if (params.length === 0) return url;
   return url + (url.includes('?') ? '&' : '?') + params.join('&');
 }

--- a/frontend/src/utils/viewUrl.test.ts
+++ b/frontend/src/utils/viewUrl.test.ts
@@ -42,6 +42,13 @@ describe('parseViewUrl', () => {
     const v = parseViewUrl('?view=viz&rel=1h&src=1.1.5&tgt=1/2/3&rel_st=OR');
     expect(v!.filters.sourceTargetRelation).toBe('OR');
   });
+
+  test('deltaContextEnabled defaults true and honors delta_off=1 (#318)', () => {
+    expect(parseViewUrl('?view=viz&rel=1h&before=500')!.filters.deltaContextEnabled).toBe(true);
+    const disabled = parseViewUrl('?view=viz&rel=1h&before=500&delta_off=1');
+    expect(disabled!.filters.deltaContextEnabled).toBe(false);
+    expect(disabled!.filters.deltaBeforeMs).toBe(500); // stored value survives being disabled
+  });
 });
 
 describe('buildViewUrl', () => {
@@ -86,6 +93,17 @@ describe('buildViewUrl', () => {
     expect(url).not.toContain('before=');
     expect(url).not.toContain('limit=');
     expect(url).not.toContain('rel_st=');
+    expect(url).not.toContain('delta_off='); // enabled is the default (#318)
+  });
+
+  test('writes delta_off=1 only when the context is disabled', () => {
+    const url = buildViewUrl({
+      plot: [],
+      filters: { ...DEFAULT_FILTERS, deltaBeforeMs: 500, deltaContextEnabled: false },
+      range: { kind: 'relative', seconds: 3600 },
+    });
+    expect(url).toContain('delta_off=1');
+    expect(parseViewUrl(url.slice(url.indexOf('?')))!.filters.deltaContextEnabled).toBe(false);
   });
 
   test('absolute ranges keep datetime-local strings', () => {

--- a/frontend/src/utils/viewUrl.ts
+++ b/frontend/src/utils/viewUrl.ts
@@ -64,6 +64,7 @@ export function parseViewUrl(search: string): VizViewState | null {
     dpts: list(p.get('dpt')).filter(d => /^\d+(\.\d+)?$/.test(d)),
     deltaBeforeMs: Math.max(0, Number(p.get('before')) || 0),
     deltaAfterMs: Math.max(0, Number(p.get('after')) || 0),
+    deltaContextEnabled: p.get('delta_off') !== '1',
     sourceTargetRelation: p.get('rel_st') === 'OR' ? 'OR' : 'AND',
   };
 
@@ -101,6 +102,7 @@ export function buildViewUrl(state: {
   if (f.dpts.length > 0) p.set('dpt', f.dpts.join(','));
   if (f.deltaBeforeMs > 0) p.set('before', String(f.deltaBeforeMs));
   if (f.deltaAfterMs > 0) p.set('after', String(f.deltaAfterMs));
+  if (!f.deltaContextEnabled) p.set('delta_off', '1');
   // `rel_st` is no longer written — all filters combine with AND (#275). Old links
   // carrying rel_st=OR are still parsed above and load (harmlessly) as AND.
   if (state.range.kind === 'relative') {

--- a/frontend/src/utils/workspaceState.test.ts
+++ b/frontend/src/utils/workspaceState.test.ts
@@ -113,6 +113,18 @@ describe('monitor URL encoding', () => {
       filters: { ...DEFAULT_FILTERS, dpts: ['1.001'] },
     });
   });
+
+  it('round-trips a disabled Time-Delta-Context, keeping the stored values (#318)', () => {
+    const ws: WorkspaceState = {
+      ...DEFAULT_WORKSPACE,
+      filters: { ...DEFAULT_FILTERS, deltaBeforeMs: 500, deltaContextEnabled: false },
+    };
+    const search = buildMonitorSearch(ws);
+    expect(search).toContain('delta_off=1');
+    const parsed = parseMonitorSearch('?' + search);
+    expect(parsed!.filters.deltaContextEnabled).toBe(false);
+    expect(parsed!.filters.deltaBeforeMs).toBe(500);
+  });
 });
 
 describe('applyWorkspaceUrl', () => {

--- a/frontend/src/utils/workspaceState.ts
+++ b/frontend/src/utils/workspaceState.ts
@@ -105,6 +105,7 @@ function sanitize(p: Partial<WorkspaceState>): WorkspaceState {
       dpts: strings(f.dpts).filter(d => /^\d+(\.\d+)?$/.test(d)),
       deltaBeforeMs: Math.max(0, Number(f.deltaBeforeMs) || 0),
       deltaAfterMs: Math.max(0, Number(f.deltaAfterMs) || 0),
+      deltaContextEnabled: typeof f.deltaContextEnabled === 'boolean' ? f.deltaContextEnabled : true,
       sourceTargetRelation: f.sourceTargetRelation === 'OR' ? 'OR' : 'AND',
     },
     plot: strings(p.plot),
@@ -131,6 +132,7 @@ export function buildMonitorSearch(state: WorkspaceState): string {
   if (f.dpts.length > 0) p.set('dpt', f.dpts.join(','));
   if (f.deltaBeforeMs > 0) p.set('before', String(f.deltaBeforeMs));
   if (f.deltaAfterMs > 0) p.set('after', String(f.deltaAfterMs));
+  if (!f.deltaContextEnabled) p.set('delta_off', '1');
   // `rel_st` is no longer written — all filters combine with AND (#275). Old links
   // carrying rel_st=OR are still parsed above and load (harmlessly) as AND.
   if (state.plot.length > 0) p.set('plot', state.plot.join(','));
@@ -160,6 +162,7 @@ export function parseMonitorSearch(search: string): WorkspaceState | null {
       dpts: list(p.get('dpt')),
       deltaBeforeMs: Number(p.get('before')) || 0,
       deltaAfterMs: Number(p.get('after')) || 0,
+      deltaContextEnabled: p.get('delta_off') !== '1',
       sourceTargetRelation: p.get('rel_st') === 'OR' ? 'OR' : 'AND',
     },
     plot: list(p.get('plot')),


### PR DESCRIPTION
## Summary
- **`ActiveFilters.deltaContextEnabled`** (default `true`) decouples "is the Time-Delta-Context window active" from the stored `deltaBeforeMs`/`deltaAfterMs` values, plus an `effectiveDeltaContext(f)` selector that zeroes the effective window while disabled without touching the stored numbers — so toggling back on restores exactly what was there.
- **Every consumer switched to the effective value**: the live-view context expansion in `App.tsx`, the history-load query params in `historyLoad.ts`, and `HistoryLoader`'s summary badges. Nothing else about the delta-context mechanics changed.
- **UI**: a `Power`-icon toggle button in the DELTA TIME quick-filter cell (added in #309) flips `deltaContextEnabled`. The before/after inputs stay visible and editable (just dimmed) while off — directly satisfying the issue's "toggle... without the need to reenter the values."
- **Persistence**: a `delta_off=1` URL param (share links, workspace URLs) and the matching `localStorage`-backed workspace field, both defaulting to enabled so existing links/workspaces keep behaving exactly as before.

This delivers the simple on/off toggle from the original request. The fuller none/some/all tristate that aggregates per-message context flags is #319's job, layered on top of this once those flags exist.

Closes #318

## Test plan
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 338/338 passing: new coverage in `filters.test.ts` (`effectiveDeltaContext`), `historyLoad.test.ts` (query-param gating), `viewUrl.test.ts` and `workspaceState.test.ts` (`delta_off` round-trip), and a `TelegramTableQuickFilter.test.tsx` case exercising the toggle button + value preservation end-to-end
- [x] Verified in a running instance (Vite dev server + Playwright): entered 500/250 ms, disabled the toggle, confirmed both input values are unchanged (`inputValue()` still `500`/`250`) and the toggle button's visual state flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
