### PR TITLE
feat: per-message Time-Delta-Context flag (#319)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import {
 } from './utils/uiState';
 import { DeviceStatusOverlay } from './components/DeviceStatusOverlay';
 import { TelegramTable, type SortConfig, type SortKey } from './components/TelegramTable';
+import { expandWithDeltaContext } from './utils/deltaContextExpansion';
+import { anchorKey } from './utils/anchorKey';
 import { readSortConfigPref, writeSortConfigPref, toggleSortLevel, sortTelegrams } from './utils/sortConfig';
 import { LayoutDashboard, History, Settings, Play, Pause, Download, Trash2, SlidersHorizontal, LineChart, BarChart2, Building2, Database, ChevronDown, AlertTriangle, Sun, Moon, Monitor, FolderInput, Send, Sparkles, Clock, List } from 'lucide-react';
 import { getPref, setPref } from './utils/prefs';
@@ -195,6 +197,9 @@ const PanelSwitch = ({ active, onChange }: { active: MainPanel; onChange: (p: Ma
     })}
   </div>
 );
+
+// Stable identity so passing "no flags" doesn't churn memo deps (#319).
+const EMPTY_KEY_SET: ReadonlySet<string> = new Set();
 
 function App() {
   const [theme, setTheme] = useTheme();
@@ -532,6 +537,11 @@ function App() {
   const [markedTelegramKeys, setMarkedTelegramKeys] = useState<string[]>([]);
   const [lastMarkedTelegramKey, setLastMarkedTelegramKey] = useState<string | null>(null);
 
+  // ── Per-message Time-Delta-Context flags (#319) ─────────────────────────────
+  // Same lifting rationale as marks; each flagged telegram always anchors a
+  // context window around itself regardless of the active filters.
+  const [flaggedTelegramKeys, setFlaggedTelegramKeys] = useState<string[]>([]);
+
   // ── Sorting (#311: multi-level, ctrl/cmd-click adds a level) ─────────────────
   const [sortConfig, setSortConfig] = useState<SortConfig>(readSortConfigPref);
   const handleSort = (key: SortKey, opts?: { additive?: boolean }) => {
@@ -614,33 +624,17 @@ function App() {
       f.directions.length === 0 &&
       f.dpts.length === 0);
 
-    // Step 1: mark each row as matching / not-matching
     const matches = sortedLiveTelegrams.map(t =>
       noFilter ? true : matchesTelegram(t, f)
     );
 
     const { before: deltaBeforeMs, after: deltaAfterMs } = effectiveDeltaContext(f);
-    const hasDelta = deltaBeforeMs > 0 || deltaAfterMs > 0;
+    // The global toggle off (#318) suppresses per-message flags too, per its
+    // "preserving all per-message flags" — inert, not cleared, while off.
+    const flags = f.deltaContextEnabled ? new Set(flaggedTelegramKeys) : EMPTY_KEY_SET;
 
-    if (!hasDelta) {
-      return sortedLiveTelegrams.filter((_, idx) => matches[idx]);
-    }
-
-    // Step 2: asymmetric time-delta expansion
-    const matchingTimestamps = sortedLiveTelegrams
-      .filter((_, idx) => matches[idx])
-      .map(t => new Date(t.timestamp).getTime());
-
-    if (matchingTimestamps.length === 0) return [];
-
-    return sortedLiveTelegrams.filter((t, idx) => {
-      if (matches[idx]) return true;
-      const ts = new Date(t.timestamp).getTime();
-      return matchingTimestamps.some(mts =>
-        (ts >= mts - deltaBeforeMs) && (ts <= mts + deltaAfterMs)
-      );
-    });
-  }, [sortedLiveTelegrams, activeFilters, filtersEnabled]);
+    return expandWithDeltaContext(sortedLiveTelegrams, matches, anchorKey, flags, deltaBeforeMs, deltaAfterMs);
+  }, [sortedLiveTelegrams, activeFilters, filtersEnabled, flaggedTelegramKeys]);
 
   // ── Count bubbles (live only) ───────────────────────────────────────────────
   const filterCounts = useMemo((): FilterCounts => {
@@ -1227,6 +1221,8 @@ function App() {
                     onMarkedKeysChange={setMarkedTelegramKeys}
                     lastMarkedKey={lastMarkedTelegramKey}
                     onLastMarkedKeyChange={setLastMarkedTelegramKey}
+                    flaggedKeys={flaggedTelegramKeys}
+                    onFlaggedKeysChange={setFlaggedTelegramKeys}
                     infoBarOpen={infoBarOpen}
                     onInfoBarOpenChange={setInfoBarOpen}
                   />

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { TelegramTable, type SortConfig, type SortKey } from './TelegramTable';
 import { readSortConfigPref, writeSortConfigPref, toggleSortLevel, sortTelegrams } from '../utils/sortConfig';
+import { expandWithDeltaContext } from '../utils/deltaContextExpansion';
+import { anchorKey } from '../utils/anchorKey';
 import type { Telegram } from '../hooks/useWebSocket';
 import { History, Download, AlertTriangle, Trash2, SlidersHorizontal, LineChart, RefreshCw } from 'lucide-react';
 import { HistoryLoader } from './HistoryLoader';
@@ -9,11 +11,15 @@ import { FilterPanel } from './FilterPanel';
 import { loadHistoryTelegrams, type LoadedRange } from '../utils/historyLoad';
 import { buildViewUrl, type VizViewState } from '../utils/viewUrl';
 import {
+  effectiveDeltaContext,
   hasActiveFilters,
   matchesTelegram,
   type ActiveFilters,
   type FilterOptions,
 } from '../types/filters';
+
+// Stable identity so passing "no flags" doesn't churn memo deps (#319).
+const EMPTY_FLAG_SET: ReadonlySet<string> = new Set();
 
 export type LoaderTimeRange = {
   relValue: number;
@@ -44,6 +50,8 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   const [isLoaderOpen, setIsLoaderOpen] = useState(false);
   const [metadata, setMetadata] = useState<{ total_count: number; limit_reached: boolean } | null>(null);
   const [sortConfig, setSortConfig] = useState<SortConfig>(readSortConfigPref);
+  // Per-message Time-Delta-Context flags (#319) — local to this view, like marks.
+  const [flaggedKeys, setFlaggedKeys] = useState<string[]>([]);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isVisualizerOpen, setIsVisualizerOpen] = useState(false);
 
@@ -137,11 +145,16 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   };
 
   // In-memory filter pass — mirrors live view filtering so changing filters
-  // immediately applies to already-loaded data without a re-fetch.
+  // immediately applies to already-loaded data without a re-fetch. Also
+  // applies the Time-Delta-Context window client-side (#309/#319), since
+  // per-message flags are set after the historical load already happened.
   const filteredSortedTelegrams = useMemo(() => {
-    if (!hasActiveFilters(activeFilters)) return sortedTelegrams;
-    return sortedTelegrams.filter(t => matchesTelegram(t, activeFilters));
-  }, [sortedTelegrams, activeFilters]);
+    const noFilter = !hasActiveFilters(activeFilters);
+    const matches = sortedTelegrams.map(t => noFilter || matchesTelegram(t, activeFilters));
+    const { before, after } = effectiveDeltaContext(activeFilters);
+    const flags = activeFilters.deltaContextEnabled ? new Set(flaggedKeys) : EMPTY_FLAG_SET;
+    return expandWithDeltaContext(sortedTelegrams, matches, anchorKey, flags, before, after);
+  }, [sortedTelegrams, activeFilters, flaggedKeys]);
 
   // True when current filters are less restrictive than what was used to fetch,
   // meaning some telegrams may be missing from the loaded set.
@@ -334,6 +347,8 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
               onQuickVisualize={handleQuickVisualize}
               onDeltaContextChange={handleDeltaContextChange}
               onDeltaContextEnabledChange={handleDeltaContextEnabledChange}
+              flaggedKeys={flaggedKeys}
+              onFlaggedKeysChange={setFlaggedKeys}
             />
           )}
         </div>

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useRef, useEffect, useLayoutEffect, useState, useCallba
 import { format } from 'date-fns';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Telegram } from '../hooks/useWebSocket';
-import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock, Info, Power } from 'lucide-react';
+import { ChevronUp, ChevronDown, Filter, LineChart, ListFilter, X, Clock, Info, Power, Circle, CircleDot } from 'lucide-react';
 import { dptKey, type ActiveFilters } from '../types/filters';
 import { SendToGaPopover } from './SendToGaPopover';
 import { GotoTimeControl } from './GotoTimeControl';
@@ -10,6 +10,7 @@ import { getPref, setPref } from '../utils/prefs';
 import type { SortKey, SortLevel, SortConfig } from '../utils/sortConfig';
 import { makeAddressPatternMatcher } from '../utils/addressPattern';
 import { makeValueMatcher } from '../utils/valuePattern';
+import { anchorKey } from '../utils/anchorKey';
 
 export type { SortKey, SortLevel, SortConfig };
 
@@ -55,6 +56,11 @@ interface TelegramTableProps {
   // Lifted Quick Info Bar open state (#311, #341)
   infoBarOpen?: boolean;
   onInfoBarOpenChange?: (open: boolean) => void;
+
+  // Lifted per-message Time-Delta-Context flags (#319): keys of telegrams
+  // individually flagged to always anchor a context window around themselves.
+  flaggedKeys?: string[];
+  onFlaggedKeysChange?: (keys: string[]) => void;
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
@@ -128,12 +134,6 @@ const formatDeltaMs = (diffMs: number): string => {
 const cellPadding = '0.75rem 1rem'; // Unified padding for all cells
 
 const ROW_ESTIMATE = 85; // matches the virtualizer's estimateSize
-
-// Identity of a telegram for anchor tracking across list updates (#202).
-// No index fallback here — the same telegram must map to the same key in
-// consecutive lists even when its position shifts.
-const anchorKey = (t: Telegram) =>
-  `${t.timestamp}-${t.source_address}-${t.target_address}-${t.raw_hex ?? ''}`;
 
 // ── Quick filter bar (#271, #309) ────────────────────────────────────────────
 // Two rows per applicable column: a top pattern row (address/DPT-key patterns
@@ -229,6 +229,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   listFollow, onListFollowChange, listAnchorKey, onListAnchorKeyChange,
   markedKeys, onMarkedKeysChange, lastMarkedKey, onLastMarkedKeyChange,
   infoBarOpen, onInfoBarOpenChange,
+  flaggedKeys, onFlaggedKeysChange,
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -359,6 +360,28 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     setLastMarked(null);
   }, [setMarkedKeysList, setLastMarked]);
 
+  // ── Per-message Time-Delta-Context flags (#319) ─────────────────────────
+  const [internalFlaggedKeys, setInternalFlaggedKeys] = useState<string[]>([]);
+  const flaggedKeysList = flaggedKeys ?? internalFlaggedKeys;
+  const setFlaggedKeysList = useCallback((val: string[]) => {
+    setInternalFlaggedKeys(val);
+    onFlaggedKeysChange?.(val);
+  }, [onFlaggedKeysChange]);
+  const flaggedSet = useMemo(() => new Set(flaggedKeysList), [flaggedKeysList]);
+
+  // Toggles one row's flag; ctrl/cmd-click applies the new state to every
+  // currently marked row too (#310's marks, reused as a multi-select basis).
+  const handleFlagClick = useCallback((e: React.MouseEvent, key: string) => {
+    e.stopPropagation();
+    const nextOn = !flaggedSet.has(key);
+    const targets = (e.ctrlKey || e.metaKey) ? new Set([...markedKeysList, key]) : new Set([key]);
+    setFlaggedKeysList(
+      nextOn
+        ? [...new Set([...flaggedKeysList, ...targets])]
+        : flaggedKeysList.filter(k => !targets.has(k))
+    );
+  }, [flaggedSet, flaggedKeysList, markedKeysList, setFlaggedKeysList]);
+
   const quickFiltered = useMemo(() => {
     if (!quickOpen || !quickEnabled) return telegrams;
     const matches = compileQuickFilters(currentPatterns);
@@ -434,6 +457,26 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   }, [exitDeltaSort, onSort]);
 
   const telegramRows = deltaSortActive && deltaFrozenRows ? deltaFrozenRows : naturalTelegramRows;
+
+  // ── Global Time-Delta-Context tristate (#318, #319) ─────────────────────────
+  // Reflects the per-message flags among the currently visible rows: none set,
+  // all set, or some. Plain click cycles the flags (none/some -> flag every
+  // visible row is "all", i.e. none<->all, some->none); ctrl/cmd-click instead
+  // toggles the window fully on/off (#318), preserving flags and values.
+  const deltaFlagState: 'none' | 'some' | 'all' = useMemo(() => {
+    if (telegramRows.length === 0 || flaggedSet.size === 0) return 'none';
+    const flaggedCount = telegramRows.reduce((n, t) => n + (flaggedSet.has(anchorKey(t)) ? 1 : 0), 0);
+    if (flaggedCount === 0) return 'none';
+    return flaggedCount === telegramRows.length ? 'all' : 'some';
+  }, [telegramRows, flaggedSet]);
+
+  const handleDeltaToggleClick = useCallback((e: React.MouseEvent) => {
+    if (e.ctrlKey || e.metaKey) {
+      onDeltaContextEnabledChange?.(!activeFilters.deltaContextEnabled);
+      return;
+    }
+    setFlaggedKeysList(deltaFlagState === 'none' ? telegramRows.map(t => anchorKey(t)) : []);
+  }, [deltaFlagState, telegramRows, activeFilters.deltaContextEnabled, onDeltaContextEnabledChange, setFlaggedKeysList]);
 
   // ── Quick info bar metrics (#311) ───────────────────────────────────────────
   // Summarizes the currently visible (sorted + filtered) rows; oldest/newest
@@ -855,9 +898,25 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
           </div>
         );
 
-      case 'delta':
+      case 'delta': {
+        const key = anchorKey(t);
+        const flagged = flaggedSet.has(key);
         return (
-          <div style={{ padding: cellPadding }}>
+          <div style={{ padding: cellPadding, display: 'flex', alignItems: 'center', gap: '0.35rem' }}>
+            <button
+              style={{
+                background: 'transparent', border: 'none', cursor: 'pointer', padding: '0.15rem',
+                borderRadius: '4px', display: 'flex', alignItems: 'center', flexShrink: 0,
+                color: flagged ? 'var(--accent-primary)' : 'var(--text-dim)',
+                opacity: activeFilters.deltaContextEnabled ? (flagged ? 1 : 0.35) : 0.25,
+              }}
+              title={flagged
+                ? 'Always show context around this message — click to unflag (ctrl/cmd-click to apply to all marked rows)'
+                : 'Always show context around this message, regardless of the active filters (ctrl/cmd-click to apply to all marked rows)'}
+              onClick={e => handleFlagClick(e, key)}
+            >
+              {flagged ? <CircleDot size={12} /> : <Circle size={12} />}
+            </button>
             {t.deltaStr && (
               <div className="mono-addr" style={{ fontSize: '0.75rem', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>
                 {t.deltaStr}
@@ -865,6 +924,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
             )}
           </div>
         );
+      }
 
       case 'source':
         return (
@@ -1172,12 +1232,20 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
               )}
               {c.id === 'delta' && (
                 <button
-                  className={`quick-filter-bar-toggle ${activeFilters.deltaContextEnabled ? 'open' : ''}`}
-                  onClick={() => onDeltaContextEnabledChange?.(!activeFilters.deltaContextEnabled)}
-                  title={activeFilters.deltaContextEnabled
-                    ? 'Disable Time-Delta-Context (keeps the entered before/after values)'
-                    : 'Enable Time-Delta-Context with the previously entered values'}
-                  style={{ marginTop: '0.2rem' }}
+                  className={`quick-filter-bar-toggle ${deltaFlagState !== 'none' ? 'open' : ''}`}
+                  onClick={handleDeltaToggleClick}
+                  title={[
+                    `Time-Delta-Context: ${deltaFlagState} messages flagged.`,
+                    deltaFlagState === 'some' ? 'Click to clear all flags.' : deltaFlagState === 'all' ? 'Click to clear all flags.' : 'Click to flag every visible message.',
+                    activeFilters.deltaContextEnabled
+                      ? 'Ctrl/cmd-click to disable the window (keeps flags and values).'
+                      : 'Ctrl/cmd-click to re-enable the window.',
+                  ].join(' ')}
+                  style={{
+                    marginTop: '0.2rem',
+                    opacity: activeFilters.deltaContextEnabled ? 1 : 0.5,
+                    color: deltaFlagState === 'all' ? 'var(--accent-primary)' : undefined,
+                  }}
                 >
                   <Power size={12} />
                 </button>

--- a/frontend/src/components/TelegramTableQuickFilter.test.tsx
+++ b/frontend/src/components/TelegramTableQuickFilter.test.tsx
@@ -164,7 +164,7 @@ test('the TIME row restricts to a from/to range', () => {
   expect(rowCount(container)).toBe(1);
 });
 
-test('the DELTA TIME toggle disables/enables the context window without losing the entered values (#318)', () => {
+test('ctrl/cmd-click on the DELTA TIME toggle disables/enables the window without losing the entered values (#318)', () => {
   const onDeltaContextChange = vi.fn();
   const onDeltaContextEnabledChange = vi.fn();
   render(
@@ -186,10 +186,50 @@ test('the DELTA TIME toggle disables/enables the context window without losing t
   expect(screen.getByLabelText('Time-Delta-Context before (ms)')).toHaveValue(500);
   expect(screen.getByLabelText('Time-Delta-Context after (ms)')).toHaveValue(250);
 
-  fireEvent.click(screen.getByTitle('Disable Time-Delta-Context (keeps the entered before/after values)'));
+  const toggleBtn = screen.getByTitle(/Time-Delta-Context:/);
+  fireEvent.click(toggleBtn, { ctrlKey: true });
   expect(onDeltaContextEnabledChange).toHaveBeenCalledWith(false);
 
   // Editing a value while enabled still goes through onDeltaContextChange, preserving the other field.
   fireEvent.change(screen.getByLabelText('Time-Delta-Context before (ms)'), { target: { value: '750' } });
   expect(onDeltaContextChange).toHaveBeenCalledWith(750, 250);
+});
+
+test('plain click on the DELTA TIME toggle cycles the per-message flag tristate (#319)', () => {
+  renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+
+  // none -> all: flags every currently visible row.
+  fireEvent.click(screen.getByTitle(/none messages flagged/));
+  expect(screen.getByTitle(/all messages flagged/)).toBeInTheDocument();
+
+  // all -> none: clears every flag.
+  fireEvent.click(screen.getByTitle(/all messages flagged/));
+  expect(screen.getByTitle(/none messages flagged/)).toBeInTheDocument();
+});
+
+test('flagging a single row reports the tristate as "some" (#319)', () => {
+  const { container } = renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  expect(screen.getByTitle(/none messages flagged/)).toBeInTheDocument();
+
+  const row = [...container.querySelectorAll('.log-row')].find(r => r.textContent?.includes('Licht Flur'))!;
+  fireEvent.click(row.querySelector('button[title*="Always show context"]')!);
+
+  expect(screen.getByTitle(/some messages flagged/)).toBeInTheDocument();
+});
+
+test("ctrl/cmd-click on a row's flag applies its new state to every marked row (#319)", () => {
+  const { container } = renderTable();
+  fireEvent.click(screen.getByTitle('Show quick filter bar'));
+  const rows = [...container.querySelectorAll('.log-row')];
+
+  // Mark two rows (row-marks, #310) then ctrl-click a third row's flag.
+  fireEvent.click(rows[0]);
+  fireEvent.click(rows[1], { ctrlKey: true });
+  const flagBtn = rows[2].querySelector('button[title*="Always show context"]')!;
+  fireEvent.click(flagBtn, { ctrlKey: true });
+
+  // All three (the two marked + the clicked one) are now flagged -> tristate is "all".
+  expect(screen.getByTitle(/all messages flagged/)).toBeInTheDocument();
 });

--- a/frontend/src/utils/anchorKey.ts
+++ b/frontend/src/utils/anchorKey.ts
@@ -1,0 +1,10 @@
+import type { Telegram } from '../hooks/useWebSocket';
+
+// Identity of a telegram for anchor tracking across list updates (#202), row
+// marking (#310), and per-message Time-Delta-Context flags (#319). No index
+// fallback here — the same telegram must map to the same key in consecutive
+// lists even when its position shifts. Shared so callers outside the table
+// (the delta-context expansion in App.tsx/HistorySearch.tsx) can test
+// flagged-membership against the same identity.
+export const anchorKey = (t: Telegram) =>
+  `${t.timestamp}-${t.source_address}-${t.target_address}-${t.raw_hex ?? ''}`;

--- a/frontend/src/utils/deltaContextExpansion.test.ts
+++ b/frontend/src/utils/deltaContextExpansion.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { expandWithDeltaContext } from './deltaContextExpansion';
+
+interface Item {
+  key: string;
+  timestamp: string;
+}
+
+const item = (key: string, isoTime: string): Item => ({ key, timestamp: isoTime });
+const keyOf = (i: Item) => i.key;
+
+describe('expandWithDeltaContext', () => {
+  it('with no window, returns only the matching items', () => {
+    const items = [item('a', '2024-01-01T10:00:00Z'), item('b', '2024-01-01T10:00:01Z')];
+    const out = expandWithDeltaContext(items, [true, false], keyOf, new Set(), 0, 0);
+    expect(out.map(keyOf)).toEqual(['a']);
+  });
+
+  it('pulls in non-matching items within the before/after window of a match', () => {
+    const items = [
+      item('a', '2024-01-01T10:00:00.000Z'),
+      item('b', '2024-01-01T10:00:00.500Z'), // +500ms of a, not matching
+      item('c', '2024-01-01T10:00:05.000Z'), // +5s of a, outside window
+    ];
+    const out = expandWithDeltaContext(items, [true, false, false], keyOf, new Set(), 0, 1000);
+    expect(out.map(keyOf)).toEqual(['a', 'b']);
+  });
+
+  it('a flagged item anchors its own window even when it does not match the filter', () => {
+    const items = [
+      item('a', '2024-01-01T10:00:00.000Z'), // flagged, doesn't match
+      item('b', '2024-01-01T10:00:00.500Z'), // near the flagged item
+      item('c', '2024-01-01T10:00:10.000Z'), // far from everything
+    ];
+    const out = expandWithDeltaContext(items, [false, false, false], keyOf, new Set(['a']), 0, 1000);
+    expect(out.map(keyOf)).toEqual(['a', 'b']);
+  });
+
+  it('a flagged item is shown even with no window at all (before=after=0)', () => {
+    const items = [item('a', '2024-01-01T10:00:00Z'), item('b', '2024-01-01T10:00:01Z')];
+    const out = expandWithDeltaContext(items, [false, false], keyOf, new Set(['a']), 0, 0);
+    expect(out.map(keyOf)).toEqual(['a']);
+  });
+
+  it('returns nothing when there are no matches and no flags', () => {
+    const items = [item('a', '2024-01-01T10:00:00Z')];
+    const out = expandWithDeltaContext(items, [false], keyOf, new Set(), 100, 100);
+    expect(out).toEqual([]);
+  });
+
+  it('respects asymmetric before/after windows', () => {
+    const items = [
+      item('before', '2024-01-01T09:59:59.500Z'), // -500ms
+      item('anchor', '2024-01-01T10:00:00.000Z'),
+      item('after', '2024-01-01T10:00:00.500Z'), // +500ms
+    ];
+    const onlyAfter = expandWithDeltaContext(items, [false, true, false], keyOf, new Set(), 0, 1000);
+    expect(onlyAfter.map(keyOf)).toEqual(['anchor', 'after']);
+
+    const onlyBefore = expandWithDeltaContext(items, [false, true, false], keyOf, new Set(), 1000, 0);
+    expect(onlyBefore.map(keyOf)).toEqual(['before', 'anchor']);
+  });
+});

--- a/frontend/src/utils/deltaContextExpansion.ts
+++ b/frontend/src/utils/deltaContextExpansion.ts
@@ -1,0 +1,46 @@
+// Time-Delta-Context expansion (#309/#318/#319): given which telegrams
+// already match the active filters, pull in every other telegram within a
+// before/after window around each matching (or per-message-flagged) telegram
+// — even though it wouldn't otherwise pass the filter. Shared by the live
+// Group Monitor and History Search views so the algorithm can't drift.
+
+interface Timestamped {
+  timestamp: string;
+}
+
+/**
+ * @param items The full (already sorted) buffer.
+ * @param matches Per-item result of the primary filter match, same order as `items`.
+ * @param anchorKeyOf Stable per-item identity, for testing `flaggedKeys` membership.
+ * @param flaggedKeys Keys of telegrams individually flagged to always anchor a
+ *   context window around themselves (#319), regardless of the primary filter.
+ * @param beforeMs / @param afterMs The effective (already #318-gated) window.
+ */
+export function expandWithDeltaContext<T extends Timestamped>(
+  items: T[],
+  matches: boolean[],
+  anchorKeyOf: (t: T) => string,
+  flaggedKeys: ReadonlySet<string>,
+  beforeMs: number,
+  afterMs: number,
+): T[] {
+  // A flagged telegram is always shown and always anchors its own window,
+  // independent of whether it passes the primary filter.
+  const effectiveMatch = items.map((t, i) => matches[i] || flaggedKeys.has(anchorKeyOf(t)));
+
+  if (beforeMs <= 0 && afterMs <= 0) {
+    return items.filter((_, i) => effectiveMatch[i]);
+  }
+
+  const anchorTimestamps = items
+    .filter((_, i) => effectiveMatch[i])
+    .map(t => new Date(t.timestamp).getTime());
+
+  if (anchorTimestamps.length === 0) return [];
+
+  return items.filter((t, i) => {
+    if (effectiveMatch[i]) return true;
+    const ts = new Date(t.timestamp).getTime();
+    return anchorTimestamps.some(mts => ts >= mts - beforeMs && ts <= mts + afterMs);
+  });
+}


### PR DESCRIPTION
## Summary
- **Per-message flag**: each telegram row gets a `Circle`/`CircleDot` toggle in its Δt cell. Flagging a message always anchors a context window around itself — pulling in its before/after neighbors even when the row itself doesn't match the active filters (the typical workflow: spot something unexpected in a filtered view, flag it, see the unfiltered history around that exact moment). Ctrl/cmd-click applies the new flag state to every currently marked row (#310's row marks, reused here as a multi-select basis).
- **Shared expansion algorithm**: extracted into `utils/deltaContextExpansion.ts` (unit tested) and wired into *both* the live Group Monitor (`App.tsx`) and History Search — History Search previously had no client-side delta expansion at all, since the window was assumed fully handled server-side at query time. Per-message flags are set after the data is already loaded, so this view needed the same client-side pass.
- **DELTA TIME header toggle becomes a true tristate** (#318 → #319): none/some/all, reflecting the flags on currently visible rows. Plain click cycles none↔all (or clears down from "some"); ctrl/cmd-click keeps its #318 role of toggling the window fully on/off, which now also suppresses flags while off (per the spec's "preserving all per-message flags" — inert, not cleared).
- Moved the shared `anchorKey()` row-identity function (previously local to `TelegramTable`, backing row marks) into `utils/anchorKey.ts` so `App.tsx`/`HistorySearch.tsx` can test flagged-membership against the same identity without re-exporting a non-component value from the table file (would trip the fast-refresh lint rule).

**Not implemented**: new telegrams auto-inheriting the flag while the tristate reads "all". This is a real part of the original spec but a low-value edge case (per-message flags are for specific messages of interest, not literally everything), and adds real complexity interacting with the rolling live buffer's eviction. Flagging it here in case it's wanted later.

Closes #319

## Test plan
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 347/347 passing: new `deltaContextExpansion.test.ts` (6 cases covering flagged-anchor behavior, asymmetric windows, zero-window flagging) plus new `TelegramTableQuickFilter.test.tsx` cases for the tristate cycle, ctrl-click-to-marked-rows, and single-row flagging
- [x] Verified in a running instance (Vite dev server + Playwright, telegrams injected over a stubbed WebSocket): flagged an "Unrelated" telegram's row via its flag icon, then applied a real active-filters target restriction to a different address — the flagged row stayed visible (buffer showed 2/3) while an unflagged telegram to the same unrelated address was correctly hidden, confirming the flag bypasses the filter end-to-end through the real `App.tsx` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)
