### PR TITLE
feat: visualization crowded-chart legend, hover highlight, and per-metric lock (#349)

### DIFF
--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useLayoutEffect, useState, useMemo } from 'react';
 import UplotReact from 'uplot-react';
 import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';
+import { Lock, LockOpen, ChevronDown, ChevronRight } from 'lucide-react';
 import type { ChartBucket } from '../hooks/useChartData';
 import { useThemeTick } from '../hooks/useTheme';
 import { seriesColor } from '../utils/seriesColors';
@@ -20,15 +21,45 @@ interface MixedChartProps {
    * (#340). When zoomed, stays false to preserve the app-controlled range (#281). */
   autoFollow?: boolean;
   onZoomRangeChange?: (value: [number, number] | null) => void;
+  /** "2/3" when this is one of several charts split off this metric by locking (#349). */
+  groupLabel?: string;
+  /** Whether this (the unit's currently-open) chart is locked against further GAs (#349). */
+  locked?: boolean;
+  onToggleLock?: () => void;
 }
 
 // Ensure we have a shared sync cursor across all charts
 const syncCursor = uPlot.sync('knx-time-axis');
-const LEFT_GUTTER = 150;
+const MIN_GUTTER = 60;
+const MAX_GUTTER = 220;
 
-export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime, stepped, showDots, autoFollow = false, onZoomRangeChange }) => {
+// Reused scratch canvas for text measurement (created lazily, once).
+let measureCanvas: HTMLCanvasElement | null = null;
+
+// Widens the y-axis gutter to fit the largest expected tick label instead of a
+// fixed guess, so e.g. "30000 lx" isn't clipped at the left edge (#349).
+const measureGutterWidth = (series: ChartBucket['series'], unit: string): number => {
+  let maxAbs = 0;
+  for (const s of series) {
+    for (const v of s.data) {
+      if (v != null && Math.abs(v) > maxAbs) maxAbs = Math.abs(v);
+    }
+  }
+  const sample = `${Math.ceil(maxAbs).toLocaleString()} ${unit}`;
+  measureCanvas ??= document.createElement('canvas');
+  const ctx = measureCanvas.getContext('2d');
+  if (!ctx) return MIN_GUTTER + 90;
+  ctx.font = '11px sans-serif'; // approximates uPlot's default axis label font
+  return Math.min(MAX_GUTTER, Math.max(MIN_GUTTER, Math.ceil(ctx.measureText(sample).width) + 30));
+};
+
+export const MixedChart: React.FC<MixedChartProps> = ({
+  bucket, minTime, maxTime, stepped, showDots, autoFollow = false, onZoomRangeChange,
+  groupLabel, locked, onToggleLock,
+}) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
+  const [legendOpen, setLegendOpen] = useState(true);
   const themeTick = useThemeTick();
 
   // Resize observer to keep chart fluid
@@ -42,6 +73,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
   }, []);
 
   const { unit, isBinary, timestamps, series } = bucket;
+  const leftGutter = useMemo(() => measureGutterWidth(series, unit), [series, unit]);
 
   // Show a date alongside times once the visible range crosses midnight (#281).
   const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
@@ -58,7 +90,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
   // uplot-react updates via setData instead of destroying and recreating the
   // chart — which would drop the cursor/hover on every telegram (#207).
   const structureKey = [
-    width, isBinary, unit, stepped, showDots, themeTick,
+    width, isBinary, unit, stepped, showDots, themeTick, leftGutter,
     minTime, maxTime,
     series.map(s => `${s.address}~${s.name}`).join('|'),
   ].join('§');
@@ -74,10 +106,19 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
   // eslint-disable-next-line react-hooks/refs
   realIndicesRef.current = series.map(s => s.real.flatMap((r, i) => (r ? [i] : [])));
 
+  // Fixed legend (#349): unlike uPlot's native legend, this doesn't move
+  // around under the cursor. Each row's value tracks the hovered x-position
+  // (or the series' last value while not hovering), and the row whose plotted
+  // y-position is nearest the cursor is highlighted so a crowded chart's
+  // hovered line is identifiable.
+  const legendValueRefs = useRef<(HTMLSpanElement | null)[]>([]);
+  const legendRowRefs = useRef<(HTMLDivElement | null)[]>([]);
+
   const options: uPlot.Options = useMemo(() => {
     const style = getComputedStyle(document.documentElement);
     const gridStroke = style.getPropertyValue('--border-subtle').trim();
     const axisStroke = style.getPropertyValue('--text-dim').trim();
+    const hoverColor = style.getPropertyValue('--accent-primary').trim() || '#6366f1';
 
     // Configure Y-Axis scale limits based on smart defaults
     let scaleConfig: uPlot.Scale = {};
@@ -97,6 +138,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
       width,
       height: isBinary ? Math.max(150, series.length * 50) : 300,
       padding: [8, 16, 8, 0],
+      legend: { show: false }, // replaced by the fixed overlay legend below (#349)
       cursor: {
         sync: { key: syncCursor.key },
         drag: { x: true, y: false, setScale: false }
@@ -112,6 +154,33 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
           const addr = series[idx - 1]?.address;
           if (addr) setSeriesHidden(addr, !opts.show);
         }],
+        setCursor: [
+          (u) => {
+            const idx = u.cursor.idx;
+            const isOutside = u.cursor.left == null || u.cursor.left < 0;
+            let nearestIdx = -1;
+            let nearestDist = Infinity;
+            series.forEach((s, sIdx) => {
+              const val = isOutside || idx == null ? s.data[s.data.length - 1] : s.data[idx];
+              const el = legendValueRefs.current[sIdx];
+              if (el) {
+                el.textContent = val == null ? '–' : isBinary ? (val === 1 ? 'On' : 'Off') : `${val} ${unit}`;
+              }
+              // Nearest-to-cursor row (by plotted y pixel), for the hover highlight.
+              if (!isOutside && idx != null && val != null) {
+                const yPos = u.valToPos(val, 'y');
+                const dist = Math.abs(yPos - (u.cursor.top ?? -Infinity));
+                if (dist < nearestDist) { nearestDist = dist; nearestIdx = sIdx; }
+              }
+            });
+            legendRowRefs.current.forEach((row, sIdx) => {
+              if (!row) return;
+              const hot = !isOutside && sIdx === nearestIdx && nearestDist < 40;
+              row.style.background = hot ? `color-mix(in srgb, ${hoverColor} 16%, transparent)` : 'transparent';
+              row.style.fontWeight = hot ? '700' : '500';
+            });
+          }
+        ],
         setSelect: [
           (u) => {
             if (u.select.width > 0) {
@@ -150,7 +219,7 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
           space: 30,
           grid: { stroke: gridStroke, width: 1 },
           stroke: axisStroke,
-          size: LEFT_GUTTER,
+          size: leftGutter,
           values: isBinary
             ? (_u, splits) => splits.map(v => v === 1 ? 'ON' : v === 0 ? 'OFF' : '')
             : undefined
@@ -184,19 +253,93 @@ export const MixedChart: React.FC<MixedChartProps> = ({ bucket, minTime, maxTime
 
   return (
     <div style={{ marginBottom: '2rem', background: 'var(--bg-inset)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)' }}>
-      <h4 style={{ margin: '0 0 1rem', fontSize: '0.9rem', color: 'var(--text-main)' }}>
-        {isBinary ? 'Binary States (Ein/Aus)' : `Metrics (${unit})`}
-      </h4>
-      <div ref={containerRef} style={{ width: '100%', overflow: 'hidden' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' }}>
+        <h4 style={{ margin: 0, fontSize: '0.9rem', color: 'var(--text-main)', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+          {isBinary ? 'Binary States (Ein/Aus)' : `Metrics (${unit})`}
+          {groupLabel && (
+            <span style={{ fontSize: '0.7rem', fontWeight: 400, color: 'var(--text-dim)' }}>{groupLabel}</span>
+          )}
+        </h4>
+        {onToggleLock && (
+          <button
+            onClick={onToggleLock}
+            title={locked
+              ? 'Unlock: further selected GAs of this metric will join this chart again'
+              : 'Lock: prevent further selected GAs of this metric from crowding this chart — they start a new one instead'}
+            style={{
+              display: 'flex', alignItems: 'center', gap: '0.3rem', background: 'transparent',
+              border: '1px solid var(--border-color)', borderRadius: '6px', padding: '0.25rem 0.5rem',
+              fontSize: '0.7rem', cursor: 'pointer',
+              color: locked ? 'var(--accent-primary)' : 'var(--text-dim)',
+            }}
+          >
+            {locked ? <Lock size={12} /> : <LockOpen size={12} />}
+            {locked ? 'Locked' : 'Lock'}
+          </button>
+        )}
+      </div>
+      <div ref={containerRef} style={{ width: '100%', overflow: 'hidden', position: 'relative' }}>
          {/* Re-fit to new data only while not zoomed (#340): keeps a new telegram
              visible instead of dropping off a frozen scale. When the user has
              zoomed, autoFollow is false so the range is preserved (#281). */}
          <UplotReact options={options} data={data} resetScales={autoFollow} />
+
+         {/* Fixed legend (#349): stays put while hovering, unlike uPlot's native
+             legend, and shows each GA's value at the hovered x-position. */}
+         <div style={{
+           position: 'absolute', top: 4, right: 4, zIndex: 10,
+           // --bg-inset (and every --bg-* token) is intentionally translucent
+           // for this app's glass-panel look, but a plotted line crossing
+           // behind a legend row at the same height reads badly through it —
+           // --bg-dark is the one fully opaque token, used here instead.
+           background: 'var(--bg-dark)',
+           boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
+           border: '1px solid var(--border-color)', borderRadius: '6px',
+           maxWidth: '55%', pointerEvents: 'auto',
+         }}>
+           <button
+             onClick={() => setLegendOpen(o => !o)}
+             style={{
+               display: 'flex', alignItems: 'center', gap: '0.25rem', width: '100%',
+               background: 'transparent', border: 'none', cursor: 'pointer',
+               padding: '0.25rem 0.4rem', fontSize: '0.65rem', color: 'var(--text-dim)',
+             }}
+           >
+             {legendOpen ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+             {series.length} GA{series.length !== 1 ? 's' : ''}
+           </button>
+           {legendOpen && (
+             <div style={{ maxHeight: '160px', overflowY: 'auto', padding: '0 0.4rem 0.35rem' }}>
+               {series.map((s, sIdx) => (
+                 <div
+                   key={s.address}
+                   ref={el => { legendRowRefs.current[sIdx] = el; }}
+                   style={{
+                     display: 'flex', alignItems: 'center', gap: '0.35rem',
+                     padding: '0.15rem 0.3rem', borderRadius: '4px', fontSize: '0.68rem',
+                     transition: 'background 0.1s',
+                   }}
+                 >
+                   <span style={{ width: 8, height: 8, borderRadius: '50%', background: seriesColor(s.address), flexShrink: 0 }} />
+                   <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--text-main)' }} title={s.name}>
+                     {s.name}
+                   </span>
+                   <span
+                     ref={el => { legendValueRefs.current[sIdx] = el; }}
+                     style={{ marginLeft: 'auto', flexShrink: 0, color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}
+                   >
+                     {s.data[s.data.length - 1] == null ? '–' : isBinary ? (s.data[s.data.length - 1] === 1 ? 'On' : 'Off') : `${s.data[s.data.length - 1]} ${unit}`}
+                   </span>
+                 </div>
+               ))}
+             </div>
+           )}
+         </div>
       </div>
       {/* Always spell out the visible window's start and end, so the range is
           readable even when the axis ticks are sparse or zoomed out (#314). */}
       {minTime != null && maxTime != null && (
-        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.35rem', paddingLeft: `${LEFT_GUTTER}px`, paddingRight: '16px', fontSize: '0.7rem', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.35rem', paddingLeft: `${leftGutter}px`, paddingRight: '16px', fontSize: '0.7rem', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>
           <span>{formatFullTime(minTime, multiDay)}</span>
           <span>{formatFullTime(maxTime, multiDay)}</span>
         </div>

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -9,6 +9,7 @@ import { Download, Link2, Check, X } from 'lucide-react';
 import { getPref, setPref } from '../utils/prefs';
 import { clearSeriesHidden } from '../utils/legendVisibility';
 import { expandDegenerateRange } from '../utils/timeRange';
+import { splitLockedBuckets } from '../utils/chartLock';
 
 interface VisualizerProps {
   telegrams: Telegram[];
@@ -64,10 +65,32 @@ export const Visualizer: React.FC<VisualizerProps> = ({
     return new Set([...rawArray].filter(a => !decoded.has(a)));
   }, [telegrams]);
 
-  const { buckets, minTime, maxTime } = useChartData(telegrams, selectedTargets, dptOverrides);
+  const { buckets, minTime, maxTime, addressToUnit } = useChartData(telegrams, selectedTargets, dptOverrides);
   const [stepped, setStepped] = useState(() => getPref('chartStepped') !== 'false');
   const [showDots, setShowDots] = useState(() => getPref('chartDots') !== 'false');
   const [linkCopied, setLinkCopied] = useState(false);
+
+  // Per-metric chart "lock" (#349): a locked chart stops taking further GAs of
+  // its unit — the next one selected spawns a new chart instead of crowding
+  // the existing one. Thresholds are "GAs assigned so far" counts (by
+  // selection order) at each lock action; see utils/chartLock.ts.
+  const [lockThresholds, setLockThresholds] = useState<Record<string, number[]>>({});
+  const displayBuckets = useMemo(
+    () => splitLockedBuckets(buckets, selectedTargets, addressToUnit, lockThresholds),
+    [buckets, selectedTargets, addressToUnit, lockThresholds]
+  );
+  // `openGroupSize` is the currently-open chart's own GA count (for that
+  // unit), read fresh from `displayBuckets` at the call site. If the most
+  // recent threshold exactly equals it, nothing has been added since that
+  // lock — toggling again undoes it; otherwise a new lock closes it off.
+  const toggleLock = (unit: string, openGroupSize: number) => {
+    setLockThresholds(prev => {
+      const existing = prev[unit] ?? [];
+      const alreadyLocked = existing.length > 0 && existing[existing.length - 1] === openGroupSize;
+      const next = alreadyLocked ? existing.slice(0, -1) : [...existing, openGroupSize];
+      return { ...prev, [unit]: next };
+    });
+  };
 
   const defaultRange = useMemo<[number, number]>(() => {
     // Pad a zero-width extent (a single telegram, or several at the same instant)
@@ -137,11 +160,18 @@ export const Visualizer: React.FC<VisualizerProps> = ({
 
   const charts = (
     <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: embed ? '0.75rem' : '1.5rem' }}>
-      {buckets.map(b => (
-        b.isBinary ? (
-          <TimelineChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} />
+      {displayBuckets.map(g => (
+        g.bucket.isBinary ? (
+          <TimelineChart key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} />
         ) : (
-          <MixedChart key={b.unit} bucket={b} minTime={activeRange[0]} maxTime={activeRange[1]} stepped={stepped} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} />
+          <MixedChart
+            key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]}
+            stepped={stepped} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange}
+            groupLabel={g.groupCount > 1 ? `${g.groupIndex}/${g.groupCount}` : undefined}
+            // Only the unit's currently-open chart is lockable; earlier ones are permanently closed (#349).
+            locked={g.isLatest ? (lockThresholds[g.bucket.unit]?.at(-1) === g.bucket.series.length) : undefined}
+            onToggleLock={g.isLatest ? () => toggleLock(g.bucket.unit, g.bucket.series.length) : undefined}
+          />
         )
       ))}
 

--- a/frontend/src/hooks/useChartData.test.ts
+++ b/frontend/src/hooks/useChartData.test.ts
@@ -43,6 +43,25 @@ describe('useChartData — DPT backfill / duplicate graphs (#206)', () => {
   });
 });
 
+describe('useChartData — addressToUnit (#349 chart lock)', () => {
+  test('maps every plotted GA to its bucket unit', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 20 }),
+      at(2, { target_address: '1/1/2', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 21 }),
+      at(3, { target_address: '1/1/3', dpt_main: 1, value_json: true }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1', '1/1/2', '1/1/3']));
+    expect(result.current.addressToUnit).toEqual({
+      '1/1/1': '°C', '1/1/2': '°C', '1/1/3': 'binary',
+    });
+  });
+
+  test('is empty when nothing is selected', () => {
+    const { result } = renderHook(() => useChartData([], []));
+    expect(result.current.addressToUnit).toEqual({});
+  });
+});
+
 describe('useChartData — datatype override for untyped GAs (#315)', () => {
   test('untyped raw-byte telegrams do not plot without a chosen datatype', () => {
     const telegrams = [

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -23,6 +23,9 @@ export interface ChartDataResult {
   buckets: ChartBucket[];
   minTime: number | null;
   maxTime: number | null;
+  /** Each plotted GA's metric/unit bucket key, so callers can group selection
+   * order by unit without redoing this classification (#349's chart lock). */
+  addressToUnit: Record<string, string>;
 }
 
 export function useChartData(
@@ -34,7 +37,7 @@ export function useChartData(
 ): ChartDataResult {
   return useMemo(() => {
     if (selectedTargets.length === 0 || telegrams.length === 0) {
-      return { buckets: [], minTime: null, maxTime: null };
+      return { buckets: [], minTime: null, maxTime: null, addressToUnit: {} };
     }
 
     // Decode an untyped GA's raw payload with its chosen datatype, if any.
@@ -72,7 +75,7 @@ export function useChartData(
       .sort((a, b) => a.ts - b.ts);
 
     if (relevant.length === 0) {
-      return { buckets: [], minTime: null, maxTime: null };
+      return { buckets: [], minTime: null, maxTime: null, addressToUnit: {} };
     }
 
     const minTime = relevant[0].ts;
@@ -81,6 +84,7 @@ export function useChartData(
     // 2. Group into physical units / buckets
     // We treat DPT1 (boolean/binary) as a special bucket called 'binary'
     const grouped = new Map<string, typeof relevant>();
+    const addressToUnit: Record<string, string> = {};
 
     for (const t of relevant) {
       const overrideKey = t.dpt_main == null ? dptOverrides[t.target_address] : undefined;
@@ -96,6 +100,7 @@ export function useChartData(
 
       if (!grouped.has(bucketKey)) grouped.set(bucketKey, []);
       grouped.get(bucketKey)!.push(t);
+      addressToUnit[t.target_address] = bucketKey;
     }
 
     // 3. For each bucket, build the aligned data matrix
@@ -164,6 +169,6 @@ export function useChartData(
     // a different metric the earliest one plotted (#312).
     buckets.sort((a, b) => a.unit.localeCompare(b.unit));
 
-    return { buckets, minTime, maxTime };
+    return { buckets, minTime, maxTime, addressToUnit };
   }, [telegrams, selectedTargets, dptOverrides]);
 }

--- a/frontend/src/utils/chartLock.test.ts
+++ b/frontend/src/utils/chartLock.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { splitLockedBuckets } from './chartLock';
+import type { ChartBucket, ChartSeries } from '../hooks/useChartData';
+
+const series = (address: string): ChartSeries => ({ address, name: address, data: [1], real: [true] });
+
+const bucket = (unit: string, addresses: string[]): ChartBucket => ({
+  unit, isBinary: false, timestamps: [1000], series: addresses.map(series),
+});
+
+describe('splitLockedBuckets', () => {
+  it('passes through a bucket with no lock thresholds unchanged, as a single group', () => {
+    const buckets = [bucket('lx', ['1/1/1', '1/1/2'])];
+    const out = splitLockedBuckets(buckets, ['1/1/1', '1/1/2'], { '1/1/1': 'lx', '1/1/2': 'lx' }, {});
+    expect(out).toHaveLength(1);
+    expect(out[0].bucket.series.map(s => s.address)).toEqual(['1/1/1', '1/1/2']);
+    expect(out[0]).toMatchObject({ groupIndex: 1, groupCount: 1, isLatest: true });
+  });
+
+  it('reorders an unlocked bucket to selection order too, not arrival order', () => {
+    const buckets = [bucket('lx', ['1/1/3', '1/1/1', '1/1/2'])]; // arrival order
+    const addressToUnit = { '1/1/1': 'lx', '1/1/2': 'lx', '1/1/3': 'lx' };
+    const out = splitLockedBuckets(buckets, ['1/1/2', '1/1/1', '1/1/3'], addressToUnit, {});
+    expect(out[0].bucket.series.map(s => s.address)).toEqual(['1/1/2', '1/1/1', '1/1/3']);
+  });
+
+  it('splits a locked unit into two charts by selection order', () => {
+    const buckets = [bucket('lx', ['1/1/1', '1/1/2', '1/1/3'])];
+    const addressToUnit = { '1/1/1': 'lx', '1/1/2': 'lx', '1/1/3': 'lx' };
+    // Locked after the first 2 GAs were selected.
+    const out = splitLockedBuckets(buckets, ['1/1/1', '1/1/2', '1/1/3'], addressToUnit, { lx: [2] });
+
+    expect(out).toHaveLength(2);
+    expect(out[0].bucket.series.map(s => s.address)).toEqual(['1/1/1', '1/1/2']);
+    expect(out[0]).toMatchObject({ groupIndex: 1, groupCount: 2, isLatest: false });
+    expect(out[1].bucket.series.map(s => s.address)).toEqual(['1/1/3']);
+    expect(out[1]).toMatchObject({ groupIndex: 2, groupCount: 2, isLatest: true });
+  });
+
+  it('respects selection order, not the bucket series array order', () => {
+    const buckets = [bucket('lx', ['1/1/3', '1/1/1', '1/1/2'])]; // arbitrary series order
+    const addressToUnit = { '1/1/1': 'lx', '1/1/2': 'lx', '1/1/3': 'lx' };
+    // Selection order: 2 was picked first, then 1, then 3. Lock after the first 2 selections.
+    const out = splitLockedBuckets(buckets, ['1/1/2', '1/1/1', '1/1/3'], addressToUnit, { lx: [2] });
+
+    expect(out[0].bucket.series.map(s => s.address)).toEqual(['1/1/2', '1/1/1']);
+    expect(out[1].bucket.series.map(s => s.address)).toEqual(['1/1/3']);
+  });
+
+  it('supports multiple locks, producing three charts', () => {
+    const buckets = [bucket('lx', ['1/1/1', '1/1/2', '1/1/3', '1/1/4'])];
+    const addressToUnit = Object.fromEntries(['1/1/1', '1/1/2', '1/1/3', '1/1/4'].map(a => [a, 'lx']));
+    const out = splitLockedBuckets(buckets, ['1/1/1', '1/1/2', '1/1/3', '1/1/4'], addressToUnit, { lx: [1, 3] });
+
+    expect(out).toHaveLength(3);
+    expect(out.map(g => g.bucket.series.map(s => s.address))).toEqual([
+      ['1/1/1'], ['1/1/2', '1/1/3'], ['1/1/4'],
+    ]);
+    expect(out.map(g => g.isLatest)).toEqual([false, false, true]);
+  });
+
+  it('leaves other units alone', () => {
+    const buckets = [bucket('lx', ['1/1/1', '1/1/2']), bucket('°C', ['1/1/3'])];
+    const addressToUnit = { '1/1/1': 'lx', '1/1/2': 'lx', '1/1/3': '°C' };
+    const out = splitLockedBuckets(buckets, ['1/1/1', '1/1/2', '1/1/3'], addressToUnit, { lx: [1] });
+
+    expect(out).toHaveLength(3); // lx split into 2 + °C untouched
+    expect(out.find(g => g.bucket.unit === '°C')).toMatchObject({ groupIndex: 1, groupCount: 1 });
+  });
+
+  it('produces unique keys across split groups', () => {
+    const buckets = [bucket('lx', ['1/1/1', '1/1/2'])];
+    const out = splitLockedBuckets(buckets, ['1/1/1', '1/1/2'], { '1/1/1': 'lx', '1/1/2': 'lx' }, { lx: [1] });
+    expect(new Set(out.map(g => g.key)).size).toBe(out.length);
+  });
+});

--- a/frontend/src/utils/chartLock.ts
+++ b/frontend/src/utils/chartLock.ts
@@ -1,0 +1,74 @@
+import type { ChartBucket } from '../hooks/useChartData';
+
+/** A bucket as actually rendered: possibly one of several split-off charts
+ * for a unit that was locked one or more times (#349). Only the last group
+ * for a unit can be locked/unlocked — earlier ones are permanently closed. */
+export interface DisplayBucket {
+  bucket: ChartBucket;
+  /** Stable React key — buckets sharing a unit are no longer unit-unique. */
+  key: string;
+  /** 1-based position among this unit's split charts, and the total count. */
+  groupIndex: number;
+  groupCount: number;
+  /** Whether this is the unit's currently-open (lockable) chart. */
+  isLatest: boolean;
+}
+
+/**
+ * Splits each bucket whose unit has one or more lock thresholds into several
+ * charts, dividing that unit's group addresses by *selection order* — the
+ * GAs selected before a lock stay in the chart that was open when it was
+ * locked; anything selected after spills into the next (new) chart (#349).
+ *
+ * @param lockThresholds Per-unit list of "GAs assigned so far" counts at each
+ *   lock action, e.g. `{ lx: [3] }` = the first 3 selected lx GAs (by
+ *   selection order) stay in chart 1; any further lx GA starts chart 2.
+ */
+export function splitLockedBuckets(
+  buckets: ChartBucket[],
+  selectedTargets: string[],
+  addressToUnit: Record<string, string>,
+  lockThresholds: Record<string, number[]>,
+): DisplayBucket[] {
+  const result: DisplayBucket[] = [];
+
+  for (const bucket of buckets) {
+    const bucketAddrs = new Set(bucket.series.map(s => s.address));
+    // This unit's GAs in selection order, restricted to what's actually plotted here.
+    const ordered = selectedTargets.filter(a => addressToUnit[a] === bucket.unit && bucketAddrs.has(a));
+    const seriesByAddr = new Map(bucket.series.map(s => [s.address, s]));
+
+    const thresholds = lockThresholds[bucket.unit];
+    if (!thresholds || thresholds.length === 0) {
+      result.push({
+        // Always in selection order, not the bucket's arrival-order series array.
+        bucket: { ...bucket, series: ordered.map(a => seriesByAddr.get(a)!) },
+        key: bucket.unit, groupIndex: 1, groupCount: 1, isLatest: true,
+      });
+      continue;
+    }
+
+    const sorted = [...thresholds].sort((a, b) => a - b);
+    const slices: string[][] = [];
+    let start = 0;
+    for (const t of sorted) {
+      slices.push(ordered.slice(start, t));
+      start = t;
+    }
+    slices.push(ordered.slice(start));
+
+    const nonEmpty = slices.filter(s => s.length > 0);
+    nonEmpty.forEach((addrs, i) => {
+      result.push({
+        // Reorder to selection order, not the bucket's original (arrival-order) series array.
+        bucket: { ...bucket, series: addrs.map(a => seriesByAddr.get(a)!) },
+        key: `${bucket.unit}#${i}`,
+        groupIndex: i + 1,
+        groupCount: nonEmpty.length,
+        isLatest: i === nonEmpty.length - 1,
+      });
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- **Fixed legend overlay**: `MixedChart`'s native uPlot legend (which floats and moves under the cursor) is disabled (`legend: { show: false }`) and replaced by a stationary, collapsible card in the chart's top-right corner listing each GA's name and its value at the hovered x-position — mirroring the pattern `TimelineChart` already used for binary-state charts (a `setCursor` hook updating ref-backed DOM elements).
- **Hover highlight**: on cursor move, the legend row whose plotted y-position is nearest the cursor pixel is bolded and washed with the accent color, so the relevant line is identifiable at a glance in a crowded chart.
- **Wider, measured scale gutter**: the y-axis gutter width is computed from the actual widest tick label (via canvas `measureText`, clamped 60–220px) instead of a fixed 150px guess, so labels like "30000 lx" are no longer clipped.
- **Per-metric chart lock**: a Lock button on a metric's currently-open chart freezes its GA membership; any further GA selected for that metric spawns a new chart instead of crowding the existing one. Implemented via `utils/chartLock.ts` (`splitLockedBuckets`) — a pure function that splits a unit's bucket by *selection order* against recorded lock thresholds, avoiding any extra effects or stateful GA→chart bookkeeping.
- `useChartData` now also returns `addressToUnit`, so the lock logic can look up each selected GA's metric group without duplicating that classification.

Closes #349

## Test plan
- [x] `npm run lint` — clean (no new errors; two pre-existing unrelated warnings)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx vitest run` — 358/358 passing: new `chartLock.test.ts` (7 cases: unlocked pass-through, single/multiple locks, selection-order-not-arrival-order, cross-unit isolation, unique keys) and two new `useChartData.test.ts` cases for `addressToUnit`
- [x] Verified in a running instance (Vite dev server + Playwright, telegrams injected over a stubbed WebSocket): selected 3 lux GAs (one at 28,500 — the "30000 lx clipped" scenario) and confirmed the gutter shows the full tick label, the fixed legend lists all 3 with live values, hovering mid-chart highlights the nearest-line legend row and updates its value, then locked the chart and selected a 4th lux GA — it correctly spawned a second "2/2" chart with its own auto-scaled axis, while the first chart's Lock button disappeared (no longer the open/lockable one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
