### PR TITLE
Timeline edge-pin, cross-nav icons, event dots for unchartable DPTs (#341)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1130,6 +1130,9 @@ function App() {
                     zoomRange={zoomRange}
                     onZoomRangeChange={setZoomRange}
                     onTimeClick={handleChartTimeClick}
+                    writeEnabled={serverConfig?.status?.write_enabled}
+                    onFilterGAs={handleFilterGAs}
+                    onLastSeen={handleQuickLastSeen}
                   />
                 ) : isLastSeenOpen ? (
                   <LastSeenOverlay
@@ -1149,6 +1152,9 @@ function App() {
                       setLastSeenMode(mode);
                       setLastSeenAddresses(addresses);
                     }}
+                    onFilterDevice={(pa) => handleQuickFilter('sources', pa)}
+                    onFilterGAs={handleFilterGAs}
+                    onVisualizeGAs={handleVisualizeGAs}
                   />
                 ) : isStatisticsOpen ? (
                   <StatisticsOverlay

--- a/frontend/src/components/EventDotsChart.tsx
+++ b/frontend/src/components/EventDotsChart.tsx
@@ -1,0 +1,309 @@
+import React, { useRef, useLayoutEffect, useState, useMemo } from 'react';
+import UplotReact from 'uplot-react';
+import uPlot from 'uplot';
+import 'uplot/dist/uPlot.min.css';
+import type { ChartBucket } from '../hooks/useChartData';
+import { useThemeTick } from '../hooks/useTheme';
+import { seriesColor } from '../utils/seriesColors';
+import { spansMultipleDays, formatAxisTime, formatFullTime } from '../utils/timeFormat';
+
+interface EventDotsChartProps {
+  bucket: ChartBucket;
+  minTime: number | null;
+  maxTime: number | null;
+  autoFollow?: boolean;
+  onZoomRangeChange?: (value: [number, number] | null) => void;
+  /** Click (not drag-select) on the chart: navigate to the telegram list around
+   * this timestamp (#308). */
+  onTimeClick?: (ms: number) => void;
+}
+
+const syncCursor = uPlot.sync('knx-time-axis');
+
+/**
+ * Discrete event dots for GAs that never resolve to a number or boolean —
+ * text (DPT16) and other unchartable/complex payloads — grouped in one lane
+ * group like the binary timeline (#341). Each dot is a standalone occurrence
+ * (no forward-fill/held state); its tooltip/legend shows the telegram's
+ * formatted value.
+ */
+export const EventDotsChart: React.FC<EventDotsChartProps> = ({ bucket, minTime, maxTime, autoFollow = false, onZoomRangeChange, onTimeClick }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(800);
+  const themeTick = useThemeTick();
+  const valueRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  // Ref-read inside the stable draw/cursor plugins (same pattern as the other
+  // charts) so live data/callback updates don't force a chart rebuild.
+  const realRef = useRef<boolean[][]>([]);
+  // eslint-disable-next-line react-hooks/refs
+  realRef.current = bucket.series.map(s => s.real);
+  const labelsRef = useRef<(string | null)[][]>([]);
+  // eslint-disable-next-line react-hooks/refs
+  labelsRef.current = bucket.series.map(s => s.labels ?? []);
+  const onTimeClickRef = useRef(onTimeClick);
+  // eslint-disable-next-line react-hooks/refs
+  onTimeClickRef.current = onTimeClick;
+
+  useLayoutEffect(() => {
+    if (!containerRef.current) return;
+    const obs = new ResizeObserver(entries => {
+      setWidth(entries[0].contentRect.width);
+    });
+    obs.observe(containerRef.current);
+    return () => obs.disconnect();
+  }, []);
+
+  const { series, timestamps } = bucket;
+  const data: uPlot.AlignedData = [
+    timestamps.map(t => t / 1000),
+    ...series.map(s => s.data)
+  ];
+
+  const multiDay = minTime != null && maxTime != null && spansMultipleDays(minTime, maxTime);
+  const LEFT_GUTTER = 150;
+
+  const rowHeight = 32;
+  const rowGap = 4;
+  // The bottom time axis + chart padding reserve a fixed amount of vertical
+  // space regardless of content, so a generous floor is needed here or the
+  // actual plot area (uPlot's bbox) can shrink to a sliver — the draw plugin
+  // below still positions rows from the *real* bbox height, not this value,
+  // but the row/legend heights on our own side need enough room to show in.
+  const chartHeight = Math.max(160, series.length * (rowHeight + rowGap) + 60);
+
+  const structureKey = [
+    width, themeTick, minTime, maxTime, series.map(s => s.name).join('|'),
+  ].join('§');
+
+  const options: uPlot.Options = useMemo(() => {
+    const style = getComputedStyle(document.documentElement);
+    const gridStroke = style.getPropertyValue('--border-subtle').trim();
+    const axisStroke = style.getPropertyValue('--text-dim').trim();
+    const dotOutline = style.getPropertyValue('--bg-inset').trim();
+
+    const eventsPlugin = () => ({
+      hooks: {
+        draw: [(u: uPlot) => {
+          const { ctx } = u;
+          const { left, top, width, height } = u.bbox;
+
+          ctx.save();
+          ctx.beginPath();
+          ctx.rect(left, top, width, height);
+          ctx.clip();
+
+          const xs = u.data[0];
+          const seriesCount = u.data.length - 1;
+          // Row positions are derived from uPlot's *actual* plot area (bbox),
+          // not a value computed independently on our side — the bottom time
+          // axis + padding reserve a fixed amount of space regardless of the
+          // container height, so a row position computed from a static offset
+          // can land outside the real (and clipped) plot rect for a small
+          // series count, silently drawing nothing.
+          const rowSlot = seriesCount > 0 ? height / seriesCount : height;
+
+          for (let sIdx = 0; sIdx < seriesCount; sIdx++) {
+            const yMid = top + sIdx * rowSlot + rowSlot / 2;
+            const color = seriesColor(series[sIdx]?.address ?? String(sIdx));
+
+            // Baseline for the row, so an empty stretch still reads as "this GA's lane".
+            ctx.strokeStyle = gridStroke;
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.moveTo(left, yMid);
+            ctx.lineTo(left + width, yMid);
+            ctx.stroke();
+
+            const real = realRef.current[sIdx];
+            for (let i = 0; i < xs.length; i++) {
+              if (!real?.[i]) continue;
+              const x = u.valToPos(xs[i], 'x', true);
+              ctx.beginPath();
+              ctx.arc(x, yMid, 4.5, 0, Math.PI * 2);
+              ctx.fillStyle = color;
+              ctx.fill();
+              ctx.lineWidth = 1.5;
+              ctx.strokeStyle = dotOutline;
+              ctx.stroke();
+            }
+          }
+
+          ctx.restore();
+        }]
+      }
+    });
+
+    return {
+      width,
+      height: chartHeight,
+      padding: [10, 16, 30, 0],
+      cursor: {
+        sync: { key: syncCursor.key },
+        drag: { x: true, y: false, setScale: false }
+      },
+      hooks: {
+        setCursor: [
+          (u) => {
+            const idx = u.cursor.idx;
+            const isOutside = u.cursor.left == null || u.cursor.left < 0;
+            series.forEach((_s, sIdx) => {
+              const el = valueRefs.current[sIdx];
+              if (!el) return;
+              const labels = labelsRef.current[sIdx] ?? [];
+              // While hovering, show the label at the cursor column only if
+              // this row actually had an event there; otherwise fall back to
+              // its last known label (matching the other charts' hover UX).
+              const hoverLabel = !isOutside && idx != null ? labels[idx] : null;
+              const lastLabel = [...labels].reverse().find(l => l != null) ?? null;
+              const text = hoverLabel ?? lastLabel;
+              el.textContent = text ?? '–';
+            });
+          }
+        ],
+        setSelect: [
+          (u) => {
+            if (u.select.width > 0) {
+              const min = u.posToVal(u.select.left, 'x');
+              const max = u.posToVal(u.select.left + u.select.width, 'x');
+              onZoomRangeChange?.([min * 1000, max * 1000]);
+            }
+          }
+        ],
+        ready: [
+          (u) => {
+            // Click (not drag-select) navigates to the telegram list around this
+            // time (#308); a dblclick still resets the zoom. The navigation is
+            // delayed past the dblclick window so the first click of a dblclick
+            // doesn't fire it before the reset cancels it.
+            let clickTimer: ReturnType<typeof setTimeout> | null = null;
+            let downX: number | null = null;
+            u.over.addEventListener('mousedown', (e) => { downX = e.clientX; });
+            u.over.addEventListener('mouseup', (e) => {
+              const startX = downX;
+              downX = null;
+              if (startX === null || Math.abs(e.clientX - startX) >= 5) return;
+              const rect = u.over.getBoundingClientRect();
+              const ms = u.posToVal(e.clientX - rect.left, 'x') * 1000;
+              clickTimer = setTimeout(() => onTimeClickRef.current?.(ms), 250);
+            });
+            u.over.addEventListener('dblclick', () => {
+              if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; }
+              onZoomRangeChange?.(null);
+            });
+          }
+        ]
+      },
+      plugins: [eventsPlugin()],
+      scales: {
+        x: {
+          time: true,
+          min: minTime ? minTime / 1000 : undefined,
+          max: maxTime ? maxTime / 1000 : undefined,
+        },
+        y: { auto: false, range: [0, 1] }
+      },
+      axes: [
+        {
+          space: multiDay ? 95 : 55,
+          stroke: axisStroke,
+          grid: { stroke: gridStroke },
+          values: (_u, splits) => splits.map(v => formatAxisTime(v * 1000, multiDay))
+        },
+        {
+          show: true,
+          stroke: axisStroke,
+          grid: { stroke: gridStroke },
+          size: LEFT_GUTTER,
+          values: () => []
+        }
+      ],
+      series: [
+        {
+          value: (_u, v) => v == null ? '-' : formatFullTime(v * 1000, multiDay)
+        },
+        ...series.map((s) => ({
+          label: s.name,
+          show: false,
+        }))
+      ]
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [structureKey]);
+
+  const plotTop = 10;
+  return (
+    <div style={{ marginBottom: '2rem', background: 'var(--bg-inset)', padding: '1rem', borderRadius: '8px', border: '1px solid var(--border-color)', overflow: 'visible' }}>
+      <h4 style={{ margin: '0 0 1rem', fontSize: '0.9rem', color: 'var(--text-main)' }}>
+        Events (unchartable values)
+      </h4>
+      <div style={{ position: 'relative', width: '100%' }}>
+        {/* HTML Legend Overlay on the left */}
+        <div style={{
+          position: 'absolute',
+          left: '8px',
+          top: `${plotTop + rowGap}px`,
+          width: `${LEFT_GUTTER - 16}px`,
+          height: `${chartHeight - plotTop - 30}px`,
+          display: 'flex',
+          flexDirection: 'column',
+          pointerEvents: 'none',
+          zIndex: 10,
+        }}>
+          {series.map((s, sIdx) => {
+            const labels = s.labels ?? [];
+            const lastLabel = [...labels].reverse().find(l => l != null) ?? null;
+            return (
+              <div
+                key={s.address}
+                style={{
+                  height: `${rowHeight}px`,
+                  marginBottom: `${rowGap}px`,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  fontSize: '0.75rem',
+                  lineHeight: '1.2',
+                }}
+              >
+                <div style={{
+                  fontWeight: 600,
+                  color: 'var(--text-main)',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }} title={s.name}>
+                  {s.name}
+                </div>
+                <div
+                  ref={el => { valueRefs.current[sIdx] = el; }}
+                  style={{
+                    fontSize: '0.7rem',
+                    fontWeight: 700,
+                    color: 'var(--text-dim)',
+                    marginTop: '2px',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                  title={lastLabel ?? undefined}
+                >
+                  {lastLabel ?? '–'}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div ref={containerRef} style={{ width: '100%', overflow: 'visible' }}>
+           <UplotReact options={options} data={data} resetScales={autoFollow} />
+        </div>
+      </div>
+      {minTime != null && maxTime != null && (
+        <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '0.35rem', paddingLeft: `${LEFT_GUTTER}px`, paddingRight: '16px', fontSize: '0.7rem', color: 'var(--text-dim)', fontVariantNumeric: 'tabular-nums' }}>
+          <span>{formatFullTime(minTime, multiDay)}</span>
+          <span>{formatFullTime(maxTime, multiDay)}</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/LastSeenOverlay.tsx
+++ b/frontend/src/components/LastSeenOverlay.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { X, Clock, RefreshCw, Search, ToggleLeft, ToggleRight, Radio, Send } from 'lucide-react';
+import { X, Clock, RefreshCw, Search, ToggleLeft, ToggleRight, Radio, Send, Filter, LineChart } from 'lucide-react';
 import { format, formatDistanceToNowStrict } from 'date-fns';
 import type { Telegram } from '../hooks/useWebSocket';
 import type { FilterOptions } from '../types/filters';
@@ -8,7 +8,7 @@ import { formatDpt, readTelegram, sendTelegram } from '../utils/knxSend';
 import { compareKnxAddress } from '../utils/knxAddress';
 import { WriteControls } from './WriteControls';
 import { SendToGaPopover } from './SendToGaPopover';
-import { secondaryBtn } from '../utils/buttonStyles';
+import { secondaryBtn, rowIconBtnStyle } from '../utils/buttonStyles';
 
 const LIMITS = [10, 20, 50, 100] as const;
 
@@ -29,6 +29,11 @@ interface LastSeenOverlayProps {
   search?: string;
   onSearchChange?: (search: string) => void;
   onSelectionChange?: (mode: 'ga' | 'pa', addresses: string[]) => void;
+  /** Cross-navigation icons on GA/device rows and the SOURCE/TARGET columns
+   * (#341): add-to-filter for both kinds, plus visualize for GAs. */
+  onFilterDevice?: (pa: string) => void;
+  onFilterGAs?: (addresses: string[]) => void;
+  onVisualizeGAs?: (addresses: string[]) => void;
 }
 
 const getTypeColor = (type?: string | null) => {
@@ -70,6 +75,9 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
   search: searchProp,
   onSearchChange,
   onSelectionChange,
+  onFilterDevice,
+  onFilterGAs,
+  onVisualizeGAs,
 }) => {
   const [mode, setMode] = useState<'ga' | 'pa'>(initialMode);
   const [selectedAddresses, setSelectedAddresses] = useState<string[]>(initialAddresses);
@@ -220,6 +228,15 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
     setSearch('');
   };
 
+  // Cross-navigation from a SOURCE/TARGET table cell of the "other" kind
+  // (e.g. a device shown as a GA telegram's source): switch mode and select
+  // it, entirely within this pane's own state (#341).
+  const gotoAddress = (address: string, kind: 'ga' | 'pa') => {
+    setMode(kind);
+    setSelectedAddresses([address]);
+    setSearch('');
+  };
+
   const filteredAddresses = addressList
     .filter(a => {
       const q = search.toLowerCase();
@@ -336,15 +353,51 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
                     </div>
                   )}
                 </button>
-                {writeEnabled && mode === 'ga' && addr.address && (
-                  <div style={{ paddingRight: '0.5rem', flexShrink: 0 }}>
-                    <SendToGaPopover
-                      address={addr.address}
-                      name={addr.name}
-                      dptMain={addr.main}
-                      dptSub={addr.sub}
-                      buttonClassName="quick-send-btn"
-                    />
+                {addr.address && (
+                  <div style={{ paddingRight: '0.5rem', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+                    {writeEnabled && mode === 'ga' && (
+                      <SendToGaPopover
+                        address={addr.address}
+                        name={addr.name}
+                        dptMain={addr.main}
+                        dptSub={addr.sub}
+                        buttonClassName="quick-send-btn"
+                        buttonStyle={rowIconBtnStyle}
+                      />
+                    )}
+                    {mode === 'ga' && onVisualizeGAs && (
+                      <button
+                        style={rowIconBtnStyle}
+                        title="Visualize this group address"
+                        onClick={() => onVisualizeGAs([addr.address!])}
+                        onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                        onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                      >
+                        <LineChart size={11} />
+                      </button>
+                    )}
+                    {mode === 'ga' && onFilterGAs && (
+                      <button
+                        style={rowIconBtnStyle}
+                        title="Filter by this group address"
+                        onClick={() => onFilterGAs([addr.address!])}
+                        onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                        onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                      >
+                        <Filter size={11} />
+                      </button>
+                    )}
+                    {mode === 'pa' && onFilterDevice && (
+                      <button
+                        style={rowIconBtnStyle}
+                        title="Filter by this device"
+                        onClick={() => onFilterDevice(addr.address!)}
+                        onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                        onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                      >
+                        <Filter size={11} />
+                      </button>
+                    )}
                   </div>
                 )}
               </div>
@@ -533,8 +586,80 @@ export const LastSeenOverlay: React.FC<LastSeenOverlayProps> = ({
                       </td>
                     )}
                     <td style={tdStyle}>
-                      <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.78rem', color: 'var(--text-dim)' }}>
-                        {mode === 'ga' ? t.source_address : t.target_address}
+                      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.2rem' }}>
+                        <span style={{ fontFamily: "'JetBrains Mono', monospace", fontSize: '0.78rem', color: 'var(--text-dim)' }}>
+                          {mode === 'ga' ? t.source_address : t.target_address}
+                        </span>
+                        {/* Cross-navigation icons on the "other kind" address of
+                            this telegram (#341): a device shown while viewing a
+                            GA's history, or a GA shown while viewing a device's. */}
+                        {mode === 'ga' ? (
+                          <>
+                            {onFilterDevice && (
+                              <button
+                                style={rowIconBtnStyle}
+                                title="Filter by this device"
+                                onClick={() => onFilterDevice(t.source_address)}
+                                onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                                onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                              >
+                                <Filter size={11} />
+                              </button>
+                            )}
+                            <button
+                              style={rowIconBtnStyle}
+                              title="Show last seen values for this device"
+                              onClick={() => gotoAddress(t.source_address, 'pa')}
+                              onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                              onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                            >
+                              <Clock size={11} />
+                            </button>
+                          </>
+                        ) : (
+                          <>
+                            {writeEnabled && (
+                              <SendToGaPopover
+                                address={t.target_address}
+                                name={t.target_name}
+                                dptMain={t.dpt_main}
+                                dptSub={t.dpt_sub}
+                                buttonStyle={rowIconBtnStyle}
+                              />
+                            )}
+                            {onVisualizeGAs && (
+                              <button
+                                style={rowIconBtnStyle}
+                                title="Visualize this group address"
+                                onClick={() => onVisualizeGAs([t.target_address])}
+                                onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                                onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                              >
+                                <LineChart size={11} />
+                              </button>
+                            )}
+                            {onFilterGAs && (
+                              <button
+                                style={rowIconBtnStyle}
+                                title="Filter by this group address"
+                                onClick={() => onFilterGAs([t.target_address])}
+                                onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                                onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                              >
+                                <Filter size={11} />
+                              </button>
+                            )}
+                            <button
+                              style={rowIconBtnStyle}
+                              title="Show last seen values for this group address"
+                              onClick={() => gotoAddress(t.target_address, 'ga')}
+                              onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                              onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                            >
+                              <Clock size={11} />
+                            </button>
+                          </>
+                        )}
                       </span>
                     </td>
                     <td style={{ ...tdStyle, color: 'var(--text-dim)', fontSize: '0.78rem', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>

--- a/frontend/src/components/TimeBrush.tsx
+++ b/frontend/src/components/TimeBrush.tsx
@@ -8,6 +8,10 @@ interface TimeBrushProps {
   value: [number, number];
   onChange: (value: [number, number]) => void;
   telegrams: Telegram[];
+  /** Whether each handle is currently pinned to its domain edge, tracking it
+   * as the buffer grows/purges instead of staying at a frozen time (#341). */
+  leftPinned?: boolean;
+  rightPinned?: boolean;
 }
 
 export const TimeBrush: React.FC<TimeBrushProps> = ({
@@ -16,6 +20,8 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
   value,
   onChange,
   telegrams,
+  leftPinned = false,
+  rightPinned = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [dragMode, setDragMode] = useState<'left' | 'right' | 'middle' | null>(null);
@@ -192,7 +198,9 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
             e.stopPropagation();
             onChange([minTime, value[1]]);
           }}
-          title="Drag to adjust · double-click to extend to the oldest data"
+          title={leftPinned
+            ? 'Pinned to the oldest data — follows as the buffer purges. Drag to unpin.'
+            : 'Drag to adjust · double-click to pin to the oldest data'}
           style={{
             position: 'absolute',
             left: `calc(${leftPct}% - 5px)`,
@@ -210,7 +218,7 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
               width: 4,
               height: 14,
               borderRadius: 2,
-              background: dragMode === 'left' ? 'var(--accent-primary)' : 'var(--text-dim)',
+              background: dragMode === 'left' || leftPinned ? 'var(--accent-primary)' : 'var(--text-dim)',
               border: '1px solid var(--border-color)',
             }}
           />
@@ -228,7 +236,9 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
             e.stopPropagation();
             onChange([value[0], maxTime]);
           }}
-          title="Drag to adjust · double-click to extend to the newest data"
+          title={rightPinned
+            ? 'Pinned to the live edge — follows as new telegrams arrive. Drag to unpin.'
+            : 'Drag to adjust · double-click to pin to the live edge'}
           style={{
             position: 'absolute',
             left: `calc(${rightPct}% - 5px)`,
@@ -246,7 +256,7 @@ export const TimeBrush: React.FC<TimeBrushProps> = ({
               width: 4,
               height: 14,
               borderRadius: 2,
-              background: dragMode === 'right' ? 'var(--accent-primary)' : 'var(--text-dim)',
+              background: dragMode === 'right' || rightPinned ? 'var(--accent-primary)' : 'var(--text-dim)',
               border: '1px solid var(--border-color)',
             }}
           />

--- a/frontend/src/components/Visualizer.tsx
+++ b/frontend/src/components/Visualizer.tsx
@@ -4,6 +4,7 @@ import { VisualizerSidebar } from './VisualizerSidebar';
 import { useChartData } from '../hooks/useChartData';
 import { MixedChart } from './MixedChart';
 import { TimelineChart } from './TimelineChart';
+import { EventDotsChart } from './EventDotsChart';
 import { TimeBrush } from './TimeBrush';
 import { Download, Link2, Check, X } from 'lucide-react';
 import { getPref, setPref } from '../utils/prefs';
@@ -25,11 +26,15 @@ interface VisualizerProps {
   /** Click on a chart's time ruler or a telegram dot: navigate to the telegram
    * list around that timestamp (#308). */
   onTimeClick?: (ms: number) => void;
+  /** Per-target row actions in the sidebar (#341): write/filter/last-seen. */
+  writeEnabled?: boolean;
+  onFilterGAs?: (addresses: string[]) => void;
+  onLastSeen?: (address: string | string[], mode: 'ga' | 'pa') => void;
 }
 
 export const Visualizer: React.FC<VisualizerProps> = ({
   telegrams, selectedTargets, onTargetsChange, onClose, getShareLink, embed = false,
-  zoomRange, onZoomRangeChange, onTimeClick,
+  zoomRange, onZoomRangeChange, onTimeClick, writeEnabled, onFilterGAs, onLastSeen,
 }) => {
 
   const chartWrapperRef = useRef<HTMLDivElement>(null);
@@ -103,18 +108,32 @@ export const Visualizer: React.FC<VisualizerProps> = ({
 
   const [internalZoomRange, setInternalZoomRange] = useState<[number, number] | null>(null);
   const currentZoomRange = zoomRange !== undefined ? zoomRange : internalZoomRange;
+
+  // Edge pin (#341, #340 follow-up): a handle left at (or dragged/double-clicked
+  // to) the domain edge keeps tracking that edge as minTime/maxTime move — the
+  // timeline analogue of the telegram list's live-edge follow (#203). Ephemeral,
+  // like the list's follow state: not part of the shareable-link zoomRange
+  // contract, so it resets on reload rather than being encoded in a URL.
+  const [edgePinned, setEdgePinned] = useState<{ left: boolean; right: boolean }>({ left: false, right: false });
+
   const setZoomRange = (val: [number, number] | null | ((prev: [number, number] | null) => [number, number] | null)) => {
     const next = typeof val === 'function' ? val(currentZoomRange) : val;
     setInternalZoomRange(next);
     onZoomRangeChange?.(next);
+    if (next && minTime !== null && maxTime !== null) {
+      const eps = Math.max(1000, (maxTime - minTime) * 0.005);
+      setEdgePinned({ left: next[0] <= minTime + eps, right: next[1] >= maxTime - eps });
+    } else {
+      setEdgePinned({ left: false, right: false });
+    }
   };
 
   const activeRange = useMemo<[number, number]>(() => {
     if (!currentZoomRange || minTime === null || maxTime === null) return defaultRange;
-    const left = Math.max(minTime, Math.min(maxTime, currentZoomRange[0]));
-    const right = Math.max(left, Math.min(maxTime, currentZoomRange[1]));
+    const left = edgePinned.left ? minTime : Math.max(minTime, Math.min(maxTime, currentZoomRange[0]));
+    const right = edgePinned.right ? maxTime : Math.max(left, Math.min(maxTime, currentZoomRange[1]));
     return [left, right];
-  }, [currentZoomRange, minTime, maxTime, defaultRange]);
+  }, [currentZoomRange, minTime, maxTime, defaultRange, edgePinned]);
 
   // Deselecting a target clears any legend-hide on it, so reselecting the same
   // target shows its series again instead of staying invisible (#205).
@@ -166,6 +185,8 @@ export const Visualizer: React.FC<VisualizerProps> = ({
       {displayBuckets.map(g => (
         g.bucket.isBinary ? (
           <TimelineChart key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]} showDots={showDots} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} onTimeClick={onTimeClick} />
+        ) : g.bucket.isEvents ? (
+          <EventDotsChart key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]} autoFollow={autoFollow} onZoomRangeChange={setZoomRange} onTimeClick={onTimeClick} />
         ) : (
           <MixedChart
             key={g.key} bucket={g.bucket} minTime={activeRange[0]} maxTime={activeRange[1]}
@@ -198,6 +219,8 @@ export const Visualizer: React.FC<VisualizerProps> = ({
             value={activeRange}
             onChange={setZoomRange}
             telegrams={telegrams}
+            leftPinned={edgePinned.left}
+            rightPinned={edgePinned.right}
           />
         )}
         {charts}
@@ -216,6 +239,9 @@ export const Visualizer: React.FC<VisualizerProps> = ({
           untypedTargets={untypedTargets}
           dptOverrides={dptOverrides}
           onDptOverrideChange={setDptOverride}
+          writeEnabled={writeEnabled}
+          onFilterGAs={onFilterGAs}
+          onLastSeen={onLastSeen}
         />
 
         {/* Chart Area */}
@@ -303,6 +329,8 @@ export const Visualizer: React.FC<VisualizerProps> = ({
               value={activeRange}
               onChange={setZoomRange}
               telegrams={telegrams}
+              leftPinned={edgePinned.left}
+              rightPinned={edgePinned.right}
             />
           )}
           {charts}

--- a/frontend/src/components/VisualizerSidebar.tsx
+++ b/frontend/src/components/VisualizerSidebar.tsx
@@ -1,14 +1,18 @@
 import React, { useMemo, useState } from 'react';
-import { LineChart, X, Search } from 'lucide-react';
+import { LineChart, X, Search, Filter, Clock } from 'lucide-react';
 import type { Telegram } from '../hooks/useWebSocket';
 import { OptionRow } from './FilterPanel';
+import { SendToGaPopover } from './SendToGaPopover';
 import { RAW_DPT_OPTIONS } from '../utils/rawDpt';
 import { getPref, setPref } from '../utils/prefs';
+import { rowIconBtnStyle } from '../utils/buttonStyles';
 
 interface TargetCount {
   address: string;
   name: string;
   count: number;
+  dptMain: number | null;
+  dptSub: number | null;
 }
 
 interface VisualizerSidebarProps {
@@ -21,11 +25,16 @@ interface VisualizerSidebarProps {
   dptOverrides?: Record<string, string>;
   /** Assign (or clear, with '') the datatype for a GA. */
   onDptOverrideChange?: (address: string, key: string) => void;
+  /** Per-target row actions (#341): write/filter/last-seen. */
+  writeEnabled?: boolean;
+  onFilterGAs?: (addresses: string[]) => void;
+  onLastSeen?: (address: string | string[], mode: 'ga' | 'pa') => void;
 }
 
 export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
   telegrams, selectedTargets, onTargetsChange,
   untypedTargets, dptOverrides = {}, onDptOverrideChange,
+  writeEnabled, onFilterGAs, onLastSeen,
 }) => {
   // Persisted so the Targets filter survives closing/reopening the panel and
   // reloads, like the other visualization prefs (#361).
@@ -44,7 +53,9 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
         map.set(t.target_address, {
           address: t.target_address,
           name: t.target_name || 'Unknown Target',
-          count: 0
+          count: 0,
+          dptMain: t.dpt_main,
+          dptSub: t.dpt_sub,
         });
       }
       map.get(t.target_address)!.count++;
@@ -125,6 +136,41 @@ export const VisualizerSidebar: React.FC<VisualizerSidebarProps> = ({
                 checked={selected}
                 count={t.count}
                 onToggle={() => toggle(t.address)}
+                actions={(writeEnabled || onFilterGAs || onLastSeen) && (
+                  <>
+                    {writeEnabled && (
+                      <SendToGaPopover
+                        address={t.address}
+                        name={t.name}
+                        dptMain={t.dptMain}
+                        dptSub={t.dptSub}
+                        buttonStyle={rowIconBtnStyle}
+                      />
+                    )}
+                    {onFilterGAs && (
+                      <button
+                        style={rowIconBtnStyle}
+                        title="Filter by this group address"
+                        onClick={() => onFilterGAs([t.address])}
+                        onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                        onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                      >
+                        <Filter size={11} />
+                      </button>
+                    )}
+                    {onLastSeen && (
+                      <button
+                        style={rowIconBtnStyle}
+                        title="Show last seen values"
+                        onClick={() => onLastSeen([t.address], 'ga')}
+                        onMouseEnter={e => (e.currentTarget.style.color = 'var(--accent-primary)')}
+                        onMouseLeave={e => (e.currentTarget.style.color = 'var(--text-dim)')}
+                      >
+                        <Clock size={11} />
+                      </button>
+                    )}
+                  </>
+                )}
               />
               {needsDpt && (
                 <div style={{ padding: '0 0.25rem 0.5rem 1.75rem', marginTop: '-0.25rem' }}>

--- a/frontend/src/hooks/useChartData.test.ts
+++ b/frontend/src/hooks/useChartData.test.ts
@@ -63,15 +63,19 @@ describe('useChartData — addressToUnit (#349 chart lock)', () => {
 });
 
 describe('useChartData — datatype override for untyped GAs (#315)', () => {
-  test('untyped raw-byte telegrams do not plot without a chosen datatype', () => {
+  test('untyped raw-byte telegrams with no chosen datatype land in the events bucket (#341)', () => {
     const telegrams = [
       at(1, { target_address: '1/1/1', value_json: [0x0c, 0x1a] as unknown as Record<string, unknown> }),
       at(2, { target_address: '1/1/1', value_json: [0x0c, 0x1b] as unknown as Record<string, unknown> }),
     ];
     const { result } = renderHook(() => useChartData(telegrams, ['1/1/1']));
-    // A bucket exists but the raw byte arrays decode to nothing plottable.
+    // Unplottable as a numeric line, but not silently dropped either — shown
+    // as discrete event dots instead (#341).
+    expect(result.current.buckets).toHaveLength(1);
+    expect(result.current.buckets[0].unit).toBe('events');
+    expect(result.current.buckets[0].isEvents).toBe(true);
     const series = result.current.buckets[0]?.series[0];
-    expect(series?.data.every(v => v === null)).toBe(true);
+    expect(series?.real).toEqual([true, true]);
   });
 
   test('a chosen datatype decodes raw payloads and groups by its unit', () => {
@@ -95,6 +99,50 @@ describe('useChartData — datatype override for untyped GAs (#315)', () => {
     const { result } = renderHook(() => useChartData(telegrams, ['1/1/1'], { '1/1/1': '5.001' }));
     expect(result.current.buckets[0].unit).toBe('%');
     expect(result.current.buckets[0].series[0].data[0]).toBeCloseTo(100, 6);
+  });
+});
+
+describe('useChartData — events bucket for unchartable DPTs (#341)', () => {
+  test('text (DPT16) telegrams land in a shared events bucket with formatted labels', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', dpt_main: 16, dpt_sub: 1, value_json: 'Hello', value_formatted: 'Hello' }),
+      at(2, { target_address: '1/1/1', dpt_main: 16, dpt_sub: 1, value_json: 'World', value_formatted: 'World' }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1']));
+    expect(result.current.buckets).toHaveLength(1);
+    expect(result.current.buckets[0].unit).toBe('events');
+    expect(result.current.addressToUnit['1/1/1']).toBe('events');
+    const series = result.current.buckets[0].series[0];
+    expect(series.labels).toEqual(['Hello', 'World']);
+  });
+
+  test('binary and numeric GAs are not swept into the events bucket', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', dpt_main: 1, value_json: true }),
+      at(2, { target_address: '1/1/2', dpt_main: 9, dpt_sub: 1, unit: '°C', value_numeric: 20 }),
+      at(3, { target_address: '1/1/3', dpt_main: 16, dpt_sub: 1, value_json: 'Alarm', value_formatted: 'Alarm' }),
+    ];
+    const { result } = renderHook(() => useChartData(telegrams, ['1/1/1', '1/1/2', '1/1/3']));
+    expect(result.current.addressToUnit).toEqual({
+      '1/1/1': 'binary', '1/1/2': '°C', '1/1/3': 'events',
+    });
+    const eventsBucket = result.current.buckets.find(b => b.unit === 'events')!;
+    expect(eventsBucket.series.map(s => s.address)).toEqual(['1/1/3']);
+  });
+
+  test('an events-bucket series does not forward-fill between occurrences', () => {
+    const telegrams = [
+      at(1, { target_address: '1/1/1', dpt_main: 16, dpt_sub: 1, value_json: 'A', value_formatted: 'A' }),
+    ];
+    // A second, unrelated GA extends maxTime — the lone event should not
+    // "hold" a value across that appended column.
+    const telegramsWithLaterOther = [
+      ...telegrams,
+      at(5, { target_address: '1/1/2', dpt_main: 1, value_json: true }),
+    ];
+    const { result } = renderHook(() => useChartData(telegramsWithLaterOther, ['1/1/1', '1/1/2']));
+    const eventsSeries = result.current.buckets.find(b => b.unit === 'events')!.series[0];
+    expect(eventsSeries.data).toEqual([1, null]);
   });
 });
 

--- a/frontend/src/hooks/useChartData.ts
+++ b/frontend/src/hooks/useChartData.ts
@@ -10,11 +10,19 @@ export interface ChartSeries {
    * forward-filled hold). Drives the telegram dots (#195), so cyclic repeats of
    * the same value are visible instead of hidden inside a flat segment. */
   real: boolean[];
+  /** Formatted value text per column, only for an "events" bucket (#341) —
+   * unchartable telegrams (e.g. DPT16 text) have no numeric `data` to plot,
+   * just a discrete occurrence with a label shown in the dot's tooltip/legend. */
+  labels?: (string | null)[];
 }
 
 export interface ChartBucket {
   unit: string;
   isBinary: boolean;
+  /** GAs that never resolve to a number or boolean (e.g. text/complex DPTs)
+   * are grouped here as discrete, unfilled event dots instead of a numeric
+   * line or an always-empty series (#341). Mutually exclusive with isBinary. */
+  isEvents: boolean;
   timestamps: number[]; // shared x-values (unix ms)
   series: ChartSeries[];
 }
@@ -81,12 +89,38 @@ export function useChartData(
     const minTime = relevant[0].ts;
     const maxTime = relevant[relevant.length - 1].ts;
 
+    // A GA whose telegrams never resolve to a number or boolean (e.g. DPT16
+    // text, or a complex/unknown DPT with no chosen override) can't be
+    // plotted as a line — it used to land in the 'unknown' bucket as an
+    // always-empty series. Route those GAs into a dedicated "events" bucket
+    // of discrete dots instead (#341).
+    const binaryAddrs = new Set<string>();
+    const decodableAddrs = new Set<string>();
+    for (const t of relevant) {
+      if (t.dpt_main === 1 || typeof t.value_json === 'boolean') {
+        binaryAddrs.add(t.target_address);
+        continue;
+      }
+      const overrideKey = t.dpt_main == null ? dptOverrides[t.target_address] : undefined;
+      let val = t.value_numeric;
+      if (val === null && typeof t.value_json === 'number') val = t.value_json;
+      else if (val === null && overrideKey) val = overrideValue(t);
+      if (val !== null) decodableAddrs.add(t.target_address);
+    }
+    const eventAddrs = new Set(
+      relevant
+        .map(t => t.target_address)
+        .filter((a, i, arr) => arr.indexOf(a) === i && !binaryAddrs.has(a) && !decodableAddrs.has(a))
+    );
+
     // 2. Group into physical units / buckets
     // We treat DPT1 (boolean/binary) as a special bucket called 'binary'
     const grouped = new Map<string, typeof relevant>();
     const addressToUnit: Record<string, string> = {};
 
     for (const t of relevant) {
+      if (eventAddrs.has(t.target_address)) continue; // built as the shared 'events' bucket below
+
       const overrideKey = t.dpt_main == null ? dptOverrides[t.target_address] : undefined;
       let bucketKey = t.unit || 'unknown';
       if (overrideKey) {
@@ -158,9 +192,39 @@ export function useChartData(
       buckets.push({
         unit,
         isBinary,
+        isEvents: false,
         timestamps,
         series
       });
+    }
+
+    // 3b. Events bucket (#341): one shared lane group for every unchartable
+    // GA, dots only — no forward-fill, since each is a discrete occurrence
+    // rather than a held state.
+    if (eventAddrs.size > 0) {
+      const eventRows = relevant.filter(t => eventAddrs.has(t.target_address));
+      const tsSet = new Set<number>();
+      eventRows.forEach(r => tsSet.add(r.ts));
+      tsSet.add(maxTime);
+      const timestamps = Array.from(tsSet).sort((a, b) => a - b);
+
+      const series: ChartSeries[] = Array.from(eventAddrs).map(addr => {
+        const rows = eventRows.filter(r => r.target_address === addr);
+        const name = rows[0]?.target_name || addr;
+        const real: boolean[] = [];
+        const data: (number | null)[] = [];
+        const labels: (string | null)[] = [];
+        for (const ts of timestamps) {
+          const match = rows.find(r => r.ts === ts);
+          real.push(!!match);
+          data.push(match ? 1 : null);
+          labels.push(match ? (match.value_formatted ?? (match.value_json != null ? String(match.value_json) : null)) : null);
+        }
+        return { address: addr, name, data, real, labels };
+      });
+
+      buckets.push({ unit: 'events', isBinary: false, isEvents: true, timestamps, series });
+      eventAddrs.forEach(a => { addressToUnit[a] = 'events'; });
     }
 
     // Order buckets by metric (unit), not by which telegram arrived first. The

--- a/frontend/src/utils/buttonStyles.ts
+++ b/frontend/src/utils/buttonStyles.ts
@@ -32,3 +32,11 @@ export function secondaryBtn(disabled: boolean): React.CSSProperties {
     cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.5 : 1,
   };
 }
+
+/** Small inline per-row action icon (filter/last-seen/visualize/write), as used
+ * on GA/device rows throughout the app (#214, #306, #341). */
+export const rowIconBtnStyle: React.CSSProperties = {
+  background: 'transparent', border: 'none', cursor: 'pointer',
+  color: 'var(--text-dim)', padding: '0.15rem', borderRadius: '3px',
+  display: 'inline-flex', alignItems: 'center', verticalAlign: 'middle',
+};

--- a/frontend/src/utils/chartLock.test.ts
+++ b/frontend/src/utils/chartLock.test.ts
@@ -5,7 +5,7 @@ import type { ChartBucket, ChartSeries } from '../hooks/useChartData';
 const series = (address: string): ChartSeries => ({ address, name: address, data: [1], real: [true] });
 
 const bucket = (unit: string, addresses: string[]): ChartBucket => ({
-  unit, isBinary: false, timestamps: [1000], series: addresses.map(series),
+  unit, isBinary: false, isEvents: false, timestamps: [1000], series: addresses.map(series),
 });
 
 describe('splitLockedBuckets', () => {


### PR DESCRIPTION
## Summary
Implements the three remaining "ready, specced" items from #341 (state-persistence, last-clicked highlight, and quick-clear were already shipped; chart-timeline click→list landed separately in #308; revert of #241 is explicitly out of scope per the triage note).

- **Autoscroll in the pan & zoom ruler**: `TimeBrush` handles now pin to their domain edge when left at (or dragged/double-clicked to) `minTime`/`maxTime`, tracking it as the buffer grows or purges — the timeline analogue of the telegram list's live-edge follow (#203). Ephemeral, like list-follow: not part of the shareable-link `zoomRange` contract.
- **Function icons throughout**: write/filter/last-seen icons on Visualization Targets sidebar rows; filter/visualize/write/last-seen icons throughout the Last Seen Values pane — sidebar rows for both GA and device modes, and (per the issue's reference screenshots) the SOURCE/TARGET table columns showing the "other kind" address of each telegram, so you can act on or jump to it without leaving the pane.
- **Dots for unchartable DPTs**: GAs whose telegrams never resolve to a number or boolean (DPT16 text, unmapped/complex payloads with no chosen override) used to silently plot an always-empty line in the "unknown" bucket. They're now grouped into a dedicated "events" bucket and rendered as discrete, labeled dots (new `EventDotsChart`), consistent with the binary timeline's per-GA lane layout, with the formatted value shown in the hover/legend.

## Bug found & fixed along the way
While building `EventDotsChart` I hit a genuine rendering bug: its canvas draw plugin computed each row's y-position from a static per-row offset, independent of uPlot's *actual* plot bbox. The fixed axis+padding overhead can shrink that bbox to a few pixels for a low series count, silently clipping all drawn content outside it — confirmed via pixel-level canvas inspection (`fillStyle` correctly set, but the pixel stayed fully transparent because the point was outside the clip region). Fixed by deriving row positions from the live bbox height instead of the static offset.

## Test plan
- [x] `npx tsc -b --noEmit`, `eslint`, `vitest run` (361/361), `npm run build` all clean
- [x] Playwright end-to-end verification against the running dev app (stubbed API/WS, no real KNX bus):
  - TimeBrush: dragged the right handle inward (unpinned, stayed put on new telegrams), then double-clicked it back to the live edge (pinned) and confirmed the window's right edge label advanced as new telegrams arrived.
  - Visualizer sidebar icons: write/filter/last-seen icons present and functional per target row.
  - Last Seen Values: GA sidebar rows get write+visualize+filter icons, device rows get filter; selecting a device and checking its telegram table's TARGET column shows write/visualize/filter/last-seen icons per GA.
  - Event dots: selected a DPT16 (text) GA, confirmed 4 discrete dots spread across the timeline (pixel-level canvas inspection after the bbox fix), hovering updates the legend to the nearest event's formatted text, and clicking a point still correctly navigates back to the telegram list per #308's mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)