### PR TITLE
Allow sending empty text for DPT 16/28 (#410)

### DIFF
--- a/frontend/src/components/WriteControls.test.tsx
+++ b/frontend/src/components/WriteControls.test.tsx
@@ -34,6 +34,16 @@ test('Write is disabled while the value is empty', () => {
   expect(screen.getByRole('button', { name: /Write/ })).toBeDisabled();
 });
 
+test('DPT 16/28 (string) allow sending an empty value (#410)', () => {
+  const onWrite = vi.fn();
+  render(<WriteControls dptMain={16} value="" onValueChange={() => {}} onWrite={onWrite} />);
+
+  const writeBtn = screen.getByRole('button', { name: /Write/ });
+  expect(writeBtn).not.toBeDisabled();
+  fireEvent.click(writeBtn);
+  expect(onWrite).toHaveBeenCalledWith('');
+});
+
 test('DPT 10 renders a time input field and handles write', () => {
   const onWrite = vi.fn();
   const onValueChange = vi.fn();

--- a/frontend/src/components/WriteControls.tsx
+++ b/frontend/src/components/WriteControls.tsx
@@ -170,7 +170,12 @@ export function WriteControls({ dptMain, dptKey, address, value, onValueChange, 
     );
   }
 
-  const writeDisabled = disabled || value.trim() === '';
+  // DPT 16 (14-byte string) and 28 (UTF-8 string) treat an empty string as a
+  // valid payload (e.g. clearing a text display) — only block the send for
+  // DPTs where an empty value isn't meaningful, e.g. because it can't be
+  // coerced to a number (#410).
+  const isTextDpt = dptMain === 16 || dptMain === 28;
+  const writeDisabled = disabled || (!isTextDpt && value.trim() === '');
   return (
     <div style={{ position: 'relative', display: 'inline-flex', gap: '0.3rem', alignItems: 'center' }}>
       <div style={{ position: 'relative' }}>


### PR DESCRIPTION
## Summary
- The bus-write Write button (`WriteControls`, shared by the send bar and Last Seen Values) was disabled whenever the value field was empty, for every DPT. Correct for numeric types (an empty string can't be coerced to a number), but it also silently blocked a legitimate payload: an empty string for DPT 16 (14-byte string) / DPT 28 (UTF-8 string), e.g. clearing a text display or alarm message.
- Verified the backend already accepts and transcodes an empty string fine (`KnxSendRequest.payload: Any`, no falsy-check in `_encode_payload`/`send_group_value`) — this was a frontend-only bug.
- Fix: `writeDisabled` in `WriteControls.tsx` now only requires a non-empty value for non-string DPTs (`dptMain !== 16 && dptMain !== 28`).

Closes #410.

## Test plan
- [x] New unit test: DPT 16 allows an empty value and calls `onWrite('')`; existing DPT 5 empty-disabled test untouched (362/362 passing)
- [x] `npx tsc -b --noEmit`, `eslint`, `npm run build` all clean
- [x] Playwright verification against the running dev app (stubbed API/WS): selected a DPT 16.001 GA in Last Seen Values, confirmed the Write button is enabled with an empty value field, clicked it, and confirmed the intercepted `/api/knx/send` request carried `payload: ""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)