### PR TITLE
Timeline on top + click-to-list navigation (#308)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -580,6 +580,24 @@ function App() {
     setIsDatabaseOpen(false);
   }, []);
 
+  // Click a time/dot on a visualization chart: close the panel, land on the
+  // telegram nearest that timestamp with live-follow paused, and auto-flag it
+  // as a Time-Delta-Context anchor so its context window opens around it (#308).
+  const handleChartTimeClick = useCallback((ms: number) => {
+    if (liveTelegrams.length === 0) return;
+    let nearest = liveTelegrams[0];
+    let bestDiff = Infinity;
+    for (const t of liveTelegrams) {
+      const diff = Math.abs(new Date(t.timestamp).getTime() - ms);
+      if (diff < bestDiff) { bestDiff = diff; nearest = t; }
+    }
+    const key = anchorKey(nearest);
+    setFlaggedTelegramKeys(prev => prev.includes(key) ? prev : [...prev, key]);
+    setListFollow(false);
+    setListAnchorKey(key);
+    setActivePanel('list');
+  }, [liveTelegrams]);
+
   const handleQuickLastSeen = useCallback((address: string | string[], mode: 'ga' | 'pa') => {
     setLastSeenAddresses(Array.isArray(address) ? address : [address]);
     setLastSeenMode(mode);
@@ -1111,6 +1129,7 @@ function App() {
                     onClose={() => setActivePanel('list')}
                     zoomRange={zoomRange}
                     onZoomRangeChange={setZoomRange}
+                    onTimeClick={handleChartTimeClick}
                   />
                 ) : isLastSeenOpen ? (
                   <LastSeenOverlay

--- a/frontend/src/components/MixedChart.tsx
+++ b/frontend/src/components/MixedChart.tsx
@@ -26,6 +26,9 @@ interface MixedChartProps {
   /** Whether this (the unit's currently-open) chart is locked against further GAs (#349). */
   locked?: boolean;
   onToggleLock?: () => void;
+  /** Click (not drag-select) on the chart: navigate to the telegram list around
+   * this timestamp (#308). */
+  onTimeClick?: (ms: number) => void;
 }
 
 // Ensure we have a shared sync cursor across all charts
@@ -55,12 +58,17 @@ const measureGutterWidth = (series: ChartBucket['series'], unit: string): number
 
 export const MixedChart: React.FC<MixedChartProps> = ({
   bucket, minTime, maxTime, stepped, showDots, autoFollow = false, onZoomRangeChange,
-  groupLabel, locked, onToggleLock,
+  groupLabel, locked, onToggleLock, onTimeClick,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const [legendOpen, setLegendOpen] = useState(true);
   const themeTick = useThemeTick();
+  // Ref-read inside the stable `ready` hook (same pattern as realIndicesRef
+  // below) so a new onTimeClick identity each render doesn't rebuild the chart.
+  const onTimeClickRef = useRef(onTimeClick);
+  // eslint-disable-next-line react-hooks/refs
+  onTimeClickRef.current = onTimeClick;
 
   // Resize observer to keep chart fluid
   useLayoutEffect(() => {
@@ -192,7 +200,23 @@ export const MixedChart: React.FC<MixedChartProps> = ({
         ],
         ready: [
           (u) => {
+            // Click (not drag-select) navigates to the telegram list around this
+            // time (#308); a dblclick still resets the zoom. The navigation is
+            // delayed past the dblclick window so the first click of a dblclick
+            // doesn't fire it before the reset cancels it.
+            let clickTimer: ReturnType<typeof setTimeout> | null = null;
+            let downX: number | null = null;
+            u.over.addEventListener('mousedown', (e) => { downX = e.clientX; });
+            u.over.addEventListener('mouseup', (e) => {
+              const startX = downX;
+              downX = null;
+              if (startX === null || Math.abs(e.clientX - startX) >= 5) return;
+              const rect = u.over.getBoundingClientRect();
+              const ms = u.posToVal(e.clientX - rect.left, 'x') * 1000;
+              clickTimer = setTimeout(() => onTimeClickRef.current?.(ms), 250);
+            });
             u.over.addEventListener('dblclick', () => {
+              if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
               onZoomRangeChange?.(null);
             });
           }

--- a/frontend/src/components/TelegramTable.tsx
+++ b/frontend/src/components/TelegramTable.tsx
@@ -753,7 +753,20 @@ export const TelegramTable: React.FC<TelegramTableProps> = ({
   };
 
   // Changing sort moves (or removes) the live edge — drop the anchor state.
+  // Skipped on mount: this effect and the restore-on-mount effect below both
+  // run in the same commit, in declaration order, and the DOM has zero
+  // scrollTop before either has scrolled anywhere — so without this guard,
+  // checkAtEdge() always reads "at edge" here first and clobbers a restored
+  // anchor (e.g. a cross-panel goto, #308) before it ever gets applied.
+  const sortEffectMounted = useRef(false);
   useEffect(() => {
+    if (!sortEffectMounted.current) {
+      sortEffectMounted.current = true;
+      // Undo the flag on cleanup so StrictMode's dev-only double-invoke
+      // (mount → cleanup → mount) still skips on both simulated mounts,
+      // instead of treating the second one as a real sortConfig change.
+      return () => { sortEffectMounted.current = false; };
+    }
     setNewSinceAnchor(0);
     setStripeOffset(0);
     anchorRef.current = null;

--- a/frontend/src/components/TimelineChart.tsx
+++ b/frontend/src/components/TimelineChart.tsx
@@ -17,11 +17,14 @@ interface TimelineChartProps {
    * (#340). When zoomed, stays false to preserve the app-controlled range (#281). */
   autoFollow?: boolean;
   onZoomRangeChange?: (value: [number, number] | null) => void;
+  /** Click (not drag-select) on the chart: navigate to the telegram list around
+   * this timestamp (#308). Omitted from the deps key since it's stable from callers. */
+  onTimeClick?: (ms: number) => void;
 }
 
 const syncCursor = uPlot.sync('knx-time-axis');
 
-export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, maxTime, showDots, autoFollow = false, onZoomRangeChange }) => {
+export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, maxTime, showDots, autoFollow = false, onZoomRangeChange, onTimeClick }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(800);
   const themeTick = useThemeTick();
@@ -34,6 +37,11 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
   const realRef = useRef<boolean[][]>([]);
   // eslint-disable-next-line react-hooks/refs
   realRef.current = bucket.series.map(s => s.real);
+  // Same "ref read inside a stable plugin/hook" pattern as realRef above, so a
+  // new onTimeClick identity each render doesn't force the chart to rebuild.
+  const onTimeClickRef = useRef(onTimeClick);
+  // eslint-disable-next-line react-hooks/refs
+  onTimeClickRef.current = onTimeClick;
 
   useLayoutEffect(() => {
     if (!containerRef.current) return;
@@ -177,7 +185,23 @@ export const TimelineChart: React.FC<TimelineChartProps> = ({ bucket, minTime, m
         ],
         ready: [
           (u) => {
+            // Click (not drag-select) navigates to the telegram list around this
+            // time (#308); a dblclick still resets the zoom. The navigation is
+            // delayed past the dblclick window so the first click of a dblclick
+            // doesn't fire it before the reset cancels it.
+            let clickTimer: ReturnType<typeof setTimeout> | null = null;
+            let downX: number | null = null;
+            u.over.addEventListener('mousedown', (e) => { downX = e.clientX; });
+            u.over.addEventListener('mouseup', (e) => {
+              const startX = downX;
+              downX = null;
+              if (startX === null || Math.abs(e.clientX - startX) >= 5) return;
+              const rect = u.over.getBoundingClientRect();
+              const ms = u.posToVal(e.clientX - rect.left, 'x') * 1000;
+              clickTimer = setTimeout(() => onTimeClickRef.current?.(ms), 250);
+            });
             u.over.addEventListener('dblclick', () => {
+              if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
               onZoomRangeChange?.(null);
             });
           }

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -22,11 +22,14 @@ interface VisualizerProps {
   embed?: boolean;
   zoomRange?: [number, number] | null;
   onZoomRangeChange?: (range: [number, number] | null) => void;
+  /** Click on a chart's time ruler or a telegram dot: navigate to the telegram
+   * list around that timestamp (#308). */
+  onTimeClick?: (ms: number) => void;
 }
 
 export const Visualizer: React.FC<VisualizerProps> = ({
   telegrams, selectedTargets, onTargetsChange, onClose, getShareLink, embed = false,
-  zoomRange, onZoomRangeChange,
+  zoomRange, onZoomRangeChange, onTimeClick,
 }) => {
 
   const chartWrapperRef = useRef<HTMLDivElement>(null);
@@ -162,7 +165,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
     <div ref={chartWrapperRef} style={{ flex: 1, overflowY: 'auto', padding: embed ? '0.75rem' : '1.5rem' }}>
       {displayBuckets.map(g => (
         g.bucket.isBinary ? (
-          <TimelineChart key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} />
+          <TimelineChart key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} onTimeClick={onTimeClick} />
         ) : (
           <MixedChart
             key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]}
@@ -171,6 +174,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
             // Only the unit's currently-open chart is lockable; earlier ones are permanently closed (#349).
             locked={g.isLatest ? (lockThresholds[g.bucket.unit]?.at(-1) === g.bucket.series.length) : undefined}
             onToggleLock={g.isLatest ? () => toggleLock(g.bucket.unit, g.bucket.series.length) : undefined}
+            onTimeClick={onTimeClick}
           />
         )
       ))}
@@ -186,7 +190,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
   if (embed) {
     return (
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', background: 'var(--bg-subtle)' }}>
-        {charts}
+        {/* Pan & zoom timeline sits above the charts it controls (#308). */}
         {minTime !== null && maxTime !== null && minTime < maxTime && (
           <TimeBrush
             minTime={minTime}
@@ -196,6 +200,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
             telegrams={telegrams}
           />
         )}
+        {charts}
       </div>
     );
   }
@@ -290,7 +295,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
             </div>
           </div>
 
-          {charts}
+          {/* Pan & zoom timeline sits above the charts it controls (#308). */}
           {minTime !== null && maxTime !== null && minTime < maxTime && (
             <TimeBrush
               minTime={minTime}
@@ -300,6 +305,7 @@ export const Visualizer: React.FC<VisualizerProps> = ({
               telegrams={telegrams}
             />
           )}
+          {charts}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Relocates the Pan & Zoom Timeline (`TimeBrush`) above the chart stack in `Visualizer`, both in the normal and embedded layouts.
- Clicking (not drag-selecting) a point on a chart's time ruler or a telegram dot closes the Visualization panel, pauses live-follow, and scrolls the telegram list to the nearest telegram — using the existing goto/anchor machinery, per the navigate-to-main-list design agreed in #341.
- Auto-flags the landed telegram as a Time-Delta-Context anchor (#319), so its context window opens around it automatically.
- A dblclick still resets the chart's zoom (unchanged) instead of triggering navigation; the click is deliberately delayed ~250ms so the first click of a dblclick doesn't fire it.
- Fixes a related latent bug found while implementing this: `TelegramTable`'s sortConfig-reset effect ran on every mount (not just on a real sort change) because it's declared before the restore-on-mount effect and both run in the same commit, before any scroll has happened — so `checkAtEdge()` always saw `scrollTop === 0` as "at the live edge" and clobbered the restored anchor. This broke any goto-and-land-away-from-edge flow across a panel switch, so it's fixed generally, not just for this feature.

Closes #308.

## Test plan
- [x] `npx tsc --noEmit`, `eslint`, `vitest run` (358/358), `npm run build` all clean
- [x] Playwright end-to-end verification against the running dev app (stubbed API/WS, no real KNX bus):
  - Confirmed the "Pan & Zoom Timeline" now renders above the chart in the Visualization panel.
  - Clicked mid-chart → panel closed, landed on the nearest telegram in the Group Monitor list, row shown flagged (context anchor icon).
  - Pushed 5 more live telegrams after landing → list stayed anchored (didn't auto-scroll), "5 new telegrams" jump-to-live pill appeared, and the flag persisted — confirming live-follow was genuinely paused, not just visually coincidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)