### PR TITLE
Show the imported project's filename and dates in settings (#425)

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,5 +1,7 @@
 import asyncio
 import dataclasses
+import json
+import logging
 import os
 import subprocess
 import tempfile
@@ -40,6 +42,8 @@ from parsers import (
     get_simplified_type,
 )
 from ws_manager import manager
+
+logger = logging.getLogger("uvicorn.error")
 
 router = APIRouter()
 
@@ -841,6 +845,17 @@ def _project_upload_path() -> tuple[str, str | None]:
     return proj_file, pwd_file
 
 
+def _project_meta_path() -> str:
+    """Sidecar holding the original upload filename and import time (#425).
+
+    Uploads are all written to the same fixed path, so the name the user
+    actually chose — which many people use for versioning — is otherwise lost.
+    Sits next to the project file like the password sidecar.
+    """
+    proj_file, _ = _project_upload_path()
+    return os.path.splitext(proj_file)[0] + "_meta.json"
+
+
 def _project_upload_writable() -> bool:
     """Returns True if the upload destination is writable."""
     proj_file, _ = _project_upload_path()
@@ -891,12 +906,33 @@ async def upload_project(file: UploadFile = File(...), password: str = Form(""))
     # Trigger reload
     success = await knx_daemon._load_project_data()
 
+    meta_file = _project_meta_path()
     if not success:
         if os.path.exists(proj_file) and not os.getenv("KNX_PROJECT_PATH"):
             os.remove(proj_file)
         if pwd_file and os.path.exists(pwd_file):
             os.remove(pwd_file)
+        # A stale sidecar would otherwise describe a project that is no longer there.
+        if os.path.exists(meta_file):
+            os.remove(meta_file)
         raise HTTPException(status_code=400, detail="Failed to load project. Incorrect password or invalid file.")
+
+    # Record what the user uploaded, now that we know it parses (#425). Never
+    # fatal: the project is loaded either way, this only feeds the settings UI.
+    def save_meta():
+        with open(meta_file, "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "original_filename": file.filename,
+                    "imported_at": datetime.now(UTC).isoformat(),
+                },
+                f,
+            )
+
+    try:
+        await asyncio.to_thread(save_meta)
+    except OSError as e:
+        logger.warning("Could not write project metadata sidecar: %s", e)
 
     return {"status": "ok", "message": "Project loaded successfully"}
 

--- a/backend/knx_daemon.py
+++ b/backend/knx_daemon.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import json
 import logging
 import os
 from datetime import UTC, datetime
@@ -521,6 +522,54 @@ async def read_group_value(address: str) -> None:
     await xknx_instance.telegrams.put(telegram)
 
 
+def _project_file_info(ets_project_file: str | None) -> dict:
+    """Project file details for the settings screen (#425).
+
+    Uploads all land on the same fixed path, so the name the user chose is kept
+    in a sidecar written at upload time; without one (a file supplied via
+    KNX_PROJECT_PATH) the path's own basename is already the real name. The
+    import time falls back to the file's mtime, which is when we wrote it.
+
+    Also surfaces what ETS recorded inside the project — its name and last
+    modification — which is not the same thing as when it was imported here.
+    """
+    info: dict = {
+        "project_file": ets_project_file,
+        "project_loaded": global_knx_project is not None,
+        "project_display_name": None,
+        "project_imported_at": None,
+        "project_ets_name": None,
+        "project_ets_last_modified": None,
+        "project_created_by": None,
+    }
+
+    if ets_project_file:
+        info["project_display_name"] = os.path.basename(ets_project_file)
+        meta_file = os.path.splitext(ets_project_file)[0] + "_meta.json"
+        try:
+            with open(meta_file, encoding="utf-8") as f:
+                meta = json.load(f)
+            info["project_display_name"] = meta.get("original_filename") or info["project_display_name"]
+            info["project_imported_at"] = meta.get("imported_at")
+        except (OSError, ValueError):
+            # No sidecar (or an unreadable one) is normal — fall back to mtime.
+            pass
+        if not info["project_imported_at"]:
+            try:
+                mtime = os.path.getmtime(ets_project_file)
+                info["project_imported_at"] = datetime.fromtimestamp(mtime, UTC).isoformat()
+            except OSError:
+                pass
+
+    if global_knx_project:
+        ets_info = global_knx_project.get("info") or {}
+        info["project_ets_name"] = ets_info.get("name")
+        info["project_ets_last_modified"] = ets_info.get("last_modified")
+        info["project_created_by"] = ets_info.get("created_by")
+
+    return info
+
+
 def get_server_config() -> dict:
     """Return the effective server configuration for the status API, with passwords masked."""
 
@@ -552,10 +601,7 @@ def get_server_config() -> dict:
                 "live_source": feed["source"],
             },
             "security": {},
-            "files": {
-                "project_file": ets_project_file,
-                "project_loaded": global_knx_project is not None,
-            },
+            "files": _project_file_info(ets_project_file),
             "status": {
                 "connected": feed["connected"],
                 "write_enabled": False,
@@ -584,8 +630,7 @@ def get_server_config() -> dict:
             "latency_ms": os.getenv("KNX_SECURE_LATENCY_MS"),
         },
         "files": {
-            "project_file": ets_project_file,
-            "project_loaded": global_knx_project is not None,
+            **_project_file_info(ets_project_file),
             "knxkeys_file": knxkeys_file,
             "knxkeys_found": knxkeys_file is not None and os.path.exists(knxkeys_file),
         },

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -583,6 +584,50 @@ def test_upload_project_with_env_path(monkeypatch, tmp_path):
     # Password sidecar written next to the project file
     pwd_file = tmp_path / "my_password"
     assert pwd_file.read_text() == "test_pass"
+
+
+def test_upload_project_records_original_filename(monkeypatch, tmp_path):
+    """The uploaded name is kept in a sidecar so the settings screen can show it
+    instead of the fixed path we store every project under (#425)."""
+    proj_file = tmp_path / "my.knxproj"
+    monkeypatch.setenv("KNX_PROJECT_PATH", str(proj_file))
+    monkeypatch.delenv("KNX_PASSWORD", raising=False)
+
+    async def mock_load():
+        knx_daemon.global_knx_project = {"fake": "project"}
+        return True
+
+    monkeypatch.setattr(knx_daemon, "_load_project_data", mock_load)
+
+    response = client.post(
+        "/api/project/upload", data={"password": ""}, files={"file": ("Home-v42.knxproj", b"dummy_content")}
+    )
+    assert response.status_code == 200
+
+    meta = json.loads((tmp_path / "my_meta.json").read_text())
+    assert meta["original_filename"] == "Home-v42.knxproj"
+    assert meta["imported_at"]
+
+
+def test_upload_project_failure_removes_stale_metadata(monkeypatch, tmp_path):
+    """A sidecar left from an earlier upload must not outlive the project it
+    describes, or the settings screen would name a file that is gone."""
+    proj_file = tmp_path / "my.knxproj"
+    meta_file = tmp_path / "my_meta.json"
+    meta_file.write_text('{"original_filename": "Old.knxproj", "imported_at": "2026-01-01T00:00:00+00:00"}')
+    monkeypatch.setenv("KNX_PROJECT_PATH", str(proj_file))
+    monkeypatch.delenv("KNX_PASSWORD", raising=False)
+
+    async def mock_load_fails():
+        return False
+
+    monkeypatch.setattr(knx_daemon, "_load_project_data", mock_load_fails)
+
+    response = client.post(
+        "/api/project/upload", data={"password": "wrong"}, files={"file": ("New.knxproj", b"dummy_content")}
+    )
+    assert response.status_code == 400
+    assert not meta_file.exists()
 
 
 def test_upload_project_invalid_file(monkeypatch):

--- a/backend/tests/test_knx_daemon.py
+++ b/backend/tests/test_knx_daemon.py
@@ -396,6 +396,79 @@ def test_get_server_config_standalone_reports_mode():
     assert "telegram_store" not in config["status"]
 
 
+def test_project_file_info_prefers_the_uploaded_filename(tmp_path):
+    """Uploads all land on one fixed path, so the sidecar carries the name the
+    user actually chose — which is what they use for versioning (#425)."""
+    import json as _json
+
+    import knx_daemon
+
+    proj = tmp_path / "knx_project.knxproj"
+    proj.write_bytes(b"x")
+    (tmp_path / "knx_project_meta.json").write_text(
+        _json.dumps({"original_filename": "Home-v42.knxproj", "imported_at": "2026-08-20T10:00:00+00:00"})
+    )
+
+    info = knx_daemon._project_file_info(str(proj))
+
+    assert info["project_display_name"] == "Home-v42.knxproj"
+    assert info["project_imported_at"] == "2026-08-20T10:00:00+00:00"
+
+
+def test_project_file_info_falls_back_to_basename_and_mtime(tmp_path):
+    """A project supplied via KNX_PROJECT_PATH has no sidecar, but its own
+    basename is already the real name and its mtime is when it arrived."""
+    import knx_daemon
+
+    proj = tmp_path / "MyHouse.knxproj"
+    proj.write_bytes(b"x")
+
+    info = knx_daemon._project_file_info(str(proj))
+
+    assert info["project_display_name"] == "MyHouse.knxproj"
+    assert info["project_imported_at"] is not None
+
+
+def test_project_file_info_survives_a_corrupt_sidecar(tmp_path):
+    """A damaged sidecar must not take down the settings screen."""
+    import knx_daemon
+
+    proj = tmp_path / "knx_project.knxproj"
+    proj.write_bytes(b"x")
+    (tmp_path / "knx_project_meta.json").write_text("{not json")
+
+    info = knx_daemon._project_file_info(str(proj))
+
+    assert info["project_display_name"] == "knx_project.knxproj"
+    assert info["project_imported_at"] is not None
+
+
+def test_project_file_info_reports_ets_metadata():
+    """The ETS project's own name and modification date are distinct from when
+    it was imported here, and are already parsed (#425)."""
+    import knx_daemon
+
+    project = {"info": {"name": "Musterhaus", "last_modified": "2026-07-01T08:00:00Z", "created_by": "ETS6"}}
+    with patch.object(knx_daemon, "global_knx_project", project):
+        info = knx_daemon._project_file_info(None)
+
+    assert info["project_ets_name"] == "Musterhaus"
+    assert info["project_ets_last_modified"] == "2026-07-01T08:00:00Z"
+    assert info["project_created_by"] == "ETS6"
+    assert info["project_loaded"] is True
+
+
+def test_project_file_info_without_a_project():
+    import knx_daemon
+
+    with patch.object(knx_daemon, "global_knx_project", None):
+        info = knx_daemon._project_file_info(None)
+
+    assert info["project_loaded"] is False
+    assert info["project_display_name"] is None
+    assert info["project_ets_name"] is None
+
+
 @pytest.mark.parametrize("feed_connected", [True, False])
 def test_get_server_config_companion_reports_live_feed(feed_connected):
     """Sqlite companion mode must not report the daemon's bus connection (#184)."""

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,6 +201,17 @@ const PanelSwitch = ({ active, onChange }: { active: MainPanel; onChange: (p: Ma
 // Stable identity so passing "no flags" doesn't churn memo deps (#319).
 const EMPTY_KEY_SET: ReadonlySet<string> = new Set();
 
+/**
+ * Settings-screen timestamp: locale date + time. ETS records its own
+ * last-modified string, which is not always parseable — show it verbatim
+ * rather than "Invalid Date" (#425).
+ */
+const formatSettingsDate = (value?: string | null): string | null => {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleString();
+};
+
 function App() {
   const [theme, setTheme] = useTheme();
   // A view shared via URL (#150) starts on the History tab with its filters applied.
@@ -990,7 +1001,8 @@ function App() {
                         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                           {serverConfig.files?.project_file && (
                             <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'var(--bg-tag)', padding: '0.15rem 0.4rem', borderRadius: 4, fontSize: '0.75rem' }}>
-                              {getFileName(serverConfig.files.project_file)}
+                              {/* The name the user uploaded, not the fixed path we store it under (#425). */}
+                              {serverConfig.files.project_display_name || getFileName(serverConfig.files.project_file)}
                             </span>
                           )}
                           <span style={{ color: serverConfig.files?.project_loaded ? 'var(--success)' : 'var(--text-dim)', fontSize: '0.75rem' }}>
@@ -998,6 +1010,20 @@ function App() {
                           </span>
                         </div>
                       </div>
+                      {/* Import time and what ETS recorded inside the project (#425). */}
+                      {[
+                        ['Imported:', formatSettingsDate(serverConfig.files?.project_imported_at)],
+                        ['ETS project:', serverConfig.files?.project_ets_name],
+                        ['ETS modified:', formatSettingsDate(serverConfig.files?.project_ets_last_modified)],
+                        ['Created by:', serverConfig.files?.project_created_by],
+                      ].map(([label, value]) => value ? (
+                        <div key={label} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '0.25rem' }}>
+                          <span style={{ color: 'var(--text-dim)' }}>{label}</span>
+                          <span style={{ fontFamily: '"JetBrains Mono", monospace', color: 'var(--text-main)', background: 'var(--bg-tag)', padding: '0.15rem 0.4rem', borderRadius: 4, fontSize: '0.75rem' }}>
+                            {value}
+                          </span>
+                        </div>
+                      ) : null)}
                       {serverConfig.files?.knxkeys_found !== undefined && (
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: '0.25rem' }}>
                           <span style={{ color: 'var(--text-dim)' }}>KNX keys file:</span>


### PR DESCRIPTION
Closes #425.

## Why it showed the wrong name

The reporter saw `knx_project.knxproj` because that is literally what is on disk: `upload_project` writes **every** upload to one fixed path and discards `file.filename`. The settings screen renders `getFileName(serverConfig.files.project_file)`, so it had nothing else to show.

That matters because, as the issue says, people name their ETS export for versioning — the name they chose is precisely the information that was being thrown away. So this needed new persistence, not just a UI change.

## What changed

**The uploaded filename and import time are recorded in a sidecar** next to the project (`<project>_meta.json`), matching the existing password-sidecar pattern. It is written only *after* the project parses, and removed when a later upload fails — so it can never describe a project that is not there.

**`KNX_PROJECT_PATH` installs need none of that**: the configured path's basename is already the user's real filename, and the file's mtime is when we wrote it. That case falls back accordingly, so this works in every deployment mode.

**ETS metadata is surfaced too** — the project's own name, last-modified date and creating tool, from the `ProjectInfo` we already parse and then discard.

The ETS modification date is labelled separately from the import date on purpose. They answer different questions ("when did I last change this in ETS" vs "when did I load it here"), and showing two unlabelled dates side by side would be worse than showing one.

Settings now reads:

```
Project file:   Haus-2026-08.knxproj   ● Loaded
Imported:       20/08/2026, 12:00:00
ETS project:    Musterhaus
ETS modified:   01/07/2026, 10:00:00
Created by:     ETS6
```

Rows are omitted when their value is absent, so nothing shows blank labels.

## Degradation

- Missing sidecar → basename + mtime.
- **Corrupt** sidecar → same fallback rather than a broken settings screen.
- An ETS date that will not parse → shown verbatim, not `Invalid Date`.

## Verification

- `pytest tests/` — **235 passed** (7 new: sidecar preferred, basename/mtime fallback, corrupt sidecar, ETS metadata, no project, upload records the name, failed upload clears a stale sidecar)
- `npm test` — 363 passed; `tsc -b --noEmit` and `npm run lint` clean
- Checked the real `/api/server/config` response end to end, not just the units

🤖 Generated with [Claude Code](https://claude.com/claude-code)
