### PR TITLE
feat: mark filtered vs unfiltered context messages (#343)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -613,7 +613,7 @@ function App() {
   );
 
   // ── In-memory filtering (live view) ────────────────────────────────────────
-  const filteredLiveTelegrams = useMemo(() => {
+  const deltaExpandedLive = useMemo(() => {
     const f = activeFilters;
     // Master toggle off (#370): show everything, keep the filter set intact.
     const noFilter =
@@ -635,6 +635,9 @@ function App() {
 
     return expandWithDeltaContext(sortedLiveTelegrams, matches, anchorKey, flags, deltaBeforeMs, deltaAfterMs);
   }, [sortedLiveTelegrams, activeFilters, filtersEnabled, flaggedTelegramKeys]);
+  const filteredLiveTelegrams = deltaExpandedLive.items;
+  // Keys of rows shown only as unfiltered context around a match/flag (#343).
+  const contextTelegramKeys = deltaExpandedLive.contextKeys;
 
   // ── Count bubbles (live only) ───────────────────────────────────────────────
   const filterCounts = useMemo((): FilterCounts => {
@@ -1223,6 +1226,7 @@ function App() {
                     onLastMarkedKeyChange={setLastMarkedTelegramKey}
                     flaggedKeys={flaggedTelegramKeys}
                     onFlaggedKeysChange={setFlaggedTelegramKeys}
+                    contextKeys={contextTelegramKeys}
                     infoBarOpen={infoBarOpen}
                     onInfoBarOpenChange={setInfoBarOpen}
                   />

--- a/frontend/src/components/HistorySearch.tsx
+++ b/frontend/src/components/HistorySearch.tsx
@@ -148,13 +148,16 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
   // immediately applies to already-loaded data without a re-fetch. Also
   // applies the Time-Delta-Context window client-side (#309/#319), since
   // per-message flags are set after the historical load already happened.
-  const filteredSortedTelegrams = useMemo(() => {
+  const deltaExpandedHistory = useMemo(() => {
     const noFilter = !hasActiveFilters(activeFilters);
     const matches = sortedTelegrams.map(t => noFilter || matchesTelegram(t, activeFilters));
     const { before, after } = effectiveDeltaContext(activeFilters);
     const flags = activeFilters.deltaContextEnabled ? new Set(flaggedKeys) : EMPTY_FLAG_SET;
     return expandWithDeltaContext(sortedTelegrams, matches, anchorKey, flags, before, after);
   }, [sortedTelegrams, activeFilters, flaggedKeys]);
+  const filteredSortedTelegrams = deltaExpandedHistory.items;
+  // Keys of rows shown only as unfiltered context around a match/flag (#343).
+  const contextTelegramKeys = deltaExpandedHistory.contextKeys;
 
   // True when current filters are less restrictive than what was used to fetch,
   // meaning some telegrams may be missing from the loaded set.
@@ -349,6 +352,7 @@ export const HistorySearch: React.FC<HistorySearchProps> = ({
               onDeltaContextEnabledChange={handleDeltaContextEnabledChange}
               flaggedKeys={flaggedKeys}
               onFlaggedKeysChange={setFlaggedKeys}
+              contextKeys={contextTelegramKeys}
             />
           )}
         </div>

--- a/frontend/src/components/TelegramTable.test.tsx
+++ b/frontend/src/components/TelegramTable.test.tsx
@@ -4,6 +4,7 @@ import { TelegramTable, type SortConfig } from './TelegramTable';
 import { makeTelegram } from '../test/telegramFactory';
 import type { Telegram } from '../hooks/useWebSocket';
 import { DEFAULT_FILTERS } from '../types/filters';
+import { anchorKey } from '../utils/anchorKey';
 
 // jsdom has no layout: give the virtualizer a viewport and rows a rect so it
 // renders items and the anchor logic finds rows.
@@ -288,4 +289,54 @@ test('quick info bar (#311): toggled via the header button and summarizes the vi
   expect(screen.getByText(/4 telegrams/)).toBeInTheDocument();
   expect(screen.getByText(/Oldest:/)).toBeInTheDocument();
   expect(screen.getByText(/Newest:/)).toBeInTheDocument();
+});
+
+test('context rows (#343): marked with a distinct class/tooltip and counted in the info bar', () => {
+  const rows = makeList(3, 2);
+  const contextKeys = new Set([anchorKey(rows[1])]); // the middle row is context-only
+
+  const { container } = render(
+    <TelegramTable
+      telegrams={rows}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+      contextKeys={contextKeys}
+    />,
+  );
+
+  const logRows = [...container.querySelectorAll('.log-row')];
+  expect(logRows.filter(r => r.classList.contains('context'))).toHaveLength(1);
+  expect(logRows.find(r => r.classList.contains('context'))).toHaveAttribute(
+    'title', 'Unfiltered Time-Delta-Context — this telegram did not match the active filters'
+  );
+
+  fireEvent.click(screen.getByTitle('Show info bar'));
+  expect(screen.getByText(/1 context/)).toBeInTheDocument();
+});
+
+test('context rows (#343): marking a context row hides the context styling in favor of the mark', () => {
+  const rows = makeList(3, 2);
+  const contextKeys = new Set([anchorKey(rows[1])]);
+
+  const { container } = render(
+    <TelegramTable
+      telegrams={rows}
+      visibleColumns={visibleColumns}
+      sortConfig={sortConfig}
+      onSort={vi.fn()}
+      activeFilters={DEFAULT_FILTERS}
+      onQuickFilter={vi.fn()}
+      onQuickVisualize={vi.fn()}
+      contextKeys={contextKeys}
+    />,
+  );
+
+  const logRows = [...container.querySelectorAll('.log-row')];
+  fireEvent.click(logRows[1]); // mark the context row
+  expect(logRows[1].classList.contains('marked')).toBe(true);
+  expect(logRows[1].classList.contains('context')).toBe(false);
 });

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -61,6 +61,11 @@ interface TelegramTableProps {
   // individually flagged to always anchor a context window around themselves.
   flaggedKeys?: string[];
   onFlaggedKeysChange?: (keys: string[]) => void;
+
+  /** Keys (via the same anchor identity) of rows present only as unfiltered
+   * Time-Delta-Context around a match/flag, not because they matched the
+   * active filters themselves — marked with a distinct background (#343). */
+  contextKeys?: ReadonlySet<string>;
 }
 
 type ColId = 'time' | 'delta' | 'source' | 'target' | 'type' | 'dpt' | 'value';
@@ -230,6 +235,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   markedKeys, onMarkedKeysChange, lastMarkedKey, onLastMarkedKeyChange,
   infoBarOpen, onInfoBarOpenChange,
   flaggedKeys, onFlaggedKeysChange,
+  contextKeys,
 }) => {
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -489,6 +495,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
     const targets = new Set<string>();
     const dpts = new Set<string>();
     const typeCounts = new Map<string, number>();
+    let contextCount = 0;
     telegramRows.forEach((t, i) => {
       if (new Date(t.timestamp) < new Date(telegramRows[oldestIdx].timestamp)) oldestIdx = i;
       if (new Date(t.timestamp) > new Date(telegramRows[newestIdx].timestamp)) newestIdx = i;
@@ -501,6 +508,7 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
       dpts.add(t.dpt_name ?? (t.dpt_main != null ? `DPT ${t.dpt_main}` : 'unknown'));
       const type = t.simplified_type || t.telegram_type;
       typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1);
+      if (contextKeys?.has(anchorKey(t))) contextCount++;
     });
     return {
       count: telegramRows.length,
@@ -510,8 +518,9 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
       targetCount: targets.size,
       dptCount: dpts.size,
       typeCounts: [...typeCounts.entries()].sort((a, b) => b[1] - a[1]),
+      contextCount,
     };
-  }, [telegramRows]);
+  }, [telegramRows, contextKeys]);
 
   const virtualizer = useVirtualizer({
     count: telegramRows.length,
@@ -1124,6 +1133,11 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
             {infoMetrics.typeCounts.map(([type, n]) => (
               <span key={type} style={infoChipStyle}>{type}: {n}</span>
             ))}
+            {infoMetrics.contextCount > 0 && (
+              <span style={infoChipStyle} title="Rows shown only as unfiltered Time-Delta-Context, not real filter matches (#343)">
+                {infoMetrics.contextCount} context
+              </span>
+            )}
           </div>
         </div>
       )}
@@ -1403,6 +1417,9 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
               const marked = markedSet.has(key);
               // The most-recently-clicked row is the most prominent (#310).
               const latest = marked && key === lastMarked;
+              // Present only as unfiltered Time-Delta-Context, not a real filter
+              // match (#343) — a distinct wash, but marks still take priority.
+              const isContext = !marked && !!contextKeys?.has(key);
               return (
                 <div
                   key={virtualRow.key}
@@ -1422,17 +1439,22 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
                     fontSize: '0.8125rem',
                     // Marked rows get an accent wash that overrides the zebra
                     // stripe; the latest click is washed more strongly and gets
-                    // an accent bar. color-mix adapts to the theme's accent.
+                    // an accent bar. Context-only rows get a distinct (warning-
+                    // hued) wash instead, so they read apart from real matches.
+                    // color-mix adapts to the theme's accent/warning colors.
                     background: latest
                       ? 'color-mix(in srgb, var(--accent-primary) 34%, transparent)'
                       : marked
                         ? 'color-mix(in srgb, var(--accent-primary) 16%, transparent)'
-                        : (virtualRow.index + stripeOffset) % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
+                        : isContext
+                          ? 'color-mix(in srgb, var(--warning, #f59e0b) 12%, transparent)'
+                          : (virtualRow.index + stripeOffset) % 2 === 0 ? 'var(--bg-subtle)' : 'transparent',
                     boxShadow: latest ? 'inset 3px 0 0 0 var(--accent-primary)' : undefined,
                     alignItems: 'start',
                     minHeight: '60px' // Ensure a minimum touch/visual target
                   }}
-                  className={`log-row${marked ? ' marked' : ''}${latest ? ' latest' : ''}`}
+                  title={isContext ? 'Unfiltered Time-Delta-Context — this telegram did not match the active filters' : undefined}
+                  className={`log-row${marked ? ' marked' : ''}${latest ? ' latest' : ''}${isContext ? ' context' : ''}`}
                 >
                   {visibleCols.map(c => (
                     <React.Fragment key={c.id}>{renderCell(c.id, t)}</React.Fragment>

--- a/frontend/src/utils/deltaContextExpansion.test.ts
+++ b/frontend/src/utils/deltaContextExpansion.test.ts
@@ -10,42 +10,47 @@ const item = (key: string, isoTime: string): Item => ({ key, timestamp: isoTime 
 const keyOf = (i: Item) => i.key;
 
 describe('expandWithDeltaContext', () => {
-  it('with no window, returns only the matching items', () => {
+  it('with no window, returns only the matching items and no context keys', () => {
     const items = [item('a', '2024-01-01T10:00:00Z'), item('b', '2024-01-01T10:00:01Z')];
     const out = expandWithDeltaContext(items, [true, false], keyOf, new Set(), 0, 0);
-    expect(out.map(keyOf)).toEqual(['a']);
+    expect(out.items.map(keyOf)).toEqual(['a']);
+    expect(out.contextKeys).toEqual(new Set());
   });
 
-  it('pulls in non-matching items within the before/after window of a match', () => {
+  it('pulls in non-matching items within the before/after window of a match, tagged as context (#343)', () => {
     const items = [
       item('a', '2024-01-01T10:00:00.000Z'),
       item('b', '2024-01-01T10:00:00.500Z'), // +500ms of a, not matching
       item('c', '2024-01-01T10:00:05.000Z'), // +5s of a, outside window
     ];
     const out = expandWithDeltaContext(items, [true, false, false], keyOf, new Set(), 0, 1000);
-    expect(out.map(keyOf)).toEqual(['a', 'b']);
+    expect(out.items.map(keyOf)).toEqual(['a', 'b']);
+    expect(out.contextKeys).toEqual(new Set(['b']));
   });
 
-  it('a flagged item anchors its own window even when it does not match the filter', () => {
+  it('a flagged item anchors its own window even when it does not match the filter, and is not itself context', () => {
     const items = [
       item('a', '2024-01-01T10:00:00.000Z'), // flagged, doesn't match
       item('b', '2024-01-01T10:00:00.500Z'), // near the flagged item
       item('c', '2024-01-01T10:00:10.000Z'), // far from everything
     ];
     const out = expandWithDeltaContext(items, [false, false, false], keyOf, new Set(['a']), 0, 1000);
-    expect(out.map(keyOf)).toEqual(['a', 'b']);
+    expect(out.items.map(keyOf)).toEqual(['a', 'b']);
+    expect(out.contextKeys).toEqual(new Set(['b'])); // 'a' is flagged, not context
   });
 
   it('a flagged item is shown even with no window at all (before=after=0)', () => {
     const items = [item('a', '2024-01-01T10:00:00Z'), item('b', '2024-01-01T10:00:01Z')];
     const out = expandWithDeltaContext(items, [false, false], keyOf, new Set(['a']), 0, 0);
-    expect(out.map(keyOf)).toEqual(['a']);
+    expect(out.items.map(keyOf)).toEqual(['a']);
+    expect(out.contextKeys).toEqual(new Set());
   });
 
   it('returns nothing when there are no matches and no flags', () => {
     const items = [item('a', '2024-01-01T10:00:00Z')];
     const out = expandWithDeltaContext(items, [false], keyOf, new Set(), 100, 100);
-    expect(out).toEqual([]);
+    expect(out.items).toEqual([]);
+    expect(out.contextKeys).toEqual(new Set());
   });
 
   it('respects asymmetric before/after windows', () => {
@@ -55,9 +60,11 @@ describe('expandWithDeltaContext', () => {
       item('after', '2024-01-01T10:00:00.500Z'), // +500ms
     ];
     const onlyAfter = expandWithDeltaContext(items, [false, true, false], keyOf, new Set(), 0, 1000);
-    expect(onlyAfter.map(keyOf)).toEqual(['anchor', 'after']);
+    expect(onlyAfter.items.map(keyOf)).toEqual(['anchor', 'after']);
+    expect(onlyAfter.contextKeys).toEqual(new Set(['after']));
 
     const onlyBefore = expandWithDeltaContext(items, [false, true, false], keyOf, new Set(), 1000, 0);
-    expect(onlyBefore.map(keyOf)).toEqual(['before', 'anchor']);
+    expect(onlyBefore.items.map(keyOf)).toEqual(['before', 'anchor']);
+    expect(onlyBefore.contextKeys).toEqual(new Set(['before']));
   });
 });

--- a/frontend/src/utils/deltaContextExpansion.ts
+++ b/frontend/src/utils/deltaContextExpansion.ts
@@ -8,6 +8,15 @@ interface Timestamped {
   timestamp: string;
 }
 
+export interface DeltaExpansionResult<T> {
+  /** The full visible set: filter matches, flagged anchors, and pulled-in context rows. */
+  items: T[];
+  /** Identity keys (via `anchorKeyOf`) of items present only because they fell
+   * within a window — i.e. they neither matched the filter nor were flagged.
+   * Used to visually mark context-only rows (#343). */
+  contextKeys: Set<string>;
+}
+
 /**
  * @param items The full (already sorted) buffer.
  * @param matches Per-item result of the primary filter match, same order as `items`.
@@ -23,24 +32,28 @@ export function expandWithDeltaContext<T extends Timestamped>(
   flaggedKeys: ReadonlySet<string>,
   beforeMs: number,
   afterMs: number,
-): T[] {
+): DeltaExpansionResult<T> {
   // A flagged telegram is always shown and always anchors its own window,
   // independent of whether it passes the primary filter.
   const effectiveMatch = items.map((t, i) => matches[i] || flaggedKeys.has(anchorKeyOf(t)));
 
   if (beforeMs <= 0 && afterMs <= 0) {
-    return items.filter((_, i) => effectiveMatch[i]);
+    return { items: items.filter((_, i) => effectiveMatch[i]), contextKeys: new Set() };
   }
 
   const anchorTimestamps = items
     .filter((_, i) => effectiveMatch[i])
     .map(t => new Date(t.timestamp).getTime());
 
-  if (anchorTimestamps.length === 0) return [];
+  if (anchorTimestamps.length === 0) return { items: [], contextKeys: new Set() };
 
-  return items.filter((t, i) => {
+  const contextKeys = new Set<string>();
+  const kept = items.filter((t, i) => {
     if (effectiveMatch[i]) return true;
     const ts = new Date(t.timestamp).getTime();
-    return anchorTimestamps.some(mts => ts >= mts - beforeMs && ts <= mts + afterMs);
+    const within = anchorTimestamps.some(mts => ts >= mts - beforeMs && ts <= mts + afterMs);
+    if (within) contextKeys.add(anchorKeyOf(t));
+    return within;
   });
+  return { items: kept, contextKeys };
 }


### PR DESCRIPTION
## Summary
- `expandWithDeltaContext` (introduced in #319) now returns `{ items, contextKeys }` instead of a bare array. `contextKeys` identifies rows present *only* because they fell within a Time-Delta-Context window — as opposed to rows that matched the active filters directly or were individually flagged (#319). Flagged/matching anchors stay unmarked, since they're real matches, not passive context.
- `TelegramTable` accepts a new `contextKeys` prop and gives those rows a distinct (warning-hued) background wash plus an explanatory tooltip, so it's immediately clear which rows are "really" filtered vs. pulled in around them. Row marks (#310) take visual priority when a row is both marked and context.
- The quick info bar (#311) now reports the context-row count when it's nonzero.
- Wired through both the live Group Monitor (`App.tsx`) and History Search, since both already compute the expansion via the shared utility from #319.

Closes #343

## Test plan
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 349/349 passing: updated `deltaContextExpansion.test.ts` for the new `{items, contextKeys}` shape (with explicit assertions that flagged/matching anchors are *not* tagged as context), and two new `TelegramTable.test.tsx` cases (context rows get the distinct class + tooltip and are counted in the info bar; marking a context row promotes it over the context styling)
- [x] Verified in a running instance (Vite dev server + Playwright, telegrams injected over a stubbed WebSocket): filtered to one target, then opened a 2s "after" Time-Delta-Context window — a nearby unrelated telegram appeared with the `context` class, the correct tooltip, and a visually distinct amber background, while the actual filter match stayed unmarked and a telegram far outside the window stayed hidden; the info bar correctly showed "1 context"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
