### PR TITLE
feat: add health status monitoring endpoint (#421)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -460,3 +460,56 @@ configured each returns `{"status": "no_project_loaded"}`.
 |---|---|
 | `analyze_bus_traffic(hours)` | Steer a read-only analysis of recent traffic (volume, busy addresses, anomalies). |
 | `find_group_addresses_without_dpts` | Audit the project for group addresses missing a DPT. |
+
+---
+
+## 8. Health Monitoring & Kubernetes Probes
+
+Spectrum KNX includes a health check endpoint for monitoring systems, load balancers, and Kubernetes probes:
+
+- **Endpoints:**
+  - `/health` or `/api/health`: Full health check endpoint. Returns HTTP `200 OK` when healthy, or HTTP `503 Service Unavailable` when degraded or unhealthy.
+  - `/health/liveness` or `/api/health/liveness`: Liveness probe. Checks core process and database reachability.
+  - `/health/readiness` or `/api/health/readiness`: Readiness probe. Checks database reachability and active KNX bus connection status.
+
+- **Response Payload:**
+  ```json
+  {
+    "status": "ok",
+    "timestamp": "2026-08-14T22:18:00.123456+00:00",
+    "version": "1.0.0",
+    "store_mode": "standalone",
+    "checks": {
+      "database": {
+        "status": "ok",
+        "error": null
+      },
+      "knx_connection": {
+        "status": "ok",
+        "connected": true
+      },
+      "telegrams": {
+        "status": "ok",
+        "last_received_at": "2026-08-14T22:15:00+00:00",
+        "seconds_since_last_telegram": 180.0
+      }
+    }
+  }
+  ```
+
+- **Kubernetes Probes Example:**
+  ```yaml
+  livenessProbe:
+    httpGet:
+      path: /health/liveness
+      port: 8765
+    initialDelaySeconds: 15
+    periodSeconds: 10
+  readinessProbe:
+    httpGet:
+      path: /health/readiness
+      port: 8765
+    initialDelaySeconds: 10
+    periodSeconds: 5
+  ```
+

--- a/backend/api.py
+++ b/backend/api.py
@@ -6,7 +6,18 @@ import tempfile
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+from fastapi import (
+    APIRouter,
+    File,
+    Form,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
 from fastapi.responses import StreamingResponse
 from knx_telegram_store import TelegramQuery
 from knx_telegram_store.formats import COMMUNICATION_LOG_FOOTER, COMMUNICATION_LOG_HEADER, format_telegram_element
@@ -16,7 +27,9 @@ from xknx.exceptions import ConversionError, CouldNotParseAddress
 from xknx.telegram.address import GroupAddress, IndividualAddress
 
 import cyclic_send
+import ha_live_bridge
 import knx_daemon  # import global config
+import pg_listen_bridge
 import telegram_export
 import telegram_import
 import update_check
@@ -51,6 +64,111 @@ def get_backend_version() -> str:
 async def get_version():
     """Returns the backend version from ENV or git"""
     return {"version": get_backend_version()}
+
+
+@router.get("/health")
+@router.get("/api/health")
+@router.get("/health/liveness")
+@router.get("/api/health/liveness")
+@router.get("/health/readiness")
+@router.get("/api/health/readiness")
+async def get_health(request: Request, response: Response, probe_type: str | None = None):
+    """Health check endpoint for monitoring systems and Kubernetes probes.
+
+    Checks:
+    - database: reachability and store query execution.
+    - knx_connection: active bus connection in standalone/postgres-readonly modes,
+      or live feed status in external-readonly mode.
+    - telegrams: timestamp of the last telegram processed and time elapsed.
+    """
+    path = request.url.path
+    if path.endswith("/liveness") or probe_type == "liveness":
+        check_type = "liveness"
+    elif path.endswith("/readiness") or probe_type == "readiness":
+        check_type = "readiness"
+    else:
+        check_type = "full"
+
+    # 1. Database Check & Latest DB Telegram
+    db_status = "ok"
+    db_error = None
+    latest_db_telegram_ts = None
+
+    try:
+        res = await store.query(TelegramQuery(limit=1, order_descending=True))
+        if res.telegrams:
+            t_ts = res.telegrams[0].timestamp
+            if t_ts.tzinfo is None:
+                t_ts = t_ts.replace(tzinfo=UTC)
+            latest_db_telegram_ts = t_ts
+    except Exception as e:
+        db_status = "error"
+        db_error = str(e)
+
+    # 2. KNX Connection Check
+    knx_status = "n/a"
+    knx_connected = None
+
+    if STORE_MODE in ("standalone", "postgres-readonly"):
+        knx_connected = knx_daemon.is_connected()
+        knx_status = "ok" if knx_connected else "disconnected"
+    elif STORE_MODE == "external-readonly":
+        feed_stat = ha_live_bridge.live_feed_status()
+        knx_connected = feed_stat.get("connected", False)
+        knx_status = "ok" if knx_connected else "disconnected"
+
+    # 3. Telegram Activity Tracking
+    in_mem_ts = None
+    if STORE_MODE in ("standalone", "postgres-readonly"):
+        in_mem_ts = knx_daemon.get_last_telegram_timestamp()
+    elif STORE_MODE == "external-readonly":
+        in_mem_ts = ha_live_bridge.get_last_telegram_timestamp()
+
+    if STORE_MODE == "postgres-readonly" and in_mem_ts is None:
+        in_mem_ts = pg_listen_bridge.get_last_telegram_timestamp()
+
+    last_received_at = None
+    if in_mem_ts and latest_db_telegram_ts:
+        last_received_at = max(in_mem_ts, latest_db_telegram_ts)
+    else:
+        last_received_at = in_mem_ts or latest_db_telegram_ts
+
+    now = datetime.now(UTC)
+    seconds_since_last = None
+    if last_received_at:
+        if last_received_at.tzinfo is None:
+            last_received_at = last_received_at.replace(tzinfo=UTC)
+        seconds_since_last = round((now - last_received_at).total_seconds(), 2)
+
+    is_live = db_status == "ok"
+    is_ready = is_live and (knx_status in ("ok", "n/a"))
+
+    overall_ok = is_live if check_type == "liveness" else is_ready
+
+    if not overall_ok:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+    return {
+        "status": "ok" if overall_ok else "unhealthy",
+        "timestamp": now.isoformat(),
+        "version": get_backend_version(),
+        "store_mode": STORE_MODE,
+        "checks": {
+            "database": {
+                "status": db_status,
+                "error": db_error,
+            },
+            "knx_connection": {
+                "status": knx_status,
+                "connected": knx_connected,
+            },
+            "telegrams": {
+                "status": "ok" if last_received_at is not None else "no_telegrams",
+                "last_received_at": last_received_at.isoformat() if last_received_at else None,
+                "seconds_since_last_telegram": seconds_since_last,
+            },
+        },
+    }
 
 
 @router.get("/api/update")

--- a/backend/ha_live_bridge.py
+++ b/backend/ha_live_bridge.py
@@ -18,9 +18,9 @@ import os
 from datetime import UTC, datetime
 
 import websockets
+from knx_telegram_store import TelegramQuery
 
 from database import store
-from knx_telegram_store import TelegramQuery
 from parsers import format_dpt_name, format_value_nicely, get_simplified_type
 from ws_manager import manager
 
@@ -39,6 +39,11 @@ _connected: bool = False
 def live_feed_status() -> dict:
     """Current live-feed state for the status API (companion mode, #184)."""
     return {"source": _active_source, "connected": _connected}
+
+
+def get_last_telegram_timestamp() -> datetime | None:
+    """Returns the timestamp of the last telegram seen by the HA bridge."""
+    return _last_seen
 
 
 def _ha_token() -> str:

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -33,6 +33,7 @@ global_knx_project: Any | None = None
 project_name_map: dict[str, dict[str, str | None]] = {"ga": {}, "ia": {}}
 _connect_task: asyncio.Task | None = None
 _watch_task: asyncio.Task | None = None
+_last_telegram_timestamp: datetime | None = None
 
 
 async def _load_project_data() -> bool:
@@ -225,6 +226,7 @@ async def _watch_files():
 
 
 async def process_telegram_async(telegram: XknxTelegram):
+    global _last_telegram_timestamp
     if STORE_MODE == "postgres-readonly":
         # The daemon is connected only to enable outbound bus writes here; the
         # telegram store is a shared, read-only view of what the writer (e.g.
@@ -234,6 +236,7 @@ async def process_telegram_async(telegram: XknxTelegram):
         return
     try:
         ts = datetime.now(UTC)
+        _last_telegram_timestamp = ts
 
         source_addr = str(telegram.source_address)
         target_addr = str(telegram.destination_address) if telegram.destination_address else "0/0/0"
@@ -415,6 +418,11 @@ def is_connected() -> bool:
         return xknx_instance.connection_manager.connected.is_set()
     except Exception:
         return False
+
+
+def get_last_telegram_timestamp() -> datetime | None:
+    """Returns the timestamp of the last telegram processed by the daemon."""
+    return _last_telegram_timestamp
 
 
 def write_enabled() -> bool:

--- a/backend/pg_listen_bridge.py
+++ b/backend/pg_listen_bridge.py
@@ -32,6 +32,11 @@ def live_feed_status() -> dict:
     return {"connected": _connected}
 
 
+def get_last_telegram_timestamp() -> datetime | None:
+    """Returns the timestamp of the last telegram seen by the Postgres listen bridge."""
+    return _last_seen
+
+
 def _as_utc(dt: datetime) -> datetime:
     """The store round-trips naive timestamps as UTC by convention."""
     return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)

--- a/backend/telegram_export.py
+++ b/backend/telegram_export.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import UTC
 
+from knx_telegram_store import StoredTelegram
 from knx_telegram_store.formats import RawTelegramRecord
 from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
 from xknx.dpt import DPTArray, DPTBinary
@@ -17,8 +18,6 @@ from xknx.exceptions import XKNXException
 from xknx.telegram import Telegram as XknxTelegram
 from xknx.telegram.address import GroupAddress, IndividualAddress
 from xknx.telegram.apci import APCI, GroupValueRead, GroupValueResponse, GroupValueWrite
-
-from knx_telegram_store import StoredTelegram
 
 # DPT main numbers whose payload travels inside the APCI byte (DPTBinary, ≤6 bit)
 _BINARY_DPT_MAINS = {1, 2, 3, 23}

--- a/backend/telegram_import.py
+++ b/backend/telegram_import.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import IO, Any
 
+from knx_telegram_store import StoredTelegram, TelegramQuery
 from knx_telegram_store.formats import RawTelegramRecord, iter_communication_log
 from xknx.cemi import CEMIFrame
 from xknx.exceptions import XKNXException
@@ -28,7 +29,6 @@ from xknx.telegram import Telegram as XknxTelegram
 from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
 
 import knx_daemon
-from knx_telegram_store import StoredTelegram, TelegramQuery
 from parsers import parse_telegram_payload
 
 logger = logging.getLogger("uvicorn.error")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -2,10 +2,10 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
 
 import knx_daemon
 from api import _aggregate_statistics
-from knx_telegram_store import StoredTelegram, TelegramQueryResult
 from main import app
 
 client = TestClient(app)

--- a/backend/tests/test_api_health.py
+++ b/backend/tests/test_api_health.py
@@ -1,0 +1,121 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
+
+import main
+
+client = TestClient(main.app)
+empty_query_result = TelegramQueryResult(telegrams=[], total_count=0, limit_reached=False)
+
+
+def test_health_endpoint_healthy():
+    """Test /health and /api/health when all systems are operational."""
+    with (
+        patch("knx_daemon.is_connected", return_value=True),
+        patch("database.store.query", new_callable=AsyncMock, return_value=empty_query_result),
+    ):
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["checks"]["database"]["status"] == "ok"
+        assert data["checks"]["knx_connection"]["status"] == "ok"
+        assert data["checks"]["knx_connection"]["connected"] is True
+
+        api_response = client.get("/api/health")
+        assert api_response.status_code == 200
+        assert api_response.json()["status"] == "ok"
+
+
+def test_health_endpoint_db_error():
+    """Test /health when database query raises an exception."""
+    with (
+        patch("knx_daemon.is_connected", return_value=True),
+        patch("database.store.query", new_callable=AsyncMock, side_effect=RuntimeError("Database connection failed")),
+    ):
+        response = client.get("/health")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "unhealthy"
+        assert data["checks"]["database"]["status"] == "error"
+        assert "Database connection failed" in data["checks"]["database"]["error"]
+
+
+def test_health_endpoint_knx_disconnected():
+    """Test /health and /health/readiness when KNX daemon is disconnected."""
+    with (
+        patch("knx_daemon.is_connected", return_value=False),
+        patch("database.store.query", new_callable=AsyncMock, return_value=empty_query_result),
+    ):
+        # Readiness / full check should fail (503)
+        response = client.get("/health")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "unhealthy"
+        assert data["checks"]["knx_connection"]["status"] == "disconnected"
+        assert data["checks"]["knx_connection"]["connected"] is False
+
+        readiness_resp = client.get("/health/readiness")
+        assert readiness_resp.status_code == 503
+
+        # Liveness check should still pass (200) since DB is reachable
+        liveness_resp = client.get("/health/liveness")
+        assert liveness_resp.status_code == 200
+        assert liveness_resp.json()["status"] == "ok"
+
+
+def test_health_liveness_db_error():
+    """Test /health/liveness when DB is failing."""
+    with (
+        patch("knx_daemon.is_connected", return_value=True),
+        patch("database.store.query", new_callable=AsyncMock, side_effect=RuntimeError("DB Down")),
+    ):
+        response = client.get("/health/liveness")
+        assert response.status_code == 503
+        assert response.json()["status"] == "unhealthy"
+
+
+def test_health_external_readonly_mode():
+    """Test /health when STORE_MODE is external-readonly."""
+    with (
+        patch("database.STORE_MODE", "external-readonly"),
+        patch("api.STORE_MODE", "external-readonly"),
+        patch("ha_live_bridge.live_feed_status", return_value={"source": "ha_websocket", "connected": True}),
+        patch("database.store.query", new_callable=AsyncMock, return_value=empty_query_result),
+    ):
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert data["checks"]["knx_connection"]["status"] == "ok"
+        assert data["checks"]["knx_connection"]["connected"] is True
+
+
+def test_health_telegram_activity_reporting():
+    """Test timestamp and elapsed seconds calculations for telegram activity."""
+    past_time = datetime.now(UTC) - timedelta(seconds=120)
+    fake_telegram = StoredTelegram(
+        timestamp=past_time,
+        source="1.1.1",
+        destination="0/0/1",
+        telegramtype="GroupValueWrite",
+        direction="Incoming",
+        payload=True,
+    )
+    fake_res = TelegramQueryResult(telegrams=[fake_telegram], total_count=1, limit_reached=False)
+
+    with (
+        patch("knx_daemon.is_connected", return_value=True),
+        patch("knx_daemon.get_last_telegram_timestamp", return_value=past_time),
+        patch("database.store.query", new_callable=AsyncMock, return_value=fake_res),
+    ):
+        response = client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        telegrams_check = data["checks"]["telegrams"]
+        assert telegrams_check["status"] == "ok"
+        assert telegrams_check["last_received_at"] is not None
+        assert telegrams_check["seconds_since_last_telegram"] is not None
+        assert telegrams_check["seconds_since_last_telegram"] >= 115

--- a/backend/tests/test_api_import_export.py
+++ b/backend/tests/test_api_import_export.py
@@ -5,9 +5,9 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
 
 import telegram_import
-from knx_telegram_store import StoredTelegram, TelegramQueryResult
 from main import app
 
 client = TestClient(app)

--- a/backend/tests/test_ha_live_bridge.py
+++ b/backend/tests/test_ha_live_bridge.py
@@ -2,10 +2,10 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
 
 import ha_live_bridge
 from ha_live_bridge import _as_utc, _fetch_since, _note_seen, ha_telegram_to_frontend
-from knx_telegram_store import StoredTelegram, TelegramQueryResult
 
 
 def _ha_telegram(**overrides) -> dict:

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
+from knx_telegram_store import StoredTelegram
 from knx_telegram_store.backends.memory import MemoryStore
 from xknx import XKNX
 from xknx.dpt import DPTArray
@@ -10,7 +11,6 @@ from xknx.telegram import GroupAddress, Telegram, apci
 
 import knx_daemon
 import mcp_server
-from knx_telegram_store import StoredTelegram
 
 NOW = datetime(2026, 7, 23, 12, 0, 0, tzinfo=UTC)
 

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -28,8 +28,9 @@ class TestSecurity(unittest.TestCase):
         self.assertFalse(is_safe_path(self.static_dir, "index.html\0.php"))
 
     def test_default_cors_origins(self):
-        from main import app
         from fastapi.testclient import TestClient
+
+        from main import app
 
         client = TestClient(app)
         response = client.options(

--- a/backend/tests/test_telegram_export.py
+++ b/backend/tests/test_telegram_export.py
@@ -9,10 +9,10 @@ verify an export→re-import round trip preserves addresses, type and payload.
 import io
 from datetime import UTC, datetime
 
+from knx_telegram_store import StoredTelegram
 from knx_telegram_store.formats import format_telegram_element, iter_communication_log
 
 import telegram_export as te
-from knx_telegram_store import StoredTelegram
 from telegram_import import decode_cemi
 
 

--- a/backend/tests/test_telegram_import.py
+++ b/backend/tests/test_telegram_import.py
@@ -10,11 +10,11 @@ import tempfile
 from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
+from knx_telegram_store import StoredTelegram, TelegramQueryResult
 from knx_telegram_store.formats import RawTelegramRecord
 
 import knx_daemon
 import telegram_import as ti
-from knx_telegram_store import StoredTelegram, TelegramQueryResult
 
 
 @pytest.fixture(autouse=True)

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -42,3 +42,10 @@ This directory contains templates for deploying Spectrum KNX on Kubernetes.
    ```bash
    kubectl apply -f spectrumknx-ingress.yaml
    ```
+
+## Health Probes & Monitoring
+
+`spectrumknx-sts.yaml` comes configured with `livenessProbe` (`/health/liveness`) and `readinessProbe` (`/health/readiness`):
+- **Liveness** (`/health/liveness`): verifies process health and database reachability.
+- **Readiness** (`/health/readiness`): verifies database reachability and active KNX bus connection status before routing traffic to the pod.
+

--- a/kubernetes/spectrumknx-sts.yaml
+++ b/kubernetes/spectrumknx-sts.yaml
@@ -41,6 +41,19 @@ spec:
           ports:
             - containerPort: 8765
               name: http
+          livenessProbe:
+            httpGet:
+              path: /health/liveness
+              port: 8765
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health/readiness
+              port: 8765
+            initialDelaySeconds: 10
+            periodSeconds: 5
+
           volumeMounts:
             - name: knxproj
               mountPath: "/knxproj"


### PR DESCRIPTION
Closes #421

### Summary of Changes

1. **Health Check Endpoint**:
   - Added `/health` and `/api/health` endpoints (plus `/health/liveness` and `/health/readiness` probe paths) in `backend/api.py`.
   - Checks database connectivity, KNX bus connection status, and telegram activity timestamp/elapsed seconds.
   - Returns HTTP 200 OK when healthy, and HTTP 503 Service Unavailable when degraded/unhealthy.

2. **Kubernetes Configuration**:
   - Updated `kubernetes/spectrumknx-sts.yaml` with `livenessProbe` (`/health/liveness`) and `readinessProbe` (`/health/readiness`).

3. **Tests & Docs**:
   - Added `backend/tests/test_api_health.py` covering all health check states and companion modes.
   - Updated `DEPLOYMENT.md` and `kubernetes/README.md`.