### PR TITLE
Default Compose to PostgreSQL 18, with a version guard and migration script (#432)

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -100,10 +100,17 @@ GITHUB_REPO=martinhoefling/SpectrumKNX
 # Used by docker-compose.yml
 APP_IMAGE=ghcr.io/martinhoefling/spectrumknx:latest
 
-# Database image. Changing the PostgreSQL major under an existing volume needs a
-# migration first — see DEPLOYMENT.md "PostgreSQL Major Versions & Upgrades".
-# New installations can start on a newer major directly.
-# DB_IMAGE=timescale/timescaledb:latest-pg18
+# Database image. Defaults to PostgreSQL 18. An existing volume from an older
+# major must be migrated first — startup is blocked with instructions until it
+# is. See DEPLOYMENT.md "PostgreSQL Major Versions & Upgrades".
+#
+# To stay on an older major, set all three. DB_DATA_MOUNT matters because
+# PostgreSQL 18 images keep their data in /var/lib/postgresql/<major>/docker and
+# expect the volume one level up, while 17 and older use
+# /var/lib/postgresql/data:
+# DB_IMAGE=timescale/timescaledb:latest-pg15
+# EXPECTED_PG_MAJOR=15
+# DB_DATA_MOUNT=/var/lib/postgresql/data
 
 # --- Frontend Settings ---
 # API URL used by the frontend (mostly for production/docker builds)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -605,7 +605,7 @@ Current versions:
 | Deployment | PostgreSQL | Migration |
 | --- | --- | --- |
 | Home Assistant add-on | 18 | automatic, on first start |
-| Docker Compose (`docker-compose.yml`) | 15 | tooling provided, run manually |
+| Docker Compose (`docker-compose.yml`) | 18 | one script, startup blocked until done |
 | Kubernetes (`kubernetes/timescaledb-sts.yaml`) | 16 | by hand, not covered |
 
 ### 10.1 Home Assistant add-on — automatic
@@ -632,31 +632,69 @@ refuses up front and changes nothing — free some space and restart the add-on.
 
 Do not stop the add-on while a migration is running.
 
-### 10.2 Docker Compose — one command
+### 10.2 Docker Compose — one script
 
-You own the database container, so the migration is a step you run. Before changing the `db`
-image tag:
+New installations get **PostgreSQL 18**. If you already have a `knx_db_data` volume from an
+older major, you must migrate it — you own the database container, so this is a step you run.
+
+**You will not fail silently into it.** A preflight container compares the volume's actual
+version against the configured image before the database starts, and stops the stack with
+instructions on a mismatch:
+
+```
+============================================================
+PostgreSQL version mismatch — refusing to start.
+
+  your data was written by PostgreSQL 15
+  the configured image expects PostgreSQL 18
+
+Nothing has been changed and no data has been lost.
+...
+============================================================
+```
+
+That guard matters more than it looks. PostgreSQL 18 images moved their data directory to
+`/var/lib/postgresql/<major>/docker` and expect the volume mounted one level up, whereas 17 and
+older use `/var/lib/postgresql/data`. Without the check, a pg18 image pointed at an old volume
+would not fail — it would quietly **initialise an empty cluster alongside your untouched data**,
+which looks exactly like data loss.
+
+#### Migrating
 
 ```bash
 docker compose down
-docker compose -f docker-compose.yml -f docker-compose.migrate.yml run --rm pg-migrate
+SOURCE_VOLUME=<project>_knx_db_data packaging/pg-migrate/compose-migrate.sh
 ```
 
-Then update the `db` image tag in `docker-compose.yml` and bring the stack back up:
+Run it from the repository root; it prints the exact `docker-compose.yml` and `.env` edits to
+make when it finishes. Omit `SOURCE_VOLUME` and it will try to work the volume name out, listing
+the candidates if it cannot.
+
+What it does, and why this route rather than `pg_upgrade`: it starts your existing cluster and a
+fresh PostgreSQL 18 one side by side, copies the schema and the four Spectrum KNX tables across,
+and re-points Compose at the new volume. **Your original volume is only ever read from**, so
+rollback is a one-line edit and nothing needs restoring.
+
+`pg_upgrade` is deliberately not used here. The stock `timescale/timescaledb` images are
+Alpine/musl and their clusters report `lc_collate=en_US.utf8`, which musl treats as byte ordering
+while glibc treats as linguistic ordering. Migrating them with Debian-based `pg_upgrade` binaries
+would rebuild system catalog indexes under glibc collation, to be served afterwards under musl.
+Copying the data through same-family images avoids the question entirely, because every index is
+rebuilt in its final environment.
+
+TimescaleDB's own catalog is not carried across and does not need to be: Spectrum KNX rebuilds
+its hypertable and compression policy on the next start. Expect the first minutes after
+migration to be busy while it does.
+
+#### Staying on your current version
+
+Set all three in `.env` — the mount path matters, per the layout change above:
 
 ```bash
-docker compose up -d
+DB_IMAGE=timescale/timescaledb:latest-pg15
+EXPECTED_PG_MAJOR=15
+DB_DATA_MOUNT=/var/lib/postgresql/data
 ```
-
-The same guarantees apply — copy mode, original kept as `<volume>/data.old-<major>`, refuses
-rather than risking a half-finished upgrade.
-
-> **Check which image you run first.** This path is for Debian-based PostgreSQL images. The stock
-> `timescale/timescaledb` images are Alpine/musl and their clusters must not be opened with
-> Debian/glibc binaries — text collation differs, which corrupts index ordering silently. For
-> those, use the logical dump/restore documented in
-> [`packaging/pg-migrate/README.md`](../packaging/pg-migrate/README.md), which rebuilds indexes
-> and is safe across any image or version.
 
 ### 10.3 Kubernetes
 

--- a/docker-compose.migrate.yml
+++ b/docker-compose.migrate.yml
@@ -1,17 +1,18 @@
 # One-shot PostgreSQL major-version migration for the knx_db_data volume (#432).
 #
 #   docker compose down
-#   docker compose -f docker-compose.yml -f docker-compose.migrate.yml run --rm pg-migrate
+#   docker compose -f docker-compose.yml -f docker-compose.migrate.yml run --build --rm pg-migrate
 #
 # Then update the db image tag in docker-compose.yml and bring the stack back up.
 # See packaging/pg-migrate/README.md — in particular the note that this path is
 # for Debian-based PostgreSQL images only.
 services:
   pg-migrate:
+    # Built locally from this repository — there is no published image to pull,
+    # so pass --build (or run "docker compose build pg-migrate" first).
     build:
       context: .
       dockerfile: packaging/pg-migrate/Dockerfile
-    image: ${PG_MIGRATE_IMAGE:-ghcr.io/martinhoefling/spectrumknx-pg-migrate:latest}
     volumes:
       - knx_db_data:/var/lib/postgresql/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,77 @@
 services:
+  # Preflight: a PostgreSQL data directory can only be opened by the major
+  # version that wrote it, so an existing pg15 volume cannot be served by the
+  # pg18 default below. Left to itself the database container just crash-loops
+  # on "incompatible data directory"; this reports the mismatch and how to fix
+  # it, then blocks startup so nothing else fails confusingly behind it (#432).
+  #
+  # Uses the same image as the database, so it costs no extra pull. Reads only
+  # PG_VERSION, and the volume is mounted read-only.
+  db-precheck:
+    image: ${DB_IMAGE:-timescale/timescaledb:latest-pg18}
+    container_name: knx_db_precheck
+    user: root
+    volumes:
+      # Keep in sync with the db service below when switching after a migration.
+      - knx_db_data:/pgdata:ro
+    environment:
+      EXPECTED_PG_MAJOR: ${EXPECTED_PG_MAJOR:-18}
+    restart: "no"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        # PostgreSQL 18 moved PGDATA from /var/lib/postgresql/data to
+        # /var/lib/postgresql/<major>/docker, so a volume can hold either shape.
+        current=""
+        if [ -s /pgdata/PG_VERSION ]; then
+          current=$$(cat /pgdata/PG_VERSION)
+        else
+          for f in /pgdata/*/docker/PG_VERSION; do
+            [ -s "$$f" ] && { current=$$(cat "$$f"); break; }
+          done
+        fi
+        # No cluster yet (fresh install) — nothing to check.
+        [ -n "$$current" ] || exit 0
+        [ "$$current" = "$$EXPECTED_PG_MAJOR" ] && exit 0
+        cat >&2 <<EOF
+        ============================================================
+        PostgreSQL version mismatch — refusing to start.
+
+          your data was written by PostgreSQL $$current
+          the configured image expects PostgreSQL $$EXPECTED_PG_MAJOR
+
+        Nothing has been changed and no data has been lost.
+
+        Either migrate your data to PostgreSQL $$EXPECTED_PG_MAJOR:
+
+          docker compose down
+          docker compose -f docker-compose.yml -f docker-compose.migrate.yml run --build --rm pg-migrate
+          docker compose up -d
+
+        (see packaging/pg-migrate/compose-migrate.sh)
+
+        or stay on your current version by putting this in .env:
+
+          DB_IMAGE=timescale/timescaledb:latest-pg$$current
+          EXPECTED_PG_MAJOR=$$current
+          DB_DATA_MOUNT=/var/lib/postgresql/data
+
+        Full guide: DEPLOYMENT.md "PostgreSQL Major Versions & Upgrades"
+        ============================================================
+        EOF
+        exit 1
+
   db:
-    # Changing the PostgreSQL major under an existing knx_db_data volume will stop
-    # the container from starting — the data directory belongs to the old major.
-    # Migrate first: see DEPLOYMENT.md "PostgreSQL Major Versions & Upgrades" and
-    # docker-compose.migrate.yml (#432). New installs can set DB_IMAGE to a newer
-    # major straight away; the default stays on pg15 so existing volumes keep
-    # working when this file is updated.
-    image: ${DB_IMAGE:-timescale/timescaledb:latest-pg15}
+    # New installs get PostgreSQL 18. An existing volume from an older major
+    # needs migrating first — db-precheck above stops you with instructions
+    # rather than letting this container fail obscurely. Set DB_IMAGE (and
+    # EXPECTED_PG_MAJOR to match) to stay on an older major.
+    image: ${DB_IMAGE:-timescale/timescaledb:latest-pg18}
+    depends_on:
+      db-precheck:
+        condition: service_completed_successfully
     container_name: knx_timescale
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-knxuser}
@@ -15,7 +80,14 @@ services:
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
-      - knx_db_data:/var/lib/postgresql/data
+      # PostgreSQL 18 images keep their data in /var/lib/postgresql/<major>/docker
+      # and expect the volume one level up; 17 and older use
+      # /var/lib/postgresql/data. DB_DATA_MOUNT switches between the two.
+      #
+      # After running compose-migrate.sh, point this (and the db-precheck mount
+      # above) at the migrated volume, e.g. knx_db_data_pg18. Both volumes are
+      # declared, so rolling back is the same edit in reverse.
+      - knx_db_data:${DB_DATA_MOUNT:-/var/lib/postgresql}
     restart: unless-stopped
 
   backend:
@@ -45,4 +117,8 @@ services:
 
 volumes:
   knx_db_data:
+  # Target for packaging/pg-migrate/compose-migrate.sh. Declared so switching to
+  # it is a one-line change above rather than an edit to this section; unused
+  # (and never created) until a migration runs.
+  knx_db_data_pg18:
   knx_project_data:

--- a/packaging/pg-migrate/README.md
+++ b/packaging/pg-migrate/README.md
@@ -39,37 +39,50 @@ first start after the bundled major changes. Take a Home Assistant backup first.
 
 ## Docker Compose
 
-Run the migration against the existing volume before changing the `db` image
-tag:
+Use **`compose-migrate.sh`**, not the `pg_upgrade` image above:
 
 ```bash
 docker compose down
-docker compose -f docker-compose.yml -f docker-compose.migrate.yml run --rm pg-migrate
-# then update the db image tag in docker-compose.yml and:
-docker compose up -d
+SOURCE_VOLUME=<project>_knx_db_data packaging/pg-migrate/compose-migrate.sh
 ```
 
-> **Only for Debian-based PostgreSQL images.** The stock
-> `timescale/timescaledb` images are Alpine/musl, and a cluster created there
-> must not be opened with the Debian/glibc binaries this image carries —
-> collation differs, which silently corrupts text index ordering. For those,
-> use the logical route below instead.
+It starts your existing cluster and a fresh target cluster side by side, copies the
+schema and the four Spectrum KNX tables across, verifies the row counts, and prints
+the `docker-compose.yml` / `.env` edits to apply. The source volume is only ever
+read from, so rollback is an edit rather than a restore.
 
-### Logical alternative (any image, any version)
+### Why not `pg_upgrade` here
 
-Spectrum KNX rebuilds its own TimescaleDB state on startup: `telegrams` is
-re-created as a hypertable (`migrate_data => TRUE`) and the compression policy
-re-applied every time the application initialises. So a plain dump/restore of
-the four tables into a fresh cluster is sufficient — TimescaleDB's own catalog
-does not need to be preserved and the extension versions need not match.
+The stock `timescale/timescaledb` images are Alpine/musl, and a cluster created by
+them reports `lc_collate=en_US.utf8` — which musl treats as byte ordering and glibc
+as linguistic ordering. Running the Debian-based image above against such a cluster
+would rebuild system catalog indexes under glibc collation, to then be served under
+musl. `pg_upgrade` also cannot bridge the PostgreSQL 18 layout change on its own
+(see below).
+
+Copying the data out and back in through same-family images avoids both problems,
+because every index is rebuilt in its final environment. It is slower than
+`pg_upgrade`, which is the price of not having to reason about collation at all.
+
+The `pg_upgrade` path remains the right one for the Home Assistant add-on, which is
+Debian end to end and therefore has no such mismatch.
+
+### The PostgreSQL 18 layout change
+
+PostgreSQL 18 images keep their data in `/var/lib/postgresql/<major>/docker` and
+expect the volume mounted one level up; 17 and older use `/var/lib/postgresql/data`.
+A pg18 image pointed at an old-layout volume does not fail — it initialises an empty
+cluster next to the untouched data. `compose-migrate.sh` and the `db-precheck`
+service in `docker-compose.yml` both understand either shape; `DB_DATA_MOUNT`
+selects the mount path.
+
+### Checking without migrating
+
+The `pg_upgrade` image can report a mismatch without touching anything:
 
 ```bash
-# from the old container
-pg_dump -U knxuser -d knx_analyzer --data-only \
-    -t telegrams -t last_ga_telegrams -t string_lookup -t store_metadata \
-    > spectrum-knx-data.sql
-# into a fresh cluster on the new major, after Spectrum KNX has created the schema
-psql -U knxuser -d knx_analyzer < spectrum-knx-data.sql
+docker run --rm -v <volume>:/var/lib/postgresql/data \
+    -e CHECK_ONLY=true -e TARGET_MAJOR=18 <image>
 ```
 
 ## Kubernetes

--- a/packaging/pg-migrate/compose-migrate.sh
+++ b/packaging/pg-migrate/compose-migrate.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Logical PostgreSQL major-version migration for a Docker Compose deployment (#432).
+#
+# Why logical rather than pg_upgrade: the stock timescale/timescaledb images are
+# Alpine/musl and their clusters report lc_collate=en_US.utf8, which musl treats
+# as byte ordering while glibc treats as linguistic ordering. Running the
+# Debian-based pg_upgrade image against such a cluster would rebuild system
+# catalog indexes under glibc collation, to be served afterwards under musl.
+# Copying the data out and back in through same-family images sidesteps that
+# entirely, because every index is rebuilt in its final environment.
+#
+# Non-destructive by construction: the source volume is only ever read from, and
+# the migrated data lands in a second volume. Roll back by pointing Compose at
+# the original volume again.
+#
+# Only the four Spectrum KNX tables are carried across. The application rebuilds
+# its own TimescaleDB state on startup — telegrams becomes a hypertable
+# (migrate_data => TRUE) and the compression policy is re-applied — so
+# TimescaleDB's own catalog does not need to be preserved and the extension
+# versions need not match.
+
+set -euo pipefail
+
+TARGET_MAJOR="${TARGET_MAJOR:-18}"
+SOURCE_VOLUME="${SOURCE_VOLUME:-}"
+TARGET_VOLUME="${TARGET_VOLUME:-}"
+DB_IMAGE_BASE="${DB_IMAGE_BASE:-timescale/timescaledb}"
+TABLES=(string_lookup store_metadata telegrams last_ga_telegrams)
+
+SRC_CTR="spectrumknx-migrate-src"
+TGT_CTR="spectrumknx-migrate-tgt"
+NETWORK="spectrumknx-migrate-net"
+
+log()  { echo "[compose-migrate] $*"; }
+fail() { echo "[compose-migrate] ERROR: $*" >&2; exit 1; }
+
+cleanup() {
+    docker rm -f "$SRC_CTR" "$TGT_CTR" >/dev/null 2>&1 || true
+    docker network rm "$NETWORK" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+command -v docker >/dev/null || fail "docker is not on PATH."
+
+# Read credentials from .env so they match the running stack. Parsed, not
+# sourced: Compose does not shell-evaluate .env, and real files contain values
+# with spaces that a "set -a; . ./.env" would try to execute.
+env_value() {
+    [ -f .env ] || return 0
+    # Last assignment wins, as Compose does; strip one layer of quoting.
+    sed -n "s/^[[:space:]]*$1=//p" .env | tail -n 1 \
+        | sed -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+}
+
+POSTGRES_USER="${POSTGRES_USER:-$(env_value POSTGRES_USER)}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-$(env_value POSTGRES_PASSWORD)}"
+POSTGRES_DB="${POSTGRES_DB:-$(env_value POSTGRES_DB)}"
+POSTGRES_USER="${POSTGRES_USER:-knxuser}"
+POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-knxpassword}"
+POSTGRES_DB="${POSTGRES_DB:-knx_analyzer}"
+
+# ── Resolve the volumes ───────────────────────────────────────────────────────
+if [ -z "$SOURCE_VOLUME" ]; then
+    # Compose prefixes volume names with the project (directory) name.
+    guess="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]')_knx_db_data"
+    if docker volume inspect "$guess" >/dev/null 2>&1; then
+        SOURCE_VOLUME="$guess"
+    else
+        echo "Could not find the database volume automatically. Candidates:" >&2
+        docker volume ls --format '  {{.Name}}' | grep -i knx >&2 || true
+        fail "set SOURCE_VOLUME to the right one and re-run."
+    fi
+fi
+docker volume inspect "$SOURCE_VOLUME" >/dev/null 2>&1 || fail "volume '$SOURCE_VOLUME' does not exist."
+TARGET_VOLUME="${TARGET_VOLUME:-${SOURCE_VOLUME}_pg${TARGET_MAJOR}}"
+
+log "Source volume: $SOURCE_VOLUME"
+log "Target volume: $TARGET_VOLUME"
+
+# ── Preflight ─────────────────────────────────────────────────────────────────
+# PostgreSQL 18 changed the official images' layout: PGDATA moved from
+# /var/lib/postgresql/data to /var/lib/postgresql/<major>/docker, with the volume
+# mounted one level higher. A volume can therefore hold either shape, so probe
+# both.
+read_pg_version() {
+    docker run --rm -v "$1:/pgdata:ro" alpine:3.22 sh -c '
+        if [ -s /pgdata/PG_VERSION ]; then cat /pgdata/PG_VERSION; exit 0; fi
+        for f in /pgdata/*/docker/PG_VERSION; do
+            [ -s "$f" ] && { cat "$f"; exit 0; }
+        done
+        true
+    ' 2>/dev/null | tr -d '[:space:]'
+}
+
+# Where the image for a given major expects its volume mounted.
+volume_mount_for() {
+    if [ "$1" -ge 18 ] 2>/dev/null; then
+        echo "/var/lib/postgresql"
+    else
+        echo "/var/lib/postgresql/data"
+    fi
+}
+
+SOURCE_MAJOR="$(read_pg_version "$SOURCE_VOLUME")"
+[ -n "$SOURCE_MAJOR" ] || fail "'$SOURCE_VOLUME' holds no PostgreSQL cluster."
+log "Source is PostgreSQL $SOURCE_MAJOR, target is PostgreSQL $TARGET_MAJOR"
+[ "$SOURCE_MAJOR" != "$TARGET_MAJOR" ] || { log "Already on PostgreSQL $TARGET_MAJOR — nothing to do."; exit 0; }
+
+if docker volume inspect "$TARGET_VOLUME" >/dev/null 2>&1; then
+    existing="$(read_pg_version "$TARGET_VOLUME")"
+    [ -z "$existing" ] || fail "'$TARGET_VOLUME' already holds a PostgreSQL $existing cluster. Remove it first (docker volume rm $TARGET_VOLUME) or set TARGET_VOLUME."
+fi
+
+# ── Start both clusters ───────────────────────────────────────────────────────
+cleanup
+docker network create "$NETWORK" >/dev/null
+
+start_pg() {
+    local name="$1" major="$2" volume="$3"
+    docker run -d --name "$name" --network "$NETWORK" \
+        -e POSTGRES_USER="$POSTGRES_USER" \
+        -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+        -e POSTGRES_DB="$POSTGRES_DB" \
+        -v "$volume:$(volume_mount_for "$major")" \
+        "${DB_IMAGE_BASE}:latest-pg${major}" >/dev/null
+    # Probe over TCP, not the socket. The official entrypoint runs a temporary
+    # server with listen_addresses='' while initialising, then shuts it down and
+    # starts the real one — a socket probe passes against that temporary server
+    # and the next command hits "the database system is shutting down".
+    local i
+    for i in $(seq 1 90); do
+        docker exec "$name" pg_isready -h 127.0.0.1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1 && return 0
+        sleep 2
+    done
+    docker logs "$name" 2>&1 | tail -20 >&2
+    fail "PostgreSQL $major ($name) did not become ready."
+}
+
+log "Starting the existing PostgreSQL $SOURCE_MAJOR cluster (read-only use)..."
+start_pg "$SRC_CTR" "$SOURCE_MAJOR" "$SOURCE_VOLUME"
+
+log "Initialising a fresh PostgreSQL $TARGET_MAJOR cluster..."
+start_pg "$TGT_CTR" "$TARGET_MAJOR" "$TARGET_VOLUME"
+
+psql_src() { docker exec -i "$SRC_CTR" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -X -v ON_ERROR_STOP=1 "$@"; }
+psql_tgt() { docker exec -i "$TGT_CTR" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -X -v ON_ERROR_STOP=1 "$@"; }
+
+# ── Which tables actually exist ───────────────────────────────────────────────
+present=()
+for t in "${TABLES[@]}"; do
+    if [ "$(psql_src -Atc "SELECT to_regclass('public.$t') IS NOT NULL")" = "t" ]; then
+        present+=("$t")
+    fi
+done
+[ ${#present[@]} -gt 0 ] || fail "none of the Spectrum KNX tables were found in '$POSTGRES_DB'."
+log "Tables to migrate: ${present[*]}"
+
+declare -A before
+for t in "${present[@]}"; do
+    before[$t]="$(psql_src -Atc "SELECT count(*) FROM $t")"
+    log "  $t: ${before[$t]} rows"
+done
+
+# ── Schema ────────────────────────────────────────────────────────────────────
+# The hypertable's parent dumps as a plain CREATE TABLE with its indexes and no
+# TimescaleDB triggers, which is exactly the shape the application expects to
+# find and then convert on startup.
+log "Copying the schema..."
+dump_args=()
+for t in "${present[@]}"; do dump_args+=(-t "$t"); done
+docker exec "$SRC_CTR" pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" \
+    --schema-only --no-owner --no-privileges "${dump_args[@]}" \
+    | psql_tgt -q
+
+# ── Data ──────────────────────────────────────────────────────────────────────
+# COPY (SELECT ...) reads straight through compressed chunks, so compression
+# state on the source is irrelevant.
+for t in "${present[@]}"; do
+    log "Copying $t (${before[$t]} rows)..."
+    docker exec "$SRC_CTR" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -X -v ON_ERROR_STOP=1 \
+        -c "COPY (SELECT * FROM $t) TO STDOUT" \
+        | psql_tgt -q -c "COPY $t FROM STDIN"
+done
+
+# Sequences carry over their definition but not their position.
+log "Advancing sequences..."
+psql_tgt -q <<'SQL'
+DO $$
+DECLARE r record; maxid bigint;
+BEGIN
+    -- public only: the TimescaleDB extension owns sequences of its own in
+    -- _timescaledb_catalog, which are none of our business.
+    FOR r IN
+        SELECT s.relname AS seq, t.relname AS tbl, a.attname AS col
+        FROM pg_class s
+        JOIN pg_depend d ON d.objid = s.oid AND d.deptype = 'a'
+        JOIN pg_class t ON t.oid = d.refobjid
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = d.refobjsubid
+        WHERE s.relkind = 'S'
+          AND s.relnamespace = 'public'::regnamespace
+          AND t.relnamespace = 'public'::regnamespace
+    LOOP
+        EXECUTE format('SELECT COALESCE(MAX(%I), 0) FROM public.%I', r.col, r.tbl) INTO maxid;
+        EXECUTE format('SELECT setval(%L, GREATEST(%s, 1))', 'public.' || r.seq, maxid);
+    END LOOP;
+END $$;
+SQL
+
+# ── Verify ────────────────────────────────────────────────────────────────────
+log "Verifying..."
+ok=true
+for t in "${present[@]}"; do
+    after="$(psql_tgt -Atc "SELECT count(*) FROM $t")"
+    if [ "$after" != "${before[$t]}" ]; then
+        echo "[compose-migrate] MISMATCH $t: ${before[$t]} -> $after" >&2
+        ok=false
+    else
+        log "  $t: $after rows OK"
+    fi
+done
+$ok || fail "row counts do not match. '$TARGET_VOLUME' is incomplete — delete it and retry. '$SOURCE_VOLUME' is untouched."
+
+cat <<DONE
+
+[compose-migrate] Migration complete.
+
+  PostgreSQL $SOURCE_MAJOR  ->  PostgreSQL $TARGET_MAJOR
+  data now in volume: $TARGET_VOLUME
+  original volume:    $SOURCE_VOLUME  (untouched)
+
+Now point Compose at the migrated volume. PostgreSQL $TARGET_MAJOR images place
+their data in a subdirectory, so the mount path changes too — in
+docker-compose.yml, for both the db and db-precheck services:
+
+  db:
+    volumes:
+      - $TARGET_VOLUME:$(volume_mount_for "$TARGET_MAJOR")
+  db-precheck:
+    volumes:
+      - $TARGET_VOLUME:/pgdata:ro
+
+and in .env:
+
+  DB_IMAGE=${DB_IMAGE_BASE}:latest-pg${TARGET_MAJOR}
+  EXPECTED_PG_MAJOR=$TARGET_MAJOR
+
+then start the stack:
+
+  docker compose up -d
+
+Spectrum KNX rebuilds the hypertable and compression policy on this first start,
+so give it a moment before judging query speed.
+
+To roll back, remove those lines from .env. Delete $SOURCE_VOLUME only once you
+are satisfied everything works.
+DONE

--- a/packaging/pg-migrate/migrate.sh
+++ b/packaging/pg-migrate/migrate.sh
@@ -60,6 +60,8 @@ Environment:
   DATADIR               PostgreSQL data directory (default /var/lib/postgresql/data)
   TARGET_MAJOR          Target major version (default: newest installed)
   SPACE_MARGIN_PERCENT  Extra free space required, percent (default 15)
+  CHECK_ONLY            "true" reports a version mismatch and exits 1 without
+                        migrating anything (Compose preflight)
 USAGE
     exit 64
 }
@@ -80,6 +82,38 @@ OLD_MAJOR="$(cat "$DATADIR/PG_VERSION")"
 if [ "$OLD_MAJOR" = "$TARGET_MAJOR" ]; then
     log "Already on PostgreSQL $TARGET_MAJOR — nothing to do."
     exit 0
+fi
+
+# CHECK_ONLY reports a mismatch without touching anything. Used as a Compose
+# preflight so a version bump surfaces this guidance instead of the database
+# container crash-looping on "incompatible data directory" (#432). Deliberately
+# before the binary checks: the check must work in any image, not only one that
+# can actually perform the migration.
+if [ "${CHECK_ONLY:-}" = "true" ]; then
+    cat >&2 <<MISMATCH
+[pg-migrate] ============================================================
+[pg-migrate] PostgreSQL version mismatch — the database cannot start.
+[pg-migrate]
+[pg-migrate]   existing data in $DATADIR was written by PostgreSQL $OLD_MAJOR
+[pg-migrate]   the configured image expects PostgreSQL $TARGET_MAJOR
+[pg-migrate]
+[pg-migrate] Nothing has been changed and no data has been lost.
+[pg-migrate]
+[pg-migrate] Either migrate the data:
+[pg-migrate]
+[pg-migrate]   docker compose down
+[pg-migrate]   docker compose -f docker-compose.yml -f docker-compose.migrate.yml \\
+[pg-migrate]       run --build --rm pg-migrate
+[pg-migrate]   docker compose up -d
+[pg-migrate]
+[pg-migrate] or stay on your current version by setting this in .env:
+[pg-migrate]
+[pg-migrate]   DB_IMAGE=timescale/timescaledb:latest-pg$OLD_MAJOR
+[pg-migrate]
+[pg-migrate] Full guide: DEPLOYMENT.md "PostgreSQL Major Versions & Upgrades"
+[pg-migrate] ============================================================
+MISMATCH
+    exit 1
 fi
 
 # A downgrade is not something pg_upgrade can do; refuse rather than damage.


### PR DESCRIPTION
Follow-up on #432: flip the Compose default to PostgreSQL 18 and make sure nobody walks into it unwarned.

**Flipping the tag alone would not have worked, and would have been dangerous.** Two things surfaced only by running it:

## 1. PostgreSQL 18 moved the data directory

| Image | `PGDATA` | Volume mounted at |
| --- | --- | --- |
| `latest-pg15` | `/var/lib/postgresql/data` | `/var/lib/postgresql/data` |
| `latest-pg18` | `/var/lib/postgresql/18/docker` | `/var/lib/postgresql` |

A pg18 image pointed at an old-layout volume **does not fail**. It initialises an empty cluster beside the untouched data — indistinguishable from data loss from the user's side. My first test run hit exactly this (`there appears to be PostgreSQL data in /var/lib/postgresql/data (unused mount/volume)`).

So: `DB_DATA_MOUNT` selects the mount path, and a **`db-precheck` service** reads the volume's real `PG_VERSION` — understanding *either* layout — before the database starts, blocking with instructions on a mismatch. It runs in the same image `db` already pulls, so it costs no extra download.

Verified against real volumes: old pg15 layout → exit 1 with the guide; new pg18 layout → silent pass; fresh volume → silent pass.

## 2. `pg_upgrade` is the wrong tool for Compose

The stock `timescale/timescaledb` images are **Alpine/musl**, and a fresh cluster reports `lc_collate=en_US.utf8` (I checked both). musl treats that as byte ordering; glibc treats it as linguistic ordering. Migrating with the Debian-based `pg_upgrade` image would rebuild **system catalog** indexes under glibc collation, to then be served under musl.

So `compose-migrate.sh` takes the logical route: start the old and new clusters side by side, copy the schema and the four Spectrum KNX tables, verify row counts. Every index is rebuilt in its final environment, and **the source volume is only ever read from** — rollback is a one-line edit, not a restore. TimescaleDB's catalog isn't carried across because the app rebuilds its hypertable and compression policy on startup.

`pg_upgrade` stays the right tool for the add-on, which is Debian end to end. That path is unchanged.

## Bugs found by running it, not reading it

- **`.env` was sourced as shell** — the repo's own `.env` has an unquoted value with a space, which the script tried to execute. Now parsed, matching how Compose actually reads it.
- **Readiness probed the socket** — that passes against the entrypoint's temporary init server, which then shuts down (`FATAL: the database system is shutting down`). Now probes TCP, which only answers when the real server is up.
- **Sequence advancing walked TimescaleDB's catalog sequences** — the timescale image auto-creates the extension. Now scoped to `public` and schema-qualified.

## End-to-end verification

Real volumes, 15 000 telegrams across a compressed hypertable, four tables, UTF-8 values:

```
[compose-migrate] Source is PostgreSQL 15, target is PostgreSQL 18
[compose-migrate]   telegrams: 15000 rows OK  (all four tables verified)
```

On the migrated pg18 volume: `18|15000|300|120|1|749250.000|3|15000` — rows, checksum, 3 indexes and sequence position all correct; `ga-7-Ätzend` round-tripped; inserts work afterwards.

Source volume after migration: `15|15000|749250.000|8` — same rows, same checksum, 8 compressed chunks still there. Untouched.

Also fixes `docker-compose.migrate.yml`, which defaulted to a `ghcr.io/...pg-migrate` image that nothing publishes (my error in #434); it now builds locally with `--build`.

## Not covered

`compose-migrate.sh` isn't in CI — it drives the `docker` CLI and needs two real containers, which doesn't fit the existing `pg-migration-test` job shape. It's verified manually as above. Worth wiring up separately if you want it gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
