### PR TITLE
release: prepare v2.0.0-beta.6

### DIFF
--- a/ha-addon-companion/CHANGELOG.md
+++ b/ha-addon-companion/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.0.0-beta.6
+
+### Added
+
+- **Building Structure readability**: shared group-address table with row-hover highlighting, project-wide name-column alignment, and blank Time/Value cells for GAs never seen on the bus; function-type names, DPT-mismatch detection between linked group addresses, a comm-object summary row, and visualize icons throughout (#306, #307).
+- **Telegram List overhaul**: multi-level sorting, an always-on delta-time column, and a quick info bar (oldest/newest, min/max delta, jump-to-row); redesigned quick filter with per-column pattern matching and a DELTA TIME quick-filter cell (#311, #309).
+- **Time-Delta-Context**: switchable on/off without losing the entered before/after values, per-message flagging so a specific telegram always anchors its own context window, and clear visual marking of filtered vs. unfiltered context rows in the list (#318, #319, #343).
+- **Visualization improvements**: crowded charts get hover highlighting, a collapsible fixed legend, and a per-metric "lock" that spawns a new chart instead of piling more lines onto one; the pan & zoom timeline now sits above the charts and pins to the live edge as the buffer grows; clicking a point on a chart's timeline jumps back to the telegram list centered on that time; group addresses with unchartable values (e.g. text/DPT16) now render as discrete, labeled event dots instead of a blank chart (#349, #308, #341).
+- **Cross-navigation icons**: write-to-GA, add-to-filter, visualize, and last-seen-values icons throughout the Visualization Targets sidebar and the Last Seen Values pane, including on the "other kind" address (device or GA) shown in each telegram's row (#341).
+
+### Fixed
+
+- **Write to bus**: sending an empty value to a DPT 16/28 (string) group address was blocked by the Write button, even though an empty string is a valid payload for clearing a text display (#410).
+
 ## 2.0.0-beta.5
 
 ### Added

--- a/ha-addon-companion/config.yaml
+++ b/ha-addon-companion/config.yaml
@@ -1,7 +1,7 @@
 name: "Spectrum KNX (HA Companion)"
 description: "KNX analyzer UI on top of Home Assistant's own KNX telegram history — no second bus connection, no separate database"
 # Shares the image built from ha-addon/ — keep version in sync with ha-addon/config.yaml
-version: "2.0.0-beta.5"
+version: "2.0.0-beta.6"
 slug: "spectrum_knx_companion"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 init: false

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.0.0-beta.6
+
+### Added
+
+- **Building Structure readability**: shared group-address table with row-hover highlighting, project-wide name-column alignment, and blank Time/Value cells for GAs never seen on the bus; function-type names, DPT-mismatch detection between linked group addresses, a comm-object summary row, and visualize icons throughout (#306, #307).
+- **Telegram List overhaul**: multi-level sorting, an always-on delta-time column, and a quick info bar (oldest/newest, min/max delta, jump-to-row); redesigned quick filter with per-column pattern matching and a DELTA TIME quick-filter cell (#311, #309).
+- **Time-Delta-Context**: switchable on/off without losing the entered before/after values, per-message flagging so a specific telegram always anchors its own context window, and clear visual marking of filtered vs. unfiltered context rows in the list (#318, #319, #343).
+- **Visualization improvements**: crowded charts get hover highlighting, a collapsible fixed legend, and a per-metric "lock" that spawns a new chart instead of piling more lines onto one; the pan & zoom timeline now sits above the charts and pins to the live edge as the buffer grows; clicking a point on a chart's timeline jumps back to the telegram list centered on that time; group addresses with unchartable values (e.g. text/DPT16) now render as discrete, labeled event dots instead of a blank chart (#349, #308, #341).
+- **Cross-navigation icons**: write-to-GA, add-to-filter, visualize, and last-seen-values icons throughout the Visualization Targets sidebar and the Last Seen Values pane, including on the "other kind" address (device or GA) shown in each telegram's row (#341).
+
+### Fixed
+
+- **Write to bus**: sending an empty value to a DPT 16/28 (string) group address was blocked by the Write button, even though an empty string is a valid payload for clearing a text display (#410).
+- **Database purge**: "purge telegrams before a date" used UTC midnight instead of the server's local midnight as the cutoff, deleting (or keeping) a couple of hours' worth of telegrams the selected date didn't intend (#416).
+
 ## 2.0.0-beta.5
 
 ### Added

--- a/ha-addon/config.yaml
+++ b/ha-addon/config.yaml
@@ -1,6 +1,6 @@
 name: "Spectrum KNX"
 description: "A professional KNX bus monitor and analyzer"
-version: "2.0.0-beta.5"
+version: "2.0.0-beta.6"
 slug: "spectrum_knx"
 image: "ghcr.io/martinhoefling/spectrum-knx-addon-{arch}"
 host_network: true


### PR DESCRIPTION
## Summary
Version bump + changelog for v2.0.0-beta.6, covering everything merged since beta.5:

**Frontend revamp epics closed out** (#371, #372, #341 — all children now closed):
- Building Structure readability (#306, #307)
- Telegram List overhaul: multi-level sort, delta column, quick info bar, redesigned quick filter (#311, #309)
- Time-Delta-Context: switchable, per-message, filtered/context row marking (#318, #319, #343)
- Visualization: crowded-chart fixes, timeline-on-top + click-to-navigate, edge-pin autoscroll, cross-navigation icons, event dots for unchartable DPTs (#349, #308, #341)

**Bug fixes**:
- Empty-text writes to DPT 16/28 group addresses were blocked by the Write button (#410)
- Database purge "before a date" used UTC midnight instead of local midnight as the cutoff (#416, standalone-only — purge is gated behind `!read_only`, so companion mode's changelog omits it)

No code changes — version bump in both `ha-addon/config.yaml` and `ha-addon-companion/config.yaml`, matching `CHANGELOG.md` entries in both.

## Test plan
- [x] Both `config.yaml` files' `version:` field updated to `2.0.0-beta.6`
- [x] Both `CHANGELOG.md` files get a matching `## 2.0.0-beta.6` section (companion's Fixed section omits the purge-only fix, per precedent set by the beta.5 TimescaleDB entry)
- [ ] After merge: tag the merged `main` commit `v2.0.0-beta.6` and push the tag to trigger `.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)