### PR TITLE
Refuse to start on a PostgreSQL major-version mismatch (#432)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -590,3 +590,57 @@ Inside the Home Assistant add-on the notification points at the add-on page, sin
 updates are applied from the add-on store rather than by pulling an image.
 
 Set `UPDATE_CHECK=false` to disable the check entirely (no outbound request is made).
+
+## 10. PostgreSQL Major Versions & Upgrades
+
+> Applies only to `DB_BACKEND=POSTGRES`. SQLite installs and the HA Companion add-on
+> (which reads Home Assistant's own database) are unaffected.
+
+A PostgreSQL **data directory can only be opened by the major version that created it**.
+Pointing a newer PostgreSQL at an existing directory does not upgrade it — the server refuses
+to start. Moving between major versions always requires an explicit data migration.
+
+Current versions:
+
+| Deployment | PostgreSQL |
+| --- | --- |
+| Home Assistant add-on | 15 (bundled in the image) |
+| Docker Compose (`docker-compose.yml`) | 15 (`timescale/timescaledb:latest-pg15`) |
+| Kubernetes (`kubernetes/timescaledb-sts.yaml`) | 16 (`timescale/timescaledb:latest-pg16`) |
+
+### 10.1 Home Assistant add-on
+
+The add-on **detects a version mismatch and refuses to start**, leaving the existing data
+directory untouched, rather than failing obscurely or coming up with an empty database. The
+add-on log states which version wrote the data and which version the add-on bundles.
+
+If you hit this, go back to the add-on version bundling the PostgreSQL major that wrote your data,
+or restore a Home Assistant backup.
+
+Automatic migration to PostgreSQL 18 on first start is planned — see
+[#432](https://github.com/martinhoefling/SpectrumKNX/issues/432). **Take a Home Assistant backup
+before installing the release that introduces it.**
+
+### 10.2 Docker Compose
+
+You own the database container. Changing the `db` image to a different PostgreSQL major while the
+`knx_db_data` volume still holds data from the old major will leave the container failing to start
+with an "incompatible data directory" error in its log. Nothing is lost — revert the tag and it
+comes back.
+
+Migration tooling for Compose is planned alongside the add-on migration (#432). Until it ships,
+either stay on the current major or migrate by hand with `pg_dump`/`pg_restore` between an old and
+a new container.
+
+### 10.3 Kubernetes
+
+**Manual.** No migration tooling is provided for Kubernetes deployments — a major upgrade of the
+TimescaleDB StatefulSet is yours to plan and execute against the PVC, using the standard
+PostgreSQL approaches (`pg_upgrade`, or `pg_dump`/`pg_restore` into a new StatefulSet).
+
+One thing worth knowing if you do it by hand: Spectrum KNX **rebuilds its own TimescaleDB state on
+startup**. `telegrams` is converted to a hypertable (`migrate_data => TRUE`) and the compression
+policy is re-applied every time the application initialises. So a plain logical dump/restore of the
+four tables (`telegrams`, `last_ga_telegrams`, `string_lookup`, `store_metadata`) into a fresh
+cluster is sufficient — you do not need to preserve TimescaleDB's own catalog, and the extension
+version does not have to match.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 services:
   db:
+    # Changing this major version under an existing knx_db_data volume will stop
+    # the container from starting — the data directory belongs to the old major.
+    # See DEPLOYMENT.md "PostgreSQL Major Versions & Upgrades" (#432).
     image: timescale/timescaledb:latest-pg15
     container_name: knx_timescale
     environment:

--- a/ha-addon/rootfs/etc/services.d/postgres/run
+++ b/ha-addon/rootfs/etc/services.d/postgres/run
@@ -8,18 +8,55 @@ if [ "$DB_BACKEND" = "SQLITE" ] || [ "$COMPANION_MODE" = "true" ]; then
     exec sleep infinity
 fi
 
+# ── Bundled PostgreSQL version ────────────────────────────────────────────────
+# Derived from the image rather than hardcoded, so moving to a new major only
+# means changing the Dockerfile (#432).
+PG_MAJOR="$(ls -1 /usr/lib/postgresql 2>/dev/null | sort -V | tail -n 1)"
+if [ -z "$PG_MAJOR" ]; then
+    bashio::log.fatal "No PostgreSQL installation found under /usr/lib/postgresql — this is a broken image."
+    exec sleep infinity
+fi
+PG_BIN="/usr/lib/postgresql/${PG_MAJOR}/bin"
+
 # ── Persistent data directory ─────────────────────────────────────────────────
 # Home Assistant persists /data across container restarts and updates.
 # We store PostgreSQL data there. The KNX project directory (/project) is set up
 # by the spectrum_knx service so it also exists in SQLite/companion modes.
 DATADIR="/data/postgres"
+INCOMPATIBLE_MARKER="/data/postgres.incompatible"
 mkdir -p "$DATADIR"
 chown -R postgres:postgres "$DATADIR"
 chmod 700 "$DATADIR"
 
+# Clear any marker from a previous boot before re-checking.
+rm -f "$INCOMPATIBLE_MARKER"
+
+# ── Major-version guard ───────────────────────────────────────────────────────
+# A PostgreSQL data directory can only be opened by the major version that wrote
+# it. Without this check a version bump would skip initdb (the directory is not
+# empty) and the new binary would reject the directory, so the add-on would fail
+# to boot with an obscure error — or, worse, look like the history was lost.
+# Refuse loudly instead and leave the data untouched. Automatic migration to a
+# newer major is tracked in #432.
+if [ -s "$DATADIR/PG_VERSION" ]; then
+    EXISTING_MAJOR="$(cat "$DATADIR/PG_VERSION")"
+    if [ "$EXISTING_MAJOR" != "$PG_MAJOR" ]; then
+        echo "$EXISTING_MAJOR" > "$INCOMPATIBLE_MARKER"
+        bashio::log.fatal "Database version mismatch — refusing to start."
+        bashio::log.fatal "  ${DATADIR} was created by PostgreSQL ${EXISTING_MAJOR}"
+        bashio::log.fatal "  this add-on bundles PostgreSQL ${PG_MAJOR}"
+        bashio::log.fatal "Your telegram history has NOT been touched or deleted."
+        bashio::log.fatal "A major-version change needs a data migration; automatic migration is tracked in issue #432."
+        bashio::log.fatal "For now: go back to the add-on version bundling PostgreSQL ${EXISTING_MAJOR}, or restore a Home Assistant backup."
+        # Hold instead of exiting: a crash loop would scroll this message out of
+        # the add-on log, which is the only place the user can read it.
+        exec sleep infinity
+    fi
+fi
+
 if [ ! -s "$DATADIR/PG_VERSION" ]; then
-    bashio::log.info "Initializing database..."
-    s6-setuidgid postgres /usr/lib/postgresql/15/bin/initdb -D "$DATADIR"
+    bashio::log.info "Initializing database (PostgreSQL ${PG_MAJOR})..."
+    s6-setuidgid postgres "$PG_BIN"/initdb -D "$DATADIR"
 
     # Add timescaledb to preload libraries
     echo "shared_preload_libraries = 'timescaledb'" >> "$DATADIR/postgresql.conf"
@@ -30,12 +67,12 @@ if [ ! -s "$DATADIR/PG_VERSION" ]; then
 
     # Start temporarily to create the database
     bashio::log.info "Creating database and extensions..."
-    s6-setuidgid postgres /usr/lib/postgresql/15/bin/pg_ctl -D "$DATADIR" -w start
+    s6-setuidgid postgres "$PG_BIN"/pg_ctl -D "$DATADIR" -w start
     s6-setuidgid postgres psql -c "CREATE DATABASE spectrum_knx;" || true
     s6-setuidgid postgres psql -d spectrum_knx -c "CREATE EXTENSION IF NOT EXISTS timescaledb;" || true
 
-    s6-setuidgid postgres /usr/lib/postgresql/15/bin/pg_ctl -D "$DATADIR" -m fast -w stop
+    s6-setuidgid postgres "$PG_BIN"/pg_ctl -D "$DATADIR" -m fast -w stop
 fi
 
 bashio::log.info "Starting PostgreSQL..."
-exec s6-setuidgid postgres /usr/lib/postgresql/15/bin/postgres -D "$DATADIR" -c listen_addresses='127.0.0.1'
+exec s6-setuidgid postgres "$PG_BIN"/postgres -D "$DATADIR" -c listen_addresses='127.0.0.1'

--- a/ha-addon/rootfs/etc/services.d/spectrum_knx/run
+++ b/ha-addon/rootfs/etc/services.d/spectrum_knx/run
@@ -31,9 +31,21 @@ elif [ "$DB_BACKEND" = "SQLITE" ]; then
     bashio::log.info "SQLite backend selected — skipping PostgreSQL wait."
     export DATABASE_URL="sqlite+aiosqlite:////data/spectrum_knx.db"
 else
+    # Bundled major, derived from the image (see the postgres service) so this
+    # does not need touching when the Dockerfile moves to a new major (#432).
+    PG_MAJOR="$(ls -1 /usr/lib/postgresql 2>/dev/null | sort -V | tail -n 1)"
+
     # Wait for Postgres to be ready
     bashio::log.info "Waiting for PostgreSQL to start..."
-    until s6-setuidgid postgres /usr/lib/postgresql/15/bin/pg_isready -h 127.0.0.1 -p 5432; do
+    until s6-setuidgid postgres "/usr/lib/postgresql/${PG_MAJOR}/bin/pg_isready" -h 127.0.0.1 -p 5432; do
+        # The postgres service refuses to start on a data directory written by a
+        # different major version. Without this check we would wait here forever
+        # with nothing but "Waiting for PostgreSQL to start..." in the log.
+        if [ -f /data/postgres.incompatible ]; then
+            bashio::log.fatal "PostgreSQL will not start: the database was created by PostgreSQL $(cat /data/postgres.incompatible), but this add-on bundles ${PG_MAJOR}."
+            bashio::log.fatal "See the PostgreSQL log above. Your telegram history has NOT been touched."
+            exec sleep infinity
+        fi
         sleep 1
     done
     bashio::log.info "PostgreSQL is ready!"


### PR DESCRIPTION
First step of #432. **No behaviour change for any current install** — the bundled major matches every existing data directory today, so this guard is inert until we bump.

## The problem it removes

`ha-addon/rootfs/etc/services.d/postgres/run` only ran `initdb` when `/data/postgres` was empty, then launched hardcoded PG15 binaries:

```bash
if [ ! -s "$DATADIR/PG_VERSION" ]; then ... initdb ...; fi
exec s6-setuidgid postgres /usr/lib/postgresql/15/bin/postgres -D "$DATADIR" ...
```

Bump the bundled major and every existing install keeps `PG_VERSION=15`, `initdb` is skipped, and the new binary rejects the directory. The add-on fails to boot with an obscure error — and from the user's side, an add-on that won't start with their entire telegram history in that directory is indistinguishable from data loss.

Worse, `spectrum_knx/run` would sit in its `pg_isready` loop forever printing `Waiting for PostgreSQL to start...` with no explanation.

## What this does

- **Detects the mismatch before touching anything** and refuses to start, naming both versions and what to do, with an explicit "your telegram history has NOT been touched".
- **Holds instead of exiting.** A crash loop would scroll the message out of the add-on log, which is the only place the user can read it.
- **Marker file** (`/data/postgres.incompatible`) so the app service's wait loop reports the same thing instead of waiting forever. Cleared on every boot before re-checking.
- **Derives the bundled major** from `/usr/lib/postgresql` in both scripts instead of hardcoding `15`, so the move to PG18 only touches the Dockerfile. During a transition release shipping two majors, `sort -V | tail -1` selects the target — verified this also handles 9-vs-10 correctly, where a lexical sort would pick 9.

## Docs

New `DEPLOYMENT.md` §10 covering all three deployment paths, and a comment on the compose `db` image line.

Per the decision on #432, **Kubernetes is explicitly manual** — no tooling will be provided. The section notes something useful for anyone doing it by hand: the app rebuilds its own TimescaleDB state on startup (`create_hypertable(..., migrate_data => TRUE)` plus the compression policy, every initialise), so a plain logical dump/restore of the four tables is sufficient and the extension version does not need to match.

## Verification

- `pytest tests/` — 228 passed
- `bash -n` clean on both service scripts
- Version-derivation logic exercised directly for the multi-major, 9-vs-10 and empty cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)
