### PR TITLE
Use local timezone, not UTC, for purge-before-date cutoff (#416)

### DIFF
--- a/frontend/src/components/DatabaseOverlay.test.tsx
+++ b/frontend/src/components/DatabaseOverlay.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { DatabaseOverlay } from './DatabaseOverlay';
+
+const INFO = {
+  backend: 'postgresql',
+  telegram_count: 637687,
+  oldest_timestamp: '2026-08-05T02:00:00',
+  newest_timestamp: '2026-08-09T08:30:31',
+  size_bytes: 116_916_224,
+  retention_days: null,
+  supports_size_stats: true,
+  supports_optimize: true,
+  read_only: false,
+};
+
+function mockFetch(purgeHandler: (body: unknown) => unknown) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes('/api/database/info')) {
+      return { ok: true, json: async () => INFO } as Response;
+    }
+    if (url.includes('/api/database/purge')) {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      return { ok: true, json: async () => purgeHandler(body) } as Response;
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch(() => ({ deleted: 0 })));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test('purge-before-date uses local midnight, not UTC midnight, as the cutoff (#416)', async () => {
+  let purgeBody: { older_than?: string } | undefined;
+  vi.stubGlobal('fetch', mockFetch(body => {
+    purgeBody = body as { older_than?: string };
+    return { deleted: 0 };
+  }));
+
+  render(<DatabaseOverlay onClose={() => {}} />);
+  await waitFor(() => expect(screen.getByText('postgresql')).toBeInTheDocument());
+
+  const dateInput = document.querySelector('input[type="date"]') as HTMLInputElement;
+  fireEvent.change(dateInput, { target: { value: '2026-08-05' } });
+  fireEvent.click(screen.getByRole('button', { name: /Preview/ }));
+
+  await waitFor(() => expect(purgeBody?.older_than).toBeDefined());
+
+  // A date-only string parses as UTC midnight per the JS spec — the buggy
+  // cutoff. Local midnight is what the user actually picked; the two only
+  // coincide when the test runner happens to be in UTC, so assert against
+  // the *local* interpretation explicitly rather than a fixed offset.
+  const expectedLocalMidnight = new Date('2026-08-05T00:00:00').toISOString();
+  const buggyUtcMidnight = new Date('2026-08-05').toISOString();
+  expect(purgeBody?.older_than).toBe(expectedLocalMidnight);
+  if (expectedLocalMidnight !== buggyUtcMidnight) {
+    expect(purgeBody?.older_than).not.toBe(buggyUtcMidnight);
+  }
+});

--- a/frontend/src/components/DatabaseOverlay.tsx
+++ b/frontend/src/components/DatabaseOverlay.tsx
@@ -240,7 +240,11 @@ export const DatabaseOverlay: React.FC<DatabaseOverlayProps> = ({ onClose }) => 
                     <button
                       className="glass-button"
                       disabled={busy || !cutoffDate}
-                      onClick={() => requestPreview(new Date(cutoffDate).toISOString())}
+                      // A date-only string ("2026-08-05") parses as UTC midnight per the
+                      // JS spec, not local midnight — appending a bare time makes it parse
+                      // as local time instead, so the cutoff matches the date the user
+                      // actually picked in their own timezone (#416).
+                      onClick={() => requestPreview(new Date(`${cutoffDate}T00:00:00`).toISOString())}
                       style={{ padding: '0.4rem 0.8rem', fontSize: '0.8rem', borderRadius: 6, border: '1px solid var(--border-color)', background: 'var(--bg-tag)', color: 'var(--text-main)', cursor: busy || !cutoffDate ? 'not-allowed' : 'pointer' }}
                     >
                       Preview


### PR DESCRIPTION
## Summary
- `Database Maintenance`'s "or before" date picker built the purge cutoff via `new Date(cutoffDate).toISOString()`, where `cutoffDate` is a date-only string ("2026-08-05") from `<input type="date">`. Per the JS `Date` spec, a date-only string parses as **UTC midnight**, not local midnight — so picking a date purged everything up to a cutoff shifted by the local UTC offset, e.g. a UTC+2 user picking "before Aug 5" actually got "before Aug 5 02:00 local", not "before Aug 5 00:00 local" as intended. Visible in the reported screenshot: after the purge, the oldest remaining telegram landed at `5.8.2026, 02:00:00` instead of `00:00:00`.
- Fix: append a bare time component (`${cutoffDate}T00:00:00`) before parsing, so it parses as local midnight instead — the date the user actually picked, in their own timezone.
- Confirmed this is frontend-only: the backend's `older_than: datetime` just does a straightforward comparison against the parsed (correct) UTC-equivalent instant.

Closes #416.

## Test plan
- [x] New unit test renders `DatabaseOverlay`, mocks `fetch`, picks a date, clicks Preview, and asserts the POST body's `older_than` equals the *local*-midnight ISO instant — confirmed it fails against the pre-fix code (`git stash` roundtrip) and passes after the fix.
- [x] `npx tsc -b --noEmit`, `eslint`, `vitest run` (362/362), `npm run build` all clean.
- [x] Playwright verification against the running dev app (stubbed API/WS): opened Database Maintenance, picked `2026-08-05`, clicked Preview, and confirmed the intercepted `/api/database/purge` request carried `older_than: "2026-08-04T22:00:00.000Z"` (correct local-midnight-in-UTC for this UTC+2 environment), not `"2026-08-05T00:00:00.000Z"` (the old UTC-midnight bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)